### PR TITLE
ci: add Dependabot, seed data in quickstart, and GHCR release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+
+A clear description of what the bug is.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or logs if available.
+
+## Environment
+
+- Powerbrain version / commit: 
+- Docker Compose version: 
+- OS: 
+- Relevant `.env` settings (redact secrets): 
+
+## Additional context
+
+Any other context, screenshots, or log output.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem / Motivation
+
+What problem does this solve? Why is it needed?
+
+## Proposed solution
+
+Describe the feature or change you'd like.
+
+## Alternatives considered
+
+Any alternative approaches you've thought about.
+
+## Additional context
+
+Links, examples, or references that help explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+What does this PR do and why?
+
+## Changes
+
+- ...
+
+## Test plan
+
+- [ ] Unit tests pass (`python -m pytest -m 'not integration'`)
+- [ ] OPA tests pass (`opa test opa-policies/pb/ -v`)
+- [ ] Docker images build
+- [ ] Manual verification: ...
+
+## Checklist
+
+- [ ] Code follows project conventions (async/await, type hints, Pydantic models)
+- [ ] No hardcoded secrets or internal URLs
+- [ ] Graceful degradation preserved (reranker down, OPA down, etc.)
+- [ ] CLAUDE.md updated if architecture changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/mcp-server"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/ingestion"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/pb-proxy"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/reranker"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/mcp-server"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "docker"
+    directory: "/ingestion"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "docker"
+    directory: "/pb-proxy"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "docker"
+    directory: "/worker"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "docker"
+    directory: "/reranker"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/powerbrain
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - name: mcp-server
+            dockerfile: mcp-server/Dockerfile
+          - name: ingestion
+            dockerfile: ingestion/Dockerfile
+          - name: reranker
+            dockerfile: reranker/Dockerfile
+          - name: proxy
+            dockerfile: pb-proxy/Dockerfile
+          - name: worker
+            dockerfile: worker/Dockerfile
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.service.name }}:${{ steps.version.outputs.VERSION }}
+            ${{ env.IMAGE_PREFIX }}-${{ matrix.service.name }}:latest
+
+  create-release:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## Container Images
+
+            ```bash
+            docker pull ghcr.io/${{ github.repository_owner }}/powerbrain-mcp-server:${{ steps.version.outputs.VERSION }}
+            docker pull ghcr.io/${{ github.repository_owner }}/powerbrain-ingestion:${{ steps.version.outputs.VERSION }}
+            docker pull ghcr.io/${{ github.repository_owner }}/powerbrain-reranker:${{ steps.version.outputs.VERSION }}
+            docker pull ghcr.io/${{ github.repository_owner }}/powerbrain-proxy:${{ steps.version.outputs.VERSION }}
+            docker pull ghcr.io/${{ github.repository_owner }}/powerbrain-worker:${{ steps.version.outputs.VERSION }}
+            ```
+
+            See [CHANGELOG.md](CHANGELOG.md) for details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # 🧠 Powerbrain
 
