### PR TITLE
ci: add worker service to Docker build pipeline

### DIFF
--- a/.forgejo/workflows/pr-validate.yml
+++ b/.forgejo/workflows/pr-validate.yml
@@ -71,3 +71,6 @@ jobs:
 
       - name: Build pb-proxy image
         run: docker build -f workspace/pb-proxy/Dockerfile -t pb-proxy:pr-test workspace
+
+      - name: Build worker image
+        run: docker build -f workspace/worker/Dockerfile -t pb-worker:pr-test workspace

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Build pb-proxy image
         run: docker build -f pb-proxy/Dockerfile -t pb-proxy:pr-test .
+
+      - name: Build worker image
+        run: docker build -f worker/Dockerfile -t pb-worker:pr-test .

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -31,6 +31,7 @@ declare -A IMAGES=(
   [ingestion]="ingestion/Dockerfile:."
   [reranker]="reranker/Dockerfile:."
   [pb-proxy]="pb-proxy/Dockerfile:."
+  [worker]="worker/Dockerfile:."
 )
 
 # ── Detect changes ──────────────────────────────────────────
@@ -45,7 +46,7 @@ fi
 # If nothing service-relevant changed, rebuild all (safety net)
 rebuild_all=false
 has_service_change=false
-for svc in mcp-server ingestion reranker pb-proxy shared init-db opa-policies; do
+for svc in mcp-server ingestion reranker pb-proxy worker shared init-db opa-policies; do
   if echo "$changed" | grep -q "^${svc}/"; then
     has_service_change=true
     break


### PR DESCRIPTION
## Summary
- Add `worker` to `scripts/build-images.sh` IMAGES map and change detection loop
- Add worker Docker build step to `.github/workflows/pr-validate.yml`
- Add worker Docker build step to `.forgejo/workflows/pr-validate.yml`

Unit tests already covered worker — this closes the gap for Docker image builds.

## Test plan
- [ ] CI docker-build job passes (builds worker image)
- [ ] Verify `build-images.sh` includes worker in `IMAGES` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)