### PR TITLE
ci: add worker service to deploy pipeline

### DIFF
--- a/.forgejo/workflows/build-images.yml
+++ b/.forgejo/workflows/build-images.yml
@@ -8,6 +8,7 @@ on:
       - 'ingestion/**'
       - 'reranker/**'
       - 'pb-proxy/**'
+      - 'worker/**'
       - 'shared/**'
       - 'init-db/**'
       - 'opa-policies/**'
@@ -49,8 +50,8 @@ jobs:
           fi
 
           cd "${DEPLOY_DIR}"
-          docker compose pull mcp-server ingestion reranker pb-proxy
-          docker compose up -d mcp-server ingestion reranker pb-proxy
+          docker compose pull mcp-server ingestion reranker pb-proxy pb-worker
+          docker compose up -d mcp-server ingestion reranker pb-proxy pb-worker
 
           echo "✅ Powerbrain services restarted"
 


### PR DESCRIPTION
## Summary
- Add `worker/**` to Forgejo CI trigger paths so worker changes trigger builds
- Add `pb-worker` to `docker compose pull` and `docker compose up -d` in deploy step
- Health-check loop unchanged (worker has no HTTP endpoint)

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Confirm worker image is pulled and restarted on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)