+[![CI](https://github.com/nuetzliches/powerbrain/actions/workflows/pr-validate.yml/badge.svg)](https://github.com/nuetzliches/powerbrain/actions/workflows/pr-validate.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Docker Compose](https://img.shields.io/badge/Docker_Compose-ready-2496ED?logo=docker)](docker-compose.yml)
+[![MCP](https://img.shields.io/badge/MCP-compatible-green)](https://modelcontextprotocol.io/)
+
 > *"AI eats context. We decide what's on the menu."*
 
 Open-source context engine that feeds AI agents with policy-compliant enterprise knowledge — self-hosted, GDPR-native, provider-agnostic.
@@ -50,7 +55,7 @@ Agent / Skill
 
 📝 **Context Summarization** — Agents can request summaries instead of raw chunks. OPA policies can enforce summarization for sensitive data (confidential = summary only, no raw text), control detail levels, or deny summarization entirely. Powered by Ollama.
 
-🔌 **MCP-Native Interface** — 16 tools accessible through the Model Context Protocol. Works with any MCP-compatible agent (Claude, OpenCode, custom). One endpoint, one protocol.
+🔌 **MCP-Native Interface** — 23 tools accessible through the Model Context Protocol. Works with any MCP-compatible agent (Claude, OpenCode, custom). One endpoint, one protocol.
 
 🏠 **Self-Hosted & GDPR-Native** — Everything runs on your infrastructure. No external API calls for embeddings, search, or summarization. Docker Compose up and you're running.
 
@@ -75,21 +80,28 @@ The `pb-worker` maintenance container runs four APScheduler jobs: accuracy metri
 ## 🚀 Quick Start
 
 ```bash
-git clone <repo-url> && cd powerbrain
-cp .env.example .env
-# Edit .env: set PG_PASSWORD (and optionally FORGEJO_URL, FORGEJO_TOKEN)
+git clone https://github.com/nuetzliches/powerbrain.git && cd powerbrain
 
-docker compose up -d
+# Automated setup (recommended):
+./scripts/quickstart.sh
 
-# Pull the embedding model
+# Or manually:
+cp .env.example .env        # Edit: set PG_PASSWORD
+docker compose --profile local-llm --profile local-reranker up -d
 docker exec pb-ollama ollama pull nomic-embed-text
-
-# Create vector collections
 for col in pb_general pb_code pb_rules; do
   curl -s -X PUT "http://localhost:6333/collections/$col" \
     -H 'Content-Type: application/json' \
     -d '{"vectors":{"size":768,"distance":"Cosine"}}' && echo " → $col ✓"
 done
+```
+
+Verify everything is running:
+
+```bash
+curl -s http://localhost:8080/health   # MCP Server
+curl -s http://localhost:6333/healthz  # Qdrant
+curl -s http://localhost:8181/health   # OPA
 ```
 
 Connect your agent:
@@ -105,7 +117,7 @@ Connect your agent:
 }
 ```
 
-That's it. Your agent now has access to `search_knowledge`, `query_data`, `graph_query`, `generate_compliance_doc`, and 12 more tools.
+That's it. Your agent now has access to `search_knowledge`, `query_data`, `graph_query`, `generate_compliance_doc`, and 19 more tools — see [MCP Tool Reference](docs/mcp-tools.md).
 
 ### Optional: AI Provider Proxy
 
@@ -148,6 +160,8 @@ curl http://localhost:8090/v1/chat/completions \
 
 | Document | Description |
 |----------|-------------|
+| [Getting Started](docs/getting-started.md) | Step-by-step tutorial: ingest data, search, understand policies |
+| [MCP Tool Reference](docs/mcp-tools.md) | All 23 MCP tools with parameters and access roles |
 | [What is Powerbrain?](docs/what-is-powerbrain.md) | Detailed overview and positioning |
 | [Architecture](docs/architecture.md) | Technical deep-dive |
 | [Deployment Guide](docs/deployment.md) | Dev, production, TLS, Docker Secrets |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest `master` | Yes |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Powerbrain, please report it responsibly:
+
+1. **Do not open a public issue.**
+2. Use [GitHub Security Advisories](https://github.com/nuetzliches/powerbrain/security/advisories/new) to report the vulnerability privately.
+3. Include: description, reproduction steps, affected components, and potential impact.
+
+## Response Timeline
+
+- **Acknowledgment:** within 3 business days
+- **Assessment:** within 7 business days
+- **Fix:** depending on severity, typically within 14 days for critical issues
+
+## Scope
+
+This policy covers the Powerbrain codebase and its Docker Compose deployment. Third-party dependencies (Qdrant, PostgreSQL, OPA, Ollama) should be reported to their respective maintainers.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,170 @@
+# Getting Started with Powerbrain
+
+This guide walks you through setting up Powerbrain, ingesting your first data, and running your first search.
+
+## Prerequisites
+
+- Docker and Docker Compose
+- ~4 GB RAM for all services
+- A terminal
+
+## 1. Setup
+
+Run the automated quickstart:
+
+```bash
+git clone https://github.com/nuetzliches/powerbrain.git
+cd powerbrain
+./scripts/quickstart.sh
+```
+
+This will:
+- Create `.env` and secrets if missing
+- Start all core services (MCP server, Qdrant, PostgreSQL, OPA, Ollama, Reranker)
+- Pull the embedding model
+- Create Qdrant vector collections
+- Verify everything is healthy
+
+## 2. Connect Your Agent
+
+Add Powerbrain to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "powerbrain": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+This works with Claude Desktop, Claude Code, OpenCode, or any MCP-compatible client.
+
+## 3. Ingest Data
+
+Use the `ingest_data` tool to add content to the knowledge base:
+
+```
+Tool: ingest_data
+Arguments:
+  source: "Our refund policy allows returns within 30 days of purchase. Items must be in original packaging. Digital products are non-refundable."
+  project: "customer-support"
+  classification: "internal"
+  metadata: {"category": "policy", "author": "ops-team"}
+```
+
+The ingestion pipeline will:
+1. Run PII detection (Microsoft Presidio)
+2. Pseudonymize any detected PII
+3. Compute quality score (Art. 10 data quality gate)
+4. Generate embeddings (nomic-embed-text)
+5. Create context layer abstracts (L0/L1)
+6. Store in Qdrant + PostgreSQL
+
+## 4. Search
+
+Use `search_knowledge` to find relevant context:
+
+```
+Tool: search_knowledge
+Arguments:
+  query: "What is the return policy?"
+  top_k: 5
+```
+
+The search pipeline:
+1. Embeds your query
+2. Qdrant returns 25 candidates (5x oversampling)
+3. OPA filters by your agent role and data classification
+4. Cross-Encoder reranks by relevance
+5. Returns the top 5 results
+
+### With Summarization
+
+```
+Tool: search_knowledge
+Arguments:
+  query: "What is the return policy?"
+  summarize: true
+  summary_detail: "brief"
+```
+
+OPA policies control whether summarization is allowed, required, or denied based on data classification.
+
+### Context Layers
+
+For progressive loading, use the `layer` parameter:
+
+```
+Tool: search_knowledge
+Arguments:
+  query: "return policy"
+  layer: "L0"
+```
+
+- **L0** — Abstract (~100 tokens): quick overview
+- **L1** — Overview (~1-2k tokens): key details
+- **L2** — Full chunks (default): complete content
+
+Drill down into a specific document:
+
+```
+Tool: get_document
+Arguments:
+  doc_id: "<doc_id from search results>"
+  layer: "L2"
+```
+
+## 5. Understand Policies
+
+Powerbrain checks OPA policies on every request. The default configuration:
+
+| Classification | Viewer | Analyst | Developer | Admin |
+|---|---|---|---|---|
+| public | read | read | read, write | full |
+| internal | - | read | read, write | full |
+| confidential | - | - | - | full |
+| restricted | - | - | - | full + purpose |
+
+Check what a specific role can access:
+
+```
+Tool: check_policy
+Arguments:
+  action: "read"
+  resource: "knowledge"
+  classification: "internal"
+```
+
+Policies are defined in `opa-policies/pb/data.json` and can be modified at runtime via the `manage_policies` tool (admin only).
+
+## 6. Knowledge Graph
+
+Query relationships between entities:
+
+```
+Tool: graph_query
+Arguments:
+  action: "find_node"
+  label: "Document"
+  properties: {"project": "customer-support"}
+```
+
+Find connections:
+
+```
+Tool: graph_query
+Arguments:
+  action: "get_neighbors"
+  label: "Document"
+  node_id: "<node_id>"
+```
+
+## Next Steps
+
+- **[MCP Tool Reference](mcp-tools.md)** — All 23 tools with parameters
+- **[Architecture](architecture.md)** — How the components interact
+- **[Deployment Guide](deployment.md)** — Production setup, TLS, Docker Secrets
+- **[AI Provider Proxy](../README.md#optional-ai-provider-proxy)** — Use Powerbrain transparently with any LLM

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,341 @@
+# MCP Tool Reference
+
+Powerbrain exposes 23 tools via the Model Context Protocol. All tools require authentication (valid `pb_` API key). Access is further controlled by OPA policies based on agent role and data classification.
+
+## Search & Retrieval
+
+### `search_knowledge`
+Semantic search over the knowledge base with 3-stage pipeline (Qdrant oversampling, OPA filtering, Cross-Encoder reranking).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | — | Search query text |
+| `collection` | string | no | `pb_general` | `pb_general`, `pb_code`, or `pb_rules` |
+| `filters` | object | no | — | Qdrant metadata filters |
+| `top_k` | integer | no | 10 | Number of results to return |
+| `layer` | string | no | all | Context layer: `L0` (abstract), `L1` (overview), `L2` (full) |
+| `summarize` | boolean | no | false | Request LLM summary of results |
+| `summary_detail` | string | no | `standard` | `brief`, `standard`, or `detailed` |
+| `rerank_query` | string | no | — | Alternative query text used only for reranking |
+| `rerank_options` | object | no | — | Heuristic boost config (see below) |
+| `pii_access_token` | object | no | — | HMAC-signed token for vault PII access |
+| `purpose` | string | no | — | Purpose for PII access (required with token) |
+
+**Rerank options:** `boost_same_project` (number), `boost_same_author` (number), `match_project` (string), `match_author` (string), `boost_file_overlap` (number), `match_files` (string[]), `boost_corrections` (number).
+
+**Access:** All authenticated roles. Results filtered by OPA based on role + classification.
+
+---
+
+### `get_code_context`
+Semantic search over code embeddings.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | — | Code search query |
+| `repo` | string | no | — | Filter by repository |
+| `language` | string | no | — | Filter by programming language |
+| `top_k` | integer | no | 5 | Number of results |
+| `layer` | string | no | all | Context layer: `L0`, `L1`, `L2` |
+| `summarize` | boolean | no | false | Request summary |
+| `summary_detail` | string | no | `standard` | Summary detail level |
+
+**Access:** All authenticated roles.
+
+---
+
+### `get_document`
+Retrieve a specific document by ID at a given context layer. Enables progressive loading.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `doc_id` | string | yes | — | Document ID (from search result metadata) |
+| `layer` | string | no | `L1` | `L0`, `L1`, or `L2` |
+| `collection` | string | no | `pb_general` | Collection to search in |
+
+**Access:** All authenticated roles. OPA checks classification.
+
+---
+
+## Structured Data
+
+### `query_data`
+Structured query against PostgreSQL datasets.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `dataset` | string | yes | — | Dataset name |
+| `conditions` | object | no | — | Filter conditions |
+| `limit` | integer | no | 50 | Max rows |
+
+**Access:** All authenticated roles. OPA checks dataset classification.
+
+---
+
+### `list_datasets`
+List available datasets, filtered by OPA access policy.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `project` | string | no | — | Filter by project |
+| `source_type` | string | no | — | Filter by source type |
+
+**Access:** All authenticated roles.
+
+---
+
+### `get_classification`
+Query the classification level of a resource.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `resource_id` | string | yes | — | Resource identifier |
+| `resource_type` | string | yes | — | `dataset`, `document`, or `rule` |
+
+**Access:** All authenticated roles.
+
+---
+
+## Data Management
+
+### `ingest_data`
+Ingest new data into the knowledge base. Runs PII scanning, quality scoring, embedding, and context layer generation.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `source` | string | yes | — | Content to ingest |
+| `source_type` | string | no | `text` | Source type identifier |
+| `project` | string | no | — | Project association |
+| `classification` | string | no | `internal` | Data classification level |
+| `metadata` | object | no | `{}` | Custom metadata |
+
+**Access:** All authenticated roles.
+
+---
+
+### `delete_documents`
+Bulk-delete documents by filter. Cascades to Qdrant, PostgreSQL, PII Vault, and Knowledge Graph.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `confirm` | boolean | yes | — | Safety flag, must be `true` |
+| `source_type` | string | no | — | Filter by source type |
+| `project` | string | no | — | Filter by project |
+| `delete_all` | boolean | no | false | Delete ALL documents |
+
+**Access:** All authenticated roles (OPA checked).
+
+---
+
+## Knowledge Graph
+
+### `graph_query`
+Query the knowledge graph (Apache AGE). Results are PII-scanned before returning.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | yes | — | `find_node`, `find_relationships`, `get_neighbors`, `find_path`, `get_subgraph` |
+| `label` | string | no | — | Node label |
+| `node_id` | string | no | — | Node identifier |
+| `properties` | object | no | — | Property filters |
+| `rel_type` | string | no | — | Relationship type filter |
+| `to_label` | string | no | — | Target node label |
+| `to_id` | string | no | — | Target node ID |
+| `max_depth` | integer | no | 2 | Max traversal depth |
+| `direction` | string | no | `both` | `out`, `in`, or `both` |
+
+**Access:** All authenticated roles.
+
+---
+
+### `graph_mutate`
+Create or delete nodes and relationships. Results are PII-scanned.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | yes | — | `create_node`, `delete_node`, `create_relationship` |
+| `label` | string | no | — | Node label |
+| `node_id` | string | no | — | Node ID (for delete) |
+| `properties` | object | no | — | Node properties |
+| `from_label` | string | no | — | Source node label (relationships) |
+| `from_id` | string | no | — | Source node ID |
+| `to_label` | string | no | — | Target node label |
+| `to_id` | string | no | — | Target node ID |
+| `rel_type` | string | no | — | Relationship type |
+| `rel_properties` | object | no | — | Relationship properties |
+
+**Access:** Developer and Admin only.
+
+---
+
+## Policy & Rules
+
+### `get_rules`
+Retrieve active business rules for a context.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `category` | string | yes | — | Rule category |
+| `context` | object | no | — | Additional context for rule matching |
+
+**Access:** All authenticated roles.
+
+---
+
+### `check_policy`
+Evaluate an OPA policy decision.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | yes | — | Action to check (e.g., `read`, `write`) |
+| `resource` | string | yes | — | Resource type |
+| `classification` | string | yes | — | Data classification level |
+
+**Access:** All authenticated roles.
+
+---
+
+### `manage_policies`
+Read or update OPA policy data sections at runtime. Validates against JSON Schema before writes.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | yes | — | `list`, `read`, or `update` |
+| `section` | string | no | — | Config section name (for read/update) |
+| `data` | any | no | — | New value (for update) |
+
+**Access:** Admin only.
+
+---
+
+## Evaluation & Feedback
+
+### `submit_feedback`
+Rate search result quality for the feedback loop.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | yes | — | Original search query |
+| `result_ids` | string[] | yes | — | IDs of received results |
+| `rating` | integer | yes | — | 1 (poor) to 5 (excellent) |
+| `relevant_ids` | string[] | no | — | IDs of helpful results |
+| `irrelevant_ids` | string[] | no | — | IDs of unhelpful results |
+| `comment` | string | no | — | Free-text comment |
+| `collection` | string | no | — | Collection searched |
+| `rerank_scores` | object | no | — | Reranker scores for analysis |
+
+**Access:** All authenticated roles.
+
+---
+
+### `get_eval_stats`
+Retrieval quality statistics with windowed metrics.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `days` | integer | no | 30 | Evaluation period in days |
+
+**Access:** All authenticated roles.
+
+---
+
+## Snapshots
+
+### `create_snapshot`
+Create a knowledge snapshot (Qdrant + PostgreSQL + OPA policy state).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | yes | — | Snapshot name |
+| `description` | string | no | — | Description |
+
+**Access:** Admin only.
+
+---
+
+### `list_snapshots`
+List available knowledge snapshots.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `limit` | integer | no | 10 | Max results |
+
+**Access:** All authenticated roles.
+
+---
+
+## EU AI Act Compliance
+
+### `generate_compliance_doc`
+Generate EU AI Act Annex IV technical documentation as Markdown from live system state.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `output_mode` | string | no | `inline` | `inline` (in response) or `file` (writes to disk) |
+
+**Access:** Admin only.
+
+---
+
+### `verify_audit_integrity`
+Verify the tamper-evident SHA-256 hash chain of the audit log (Art. 12).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `start_id` | integer | no | — | First ID to verify |
+| `end_id` | integer | no | — | Last ID to verify |
+
+**Access:** Admin only.
+
+---
+
+### `export_audit_log`
+Export audit log entries for compliance review (Art. 12).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `format` | string | no | `json` | `json` or `csv` |
+| `since` | string | no | — | ISO-8601 lower bound |
+| `until` | string | no | — | ISO-8601 upper bound |
+| `agent_id` | string | no | — | Filter by agent |
+| `action` | string | no | — | Filter by action |
+| `limit` | integer | no | — | Max rows (capped by OPA config) |
+
+**Access:** Admin only.
+
+---
+
+### `get_system_info`
+Transparency report (Art. 13): active models, OPA policies, collection stats, PII config, audit integrity.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+
+No parameters.
+
+**Access:** All authenticated roles.
+
+---
+
+### `review_pending`
+List or decide pending human oversight reviews (Art. 14).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | string | no | `list` | `list`, `approve`, or `deny` |
+| `review_id` | string | no | — | UUID of review to decide |
+| `reason` | string | no | — | Justification for decision |
+| `limit` | integer | no | 50 | Max rows for list |
+
+**Access:** Admin only.
+
+---
+
+### `get_review_status`
+Poll the status of a pending human oversight review.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `review_id` | string | yes | — | UUID from original tool call |
+
+**Access:** All authenticated roles (own reviews); Admin (all reviews).

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# ============================================================
+#  Powerbrain Quick Start
+#  Sets up a local Powerbrain instance from scratch.
+#  Usage: ./scripts/quickstart.sh
+# ============================================================
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[+]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+error() { echo -e "${RED}[x]${NC} $*"; exit 1; }
+
+# ── Prerequisites ───────────────────────────────────────────
+command -v docker >/dev/null 2>&1 || error "Docker is not installed. See https://docs.docker.com/get-docker/"
+docker info >/dev/null 2>&1     || error "Docker daemon is not running."
+
+# ── .env setup ──────────────────────────────────────────────
+if [ ! -f .env ]; then
+    info "Creating .env from .env.example ..."
+    cp .env.example .env
+    warn "Edit .env to set PG_PASSWORD before proceeding."
+    warn "  Recommended: also create secrets/pg_password.txt"
+    echo ""
+    read -rp "Press Enter when .env is ready, or Ctrl+C to abort ..."
+fi
+
+# ── Secrets directory ───────────────────────────────────────
+if [ ! -f secrets/pg_password.txt ]; then
+    warn "secrets/pg_password.txt not found."
+    warn "Generating a random password ..."
+    mkdir -p secrets
+    openssl rand -base64 24 > secrets/pg_password.txt
+    info "Password written to secrets/pg_password.txt"
+fi
+
+if [ ! -f secrets/vault_hmac_secret.txt ]; then
+    mkdir -p secrets
+    openssl rand -base64 32 > secrets/vault_hmac_secret.txt
+    info "HMAC secret written to secrets/vault_hmac_secret.txt"
+fi
+
+# ── Start services ──────────────────────────────────────────
+info "Starting Powerbrain services ..."
+docker compose --profile local-llm --profile local-reranker up -d
+
+# ── Wait for healthchecks ───────────────────────────────────
+info "Waiting for services to become healthy ..."
+
+wait_for() {
+    local name=$1 url=$2 max_attempts=${3:-30}
+    for i in $(seq 1 "$max_attempts"); do
+        if curl -sf "$url" >/dev/null 2>&1; then
+            info "$name is ready."
+            return 0
+        fi
+        sleep 2
+    done
+    error "$name did not become healthy after $((max_attempts * 2))s"
+}
+
+wait_for "PostgreSQL"  "http://localhost:8080/health" 60  # mcp-server depends on PG
+wait_for "Qdrant"      "http://localhost:6333/healthz"
+wait_for "OPA"         "http://localhost:8181/health"
+wait_for "Reranker"    "http://localhost:8082/health"
+
+# ── Pull embedding model ────────────────────────────────────
+info "Pulling embedding model (nomic-embed-text) ..."
+docker exec pb-ollama ollama pull nomic-embed-text
+
+# ── Create Qdrant collections ──────────────────────────────
+info "Creating Qdrant collections ..."
+for col in pb_general pb_code pb_rules; do
+    status=$(curl -sf -o /dev/null -w "%{http_code}" \
+        "http://localhost:6333/collections/$col")
+    if [ "$status" = "200" ]; then
+        info "  $col already exists, skipping."
+    else
+        curl -sf -X PUT "http://localhost:6333/collections/$col" \
+            -H 'Content-Type: application/json' \
+            -d '{"vectors":{"size":768,"distance":"Cosine"}}' >/dev/null
+        info "  $col created."
+    fi
+done
+
+# ── Verify ──────────────────────────────────────────────────
+info "Verifying setup ..."
+echo ""
+
+check_service() {
+    local name=$1 url=$2
+    if curl -sf "$url" >/dev/null 2>&1; then
+        echo -e "  ${GREEN}OK${NC}  $name"
+    else
+        echo -e "  ${RED}FAIL${NC}  $name ($url)"
+    fi
+}
+
+check_service "MCP Server"  "http://localhost:8080/health"
+check_service "Qdrant"      "http://localhost:6333/healthz"
+check_service "OPA"         "http://localhost:8181/health"
+check_service "Reranker"    "http://localhost:8082/health"
+check_service "Ollama"      "http://localhost:11434/api/tags"
+
+echo ""
+info "Powerbrain is ready!"
+echo ""
+echo "  Connect your MCP agent to: http://localhost:8080/mcp"
+echo ""
+echo "  Next steps:"
+echo "    - Read the Getting Started guide: docs/getting-started.md"
+echo "    - See all MCP tools:              docs/mcp-tools.md"
+echo "    - Deploy with TLS:                docs/deployment.md"
+echo ""

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -87,6 +87,15 @@ for col in pb_general pb_code pb_rules; do
     fi
 done
 
+# ── Seed demo data (optional) ───────────────────────────────
+if [ "${SKIP_SEED:-}" != "1" ]; then
+    info "Seeding demo data (20 documents) ..."
+    docker compose --profile seed up seed --exit-code-from seed 2>/dev/null || {
+        warn "Seed container not available or failed. Skipping demo data."
+        warn "You can seed later: docker compose --profile seed up seed"
+    }
+fi
+
 # ── Verify ──────────────────────────────────────────────────
 info "Verifying setup ..."
 echo ""
@@ -115,4 +124,6 @@ echo "  Next steps:"
 echo "    - Read the Getting Started guide: docs/getting-started.md"
 echo "    - See all MCP tools:              docs/mcp-tools.md"
 echo "    - Deploy with TLS:                docs/deployment.md"
+echo ""
+echo "  To skip demo data seeding: SKIP_SEED=1 ./scripts/quickstart.sh"
 echo ""


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` — weekly dependency updates for pip (5 services), Docker (5 Dockerfiles), and GitHub Actions
- Extend `scripts/quickstart.sh` to automatically seed 20 demo documents via `--profile seed` (skippable with `SKIP_SEED=1`)
- Add `.github/workflows/release.yml` — on `v*` tag push: build + push 5 container images to GHCR, create GitHub Release with image pull commands

## Test plan
- [ ] Dependabot picks up config after merge (check Security tab)
- [ ] `quickstart.sh` seeds data when stack is running
- [ ] `SKIP_SEED=1 ./scripts/quickstart.sh` skips seeding
- [ ] Release workflow triggers on `git tag v0.4.0 && git push --tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)