### PR TITLE
docs: clarify that Forgejo and Ollama are examples, not requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Initial public release of the Powerbrain Context Engine.
 - Performance caches (embedding cache, OPA result cache, batch embedding)
 - Evaluation and feedback loop
 - Monitoring stack (Prometheus, Grafana, Tempo)
-- CI workflows for Forgejo and GitHub Actions
+- CI workflows (GitHub Actions + Forgejo for internal use)
 - Comprehensive documentation (architecture, deployment, scalability, GDPR, ADRs)
 
 [0.3.1]: https://github.com/nuetzliches/powerbrain/compare/v0.3.0...v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,11 @@ powerbrain/
 | qdrant        | 6333  | Qdrant                             | Vector database                  |
 | postgres      | 5432  | PostgreSQL 16 + Apache AGE         | Structured data + graph + audit  |
 | opa           | 8181  | Open Policy Agent                  | Policy engine + access control   |
-| ollama        | 11434 | Ollama                             | Local embeddings + summarization |
+| ollama        | 11434 | Ollama (optional, `local-llm`)     | Local embeddings + summarization |
 | vllm          | 8000  | vLLM (optional, `gpu` profile)     | Production LLM serving           |
 | tei           | 8010  | HF TEI (optional, `gpu` profile)   | Production embedding serving     |
 | caddy         | 80/443| Caddy 2 (optional, `tls` profile)  | TLS reverse proxy                |
-| forgejo       | 3000  | Forgejo (external, not in Compose) | Git repos, policies, schemas     |
+| git server    | —     | Any Git server (external, optional)| Git repos, policies, schemas     |
 | prometheus    | 9090  | Prometheus                         | Metrics collection               |
 | grafana       | 3001  | Grafana                            | Dashboards + visualization       |
 | tempo         | 4317  | Grafana Tempo                      | Distributed tracing              |
@@ -262,11 +262,13 @@ Sensitive values can be provided as Docker Secrets files in `./secrets/*.txt`:
 Services read from `/run/secrets/<name>` with env var fallback for backward compatibility.
 The `_read_secret()` helper checks `<ENV_VAR>_FILE` first, then falls back to `<ENV_VAR>`.
 
-### Forgejo Integration
-No separate git container — uses existing Forgejo:
-- `pb-policies` repo → OPA bundle polling
+### Git Server Integration
+No separate git container — uses any existing Git server (Forgejo, GitHub, GitLab, Gitea, etc.):
+- `pb-policies` repo → OPA bundle polling (via OPAL or direct)
 - `pb-schemas` repo → JSON schema validation
 - `pb-docs` + project repos → Ingestion pipeline
+
+Configured via `FORGEJO_URL` / `OPAL_POLICY_REPO_URL`. The env var names use "Forgejo" for historical reasons but accept any Git server URL.
 
 ### LLM Provider Abstraction
 Embedding and Summarization use the OpenAI-compatible API (`/v1/embeddings`, `/v1/chat/completions`).
@@ -332,8 +334,8 @@ Configuration: `pb-proxy/litellm_config.yaml` for aliases + `provider_keys`, `pb
 
 ### Prerequisites
 - Docker + Docker Compose
-- Access to existing Forgejo server (optional)
-- Forgejo API token with `read:repository` permission (optional)
+- Access to a Git server for policy repos (optional, any: Forgejo, GitHub, GitLab, etc.)
+- Git server API token with `read:repository` permission (optional)
 
 ### First Start
 ```bash
@@ -342,7 +344,7 @@ Configuration: `pb-proxy/litellm_config.yaml` for aliases + `provider_keys`, `pb
 
 # Or manually:
 cp .env.example .env
-# Edit .env: PG_PASSWORD (and optionally FORGEJO_URL, FORGEJO_TOKEN)
+# Edit .env: PG_PASSWORD (and optionally FORGEJO_URL for Git server integration)
 
 docker compose --profile local-llm --profile local-reranker up -d
 
@@ -511,7 +513,7 @@ All project-specific identifiers use the `pb` (Powerbrain) prefix consistently:
 | Prometheus metrics | `pb_<service>_` | `pb_mcp_requests_total`, `pb_reranker_duration_seconds` |
 | Qdrant collections | `pb_<type>` | `pb_general`, `pb_code`, `pb_rules` |
 | Logger names | `pb-<component>` | `pb-mcp`, `pb-ingestion`, `pb-graph` |
-| Forgejo org/repos | `pb-org/pb-<name>` | `pb-org/pb-policies`, `pb-org/pb-schemas` |
+| Git repos | `pb-<name>` | `pb-policies`, `pb-schemas` (any Git server) |
 
 ### Plans and Specs
 
@@ -531,7 +533,7 @@ Implementation plans and design specs are stored centrally:
 | Summarization | qwen2.5:3b (Ollama) | llama3.2:3b | Small, fast, good instruction following |
 | Policy Engine | OPA (Rego) | Cerbos, GoRules | CNCF standard, battle-tested |
 | PII Scanner | Presidio | spaCy NER | Broad entity detection + extensible |
-| Git Server | Forgejo (external) | Gitea | Already available, API-compatible |
+| Git Server | Any (Forgejo default) | — | Supports Forgejo, GitHub, GitLab, Gitea, Bitbucket |
 | Relational DB | PostgreSQL 16 | MySQL, SQLite | JSONB, GIN index, extensions |
 | PII Storage | Sealed Vault (Dual) | Destructive masking, full encryption | Reversible, searchable, GDPR-compliant |
 | TLS | Caddy (optional profile) | Nginx, Traefik | Zero-config HTTPS, simple Caddyfile |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ Art. 17 deletion: delete vault mapping → pseudonyms become irreversible.
 Sensitive values can be provided as Docker Secrets files in `./secrets/*.txt`:
 - `pg_password.txt` — PostgreSQL password
 - `vault_hmac_secret.txt` — Vault HMAC signing key
-- `forgejo_token.txt` — Forgejo API token
+- `forgejo_token.txt` — Git server API token (any: Forgejo, GitHub, GitLab, etc.)
 - `github_pat.txt` — GitHub PAT (AI Proxy provider key)
 - `anthropic_api_key.txt` — Anthropic API key (AI Proxy provider key)
 - `mcp_auth_token.txt` — Token for pb-proxy → mcp-server auth

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Agent / Skill
 └─────────────────────────────────────────────────┘
     │           │           │           │
     ▼           ▼           ▼           ▼
- Qdrant    PostgreSQL     OPA       Ollama
+ Qdrant    PostgreSQL     OPA       Ollama/vLLM/TEI
  (vectors)  (data+vault)  (policies) (embeddings+LLM)
                 │
                 ▼
@@ -53,7 +53,7 @@ Agent / Skill
 
 🎯 **Relevance Pipeline** — 3-stage search: Qdrant oversampling (5x candidates) → OPA policy filtering → Cross-Encoder reranking. Graceful degradation: if the reranker is down, results fall back to vector ordering.
 
-📝 **Context Summarization** — Agents can request summaries instead of raw chunks. OPA policies can enforce summarization for sensitive data (confidential = summary only, no raw text), control detail levels, or deny summarization entirely. Powered by Ollama.
+📝 **Context Summarization** — Agents can request summaries instead of raw chunks. OPA policies can enforce summarization for sensitive data (confidential = summary only, no raw text), control detail levels, or deny summarization entirely. Powered by any OpenAI-compatible LLM (Ollama, vLLM, or external).
 
 🔌 **MCP-Native Interface** — 23 tools accessible through the Model Context Protocol. Works with any MCP-compatible agent (Claude, OpenCode, custom). One endpoint, one protocol.
 
@@ -142,12 +142,12 @@ curl http://localhost:8090/v1/chat/completions \
 
 ```
 1. Agent calls search_knowledge("GDPR deletion policy", summarize=true)
-2. Powerbrain embeds the query via Ollama (nomic-embed-text)
+2. Powerbrain embeds the query (nomic-embed-text via configurable provider)
 3. Qdrant returns 50 candidates (10 × 5 oversampling)
 4. OPA filters by agent role + data classification → 30 remain
 5. Cross-Encoder reranks by query-document relevance → top 10
 6. OPA summarization policy: allowed? required? detail level?
-7. Ollama summarizes the chunks (if applicable)
+7. LLM summarizes the chunks (if applicable)
 8. Response: results + summary + policy transparency
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,8 +4,8 @@
 
 - **Separation of Concerns**: Each component has exactly one responsibility
 - **MCP-First**: The MCP server is the sole access point for agents
-- **GitOps for Rules**: Business rules as Rego code in Forgejo, versioned and reviewable
-- **Local Embeddings**: Ollama in its own container, no data leaves the infrastructure
+- **GitOps for Rules**: Business rules as Rego code in any Git repository, versioned and reviewable
+- **Local Embeddings**: Any OpenAI-compatible provider (Ollama, vLLM, TEI), no data leaves the infrastructure
 - **Graceful Degradation**: Every optional service (reranker) can fail without blocking the system
 
 ## 2. Components
@@ -36,7 +36,7 @@ Three policy packages:
 - `pb.rules` — Business rules (pricing, workflow, compliance)
 - `pb.privacy` — GDPR: purpose binding, PII handling, retention periods, right to erasure
 
-Policies are polled as a bundle from the Forgejo repo `pb-policies`.
+Policies are polled as a bundle from a Git repository (e.g., `pb-policies`). Any Git server works (Forgejo, GitHub, GitLab, etc.).
 
 ### 2.4 Knowledge Graph (Apache AGE)
 
@@ -70,13 +70,22 @@ The reranker backend is configurable via `RERANKER_BACKEND` (default: `powerbrai
 
 **GDPR note:** External backends (`cohere`, remote `tei`) send document content outside your infrastructure. Ensure compliance with data processing agreements. See `docs/gdpr-external-ai-services.md`.
 
-### 2.6 Ollama
+### 2.6 Embedding & LLM Provider
 
-Hosts the embedding model `nomic-embed-text` (768d) locally. GPU support optional. For higher accuracy: `mxbai-embed-large` (1024d) — requires adjustment of the Qdrant collection dimension.
+Any OpenAI-compatible endpoint for embeddings and summarization. Configured via `EMBEDDING_PROVIDER_URL` and `LLM_PROVIDER_URL`. Options:
 
-### 2.7 Forgejo (external)
+| Provider | Use Case | Profile |
+|---|---|---|
+| Ollama (default) | Local CPU inference | `--profile local-llm` |
+| vLLM | GPU-accelerated, production | `--profile gpu` |
+| HuggingFace TEI | GPU embeddings | `--profile gpu` |
+| Any OpenAI-compatible | External or custom | Set provider URL |
 
-Existing instance in the network. Repositories:
+Default model: `nomic-embed-text` (768d). For higher accuracy: `mxbai-embed-large` (1024d) — requires adjustment of the Qdrant collection dimension.
+
+### 2.7 Git Server (external, optional)
+
+Any Git server for policy and schema repositories. Configured via `FORGEJO_URL` / `OPAL_POLICY_REPO_URL`. Supports Forgejo, GitHub, GitLab, Gitea, Bitbucket, etc. Repositories:
 - `pb-policies` — OPA Rego files
 - `pb-schemas` — JSON schemas for datasets
 - `pb-docs` — Technical documentation
@@ -85,7 +94,7 @@ Existing instance in the network. Repositories:
 ## 3. Search Pipeline
 
 ```
-Query → Embedding (Ollama) → Qdrant (top_k × 5)
+Query → Embedding (configurable provider) → Qdrant (top_k × 5)
   → OPA Policy Filter → Reranker (configurable backend) → Top-K Results
 ```
 
@@ -252,7 +261,7 @@ Goal: knowledge state reconstructable at any point in time. Important for compli
 ### 7.2 Snapshot Service (`ingestion/snapshot_service.py`)
 
 Functions:
-- `create_snapshot(name, description)` — Creates Qdrant snapshots for all collections via the native API (`POST /collections/{name}/snapshots`), stores PG row counts and the current Forgejo policy commit hash in `knowledge_snapshots`
+- `create_snapshot(name, description)` — Creates Qdrant snapshots for all collections via the native API (`POST /collections/{name}/snapshots`), stores PG row counts and the current Git policy commit hash in `knowledge_snapshots`
 - `list_snapshots(limit)` — All snapshots with metadata from PostgreSQL
 - `cleanup_old_snapshots(keep_last_n=10)` — Deletes Qdrant snapshots + PG entries beyond the keep limit
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,8 +165,8 @@ This means you can migrate to Docker Secrets gradually — existing `.env` setup
    # Generate HMAC secret
    openssl rand -base64 32 > secrets/vault_hmac_secret.txt
 
-   # Add Forgejo token
-   echo "your-forgejo-token" > secrets/forgejo_token.txt
+   # Add Git server token (Forgejo, GitHub, GitLab, etc.)
+   echo "your-git-server-token" > secrets/forgejo_token.txt
    ```
 
 2. Set restrictive permissions:
@@ -318,8 +318,8 @@ If you don't need real-time sync, the default setup (static volume mount) contin
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PG_PASSWORD` | `changeme_in_production` | PostgreSQL password |
-| `FORGEJO_URL` | `http://forgejo.local:3000` | Forgejo server URL |
-| `FORGEJO_TOKEN` | (empty) | Forgejo API token |
+| `FORGEJO_URL` | `http://forgejo.local:3000` | Git server URL (any: Forgejo, GitHub, GitLab, etc.) |
+| `FORGEJO_TOKEN` | (empty) | Git server API token |
 | `VAULT_HMAC_SECRET` | `change-me-in-production` | Vault token signing key |
 | `RERANKER_MODEL` | `cross-encoder/ms-marco-MiniLM-L-6-v2` | Reranker model |
 | `RERANKER_ENABLED` | `true` | Enable/disable reranker |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ cd powerbrain
 
 This will:
 - Create `.env` and secrets if missing
-- Start all core services (MCP server, Qdrant, PostgreSQL, OPA, Ollama, Reranker)
+- Start all core services (MCP server, Qdrant, PostgreSQL, OPA, Ollama for local embeddings/LLM, Reranker)
 - Pull the embedding model
 - Create Qdrant vector collections
 - Verify everything is healthy

--- a/docs/what-is-powerbrain.md
+++ b/docs/what-is-powerbrain.md
@@ -23,7 +23,7 @@ Powerbrain is a self-hosted context delivery layer. It doesn't replace your AI a
 ```
 Agent → MCP → Powerbrain → Policy Check → Context Delivery
                               ↕
-                    Qdrant · PostgreSQL · OPA · Ollama
+                    Qdrant · PostgreSQL · OPA · Ollama/vLLM/TEI
 ```
 
 ## Core Features
@@ -54,7 +54,7 @@ Agents can request summaries instead of raw chunks. OPA policies control this pe
 - **Enforced** — Confidential data is only returned as summaries (raw chunks stripped)
 - **Denied** — Viewers don't get summarization access
 
-Powered by Ollama with configurable models. Falls back to raw chunks if summarization fails.
+Powered by any OpenAI-compatible LLM (Ollama, vLLM, or external) with configurable models. Falls back to raw chunks if summarization fails.
 
 ### 🔌 MCP-Native Interface
 
@@ -77,7 +77,7 @@ Works with any MCP-compatible agent — Claude, OpenCode, or custom implementati
 
 ### 🏠 Self-Hosted & GDPR-Native
 
-Everything runs on your infrastructure as Docker containers. No external API calls for embeddings (Ollama), search (Qdrant), policies (OPA), or summarization (Ollama). Optional TLS via Caddy reverse proxy profile.
+Everything runs on your infrastructure as Docker containers. No external API calls required for embeddings, search (Qdrant), policies (OPA), or summarization — all can run locally via Ollama, vLLM, or TEI. Optional TLS via Caddy reverse proxy profile.
 
 ### 🔀 AI Provider Proxy
 
@@ -109,7 +109,7 @@ Agent / Skill
 └─────────────────────────────────────────────────┘
     │           │           │           │
     ▼           ▼           ▼           ▼
- Qdrant    PostgreSQL     OPA       Ollama
+ Qdrant    PostgreSQL     OPA       Ollama/vLLM/TEI
  (vectors)  (data+graph   (policies) (embeddings
              +vault+audit)            +summarization)
 ```

--- a/docs/what-is-powerbrain.md
+++ b/docs/what-is-powerbrain.md
@@ -58,22 +58,20 @@ Powered by any OpenAI-compatible LLM (Ollama, vLLM, or external) with configurab
 
 ### 🔌 MCP-Native Interface
 
-10 tools accessible through a single MCP endpoint:
+23 tools accessible through a single MCP endpoint:
 
-| Tool | Purpose |
-|------|---------|
-| `search_knowledge` | Semantic search with optional summarization |
-| `get_code_context` | Code-specific search with reranking |
-| `query_data` | Structured PostgreSQL queries |
-| `graph_query` | Knowledge graph traversal (Apache AGE) |
-| `graph_mutate` | Graph modifications (developer/admin only) |
-| `check_policy` | OPA policy evaluation |
-| `get_rules` | Business rules for a context |
-| `ingest_data` | Data ingestion |
-| `get_classification` | Data classification lookup |
-| `list_datasets` | Available datasets |
+| Category | Tools |
+|----------|-------|
+| **Search & Retrieval** | `search_knowledge`, `get_code_context`, `get_document` (progressive loading via L0/L1/L2 context layers) |
+| **Structured Data** | `query_data`, `list_datasets`, `get_classification` |
+| **Data Management** | `ingest_data`, `delete_documents` |
+| **Knowledge Graph** | `graph_query` (traverse, find paths), `graph_mutate` (developer/admin) |
+| **Policy & Rules** | `check_policy`, `get_rules`, `manage_policies` (runtime OPA config, admin) |
+| **Evaluation** | `submit_feedback` (1-5 star ratings), `get_eval_stats` (quality metrics) |
+| **Snapshots** | `create_snapshot`, `list_snapshots` |
+| **EU AI Act** | `generate_compliance_doc` (Annex IV), `verify_audit_integrity` (Art. 12), `export_audit_log`, `get_system_info` (Art. 13 transparency), `review_pending` + `get_review_status` (Art. 14 human oversight) |
 
-Works with any MCP-compatible agent — Claude, OpenCode, or custom implementations.
+Works with any MCP-compatible agent — Claude, Claude Code, OpenCode, or custom implementations. See the full [MCP Tool Reference](mcp-tools.md) for parameters and access roles.
 
 ### 🏠 Self-Hosted & GDPR-Native
 
@@ -89,6 +87,20 @@ Two access patterns:
 
 Activate with `docker compose --profile proxy up`. OPA policies control which tools are mandatory, which providers are allowed, and iteration limits.
 
+### ⚖️ EU AI Act Compliance Toolkit
+
+For deployers operating high-risk AI systems, Powerbrain ships executable compliance building blocks:
+
+- **Art. 9** — Risk register with live indicators (`GET /health` returns risk status)
+- **Art. 10** — Ingestion quality gate with composite scoring and per-source thresholds
+- **Art. 11/Annex IV** — Auto-generated technical documentation from live system state
+- **Art. 12** — Tamper-evident SHA-256 audit hash chain with verify/export tools
+- **Art. 13** — Transparency endpoint reporting models, policies, PII config, audit integrity
+- **Art. 14** — Circuit breaker kill-switch + approval queue for sensitive operations
+- **Art. 15** — Embedding drift detection, windowed feedback metrics, Prometheus alerts
+
+Background maintenance via `pb-worker` (APScheduler): accuracy metrics refresh, audit retention, GDPR cleanup, review timeouts.
+
 ## Architecture Overview
 
 ```
@@ -97,24 +109,31 @@ Agent / Skill
     ▼
 ┌─────────────────────────────────────────────────┐
 │  MCP Server (Python, FastAPI)                   │
-│  ├─ Authentication (API key verification)       │
+│  ├─ Authentication (API key + OAuth)             │
 │  ├─ Rate Limiting (per-role token bucket)       │
 │  ├─ OPA Policy Check (every request)            │
+│  ├─ Circuit Breaker + Approval Queue (Art. 14)  │
 │  ├─ Qdrant Vector Search (oversampled)          │
 │  ├─ Cross-Encoder Reranking (top-k)             │
 │  ├─ Context Summarization (OPA-controlled)      │
-│  ├─ Sealed Vault (PII resolution)               │
+│  ├─ Sealed Vault (PII pseudonymization)         │
 │  ├─ Knowledge Graph (Apache AGE/Cypher)         │
-│  └─ Audit Log (GDPR-compliant)                  │
+│  └─ Tamper-Evident Audit Log (Art. 12)          │
 └─────────────────────────────────────────────────┘
     │           │           │           │
     ▼           ▼           ▼           ▼
  Qdrant    PostgreSQL     OPA       Ollama/vLLM/TEI
  (vectors)  (data+graph   (policies) (embeddings
              +vault+audit)            +summarization)
+                │
+                ▼
+         ┌──────────────┐
+         │  pb-worker   │  Accuracy metrics, drift
+         │ (APScheduler)│  detection, audit retention
+         └──────────────┘
 ```
 
-**Monitoring:** Prometheus metrics, Grafana dashboards, Grafana Tempo distributed tracing.
+**Monitoring:** Prometheus metrics, Grafana dashboards, Grafana Tempo distributed tracing (W3C traceparent propagation).
 
 ## How is This Different?
 
@@ -129,4 +148,8 @@ Agent / Skill
 
 ## Getting Started
 
-See the [README](../README.md) for quick start instructions and [Deployment Guide](deployment.md) for production setup. The full technical reference is in [CLAUDE.md](../CLAUDE.md).
+- **[Quick Start](../README.md#-quick-start)** — `./scripts/quickstart.sh` for automated setup
+- **[Getting Started Guide](getting-started.md)** — Step-by-step tutorial: auth, ingest, search, policies
+- **[MCP Tool Reference](mcp-tools.md)** — All 23 tools with parameters and access roles
+- **[Deployment Guide](deployment.md)** — Production setup, TLS, Docker Secrets
+- **[Architecture](architecture.md)** — Technical deep-dive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerbrain"
-version = "0.1.0"
+version = "0.3.1"
 requires-python = ">=3.12"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
Fixes language across 6 docs that incorrectly implied Forgejo is the only Git server and Ollama is the only LLM/embedding provider.

- **Forgejo** → "any Git server (Forgejo, GitHub, GitLab, Gitea, Bitbucket)"
- **Ollama** → "any OpenAI-compatible provider (Ollama, vLLM, TEI, external)"

### Files changed
- `docs/architecture.md` — Design principles, component descriptions, search pipeline diagram
- `CLAUDE.md` — Components table, Git integration section, prerequisites, naming conventions, key decisions
- `README.md` — Architecture diagram, summarization description, How It Works section
- `docs/what-is-powerbrain.md` — Diagrams, feature descriptions
- `docs/getting-started.md` — Setup description
- `docs/deployment.md` — Secrets setup, env var table

## Test plan
- [ ] No remaining instances of Forgejo/Ollama implying exclusivity in public docs
- [ ] Internal plan/spec docs intentionally left unchanged (historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)