### PR TITLE
docs: add GitHub adapter documentation and OPA tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- GitHub Adapter: first source adapter for knowledge base ingestion from GitHub repositories (#39)
+  - Incremental sync via commit SHA tracking (`repo_sync_state` table)
+  - Configurable include/exclude path patterns, default binary/noise skip rules
+  - PAT + GitHub App authentication (JWT → installation token)
+  - Polling via pb-worker (configurable interval) + `POST /sync/{repo}` endpoint
+  - Full pipeline: PII scan, OPA quality gate, embedding, context layers
+  - Cascade deletion of removed files (Qdrant, PG, vault, graph)
+  - Config: `ingestion/repos.yaml` (example provided)
+  - 59 new unit tests
+
 ## [0.3.1] - 2026-04-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,13 @@ powerbrain/
 │   ├── pii_scanner.py     ← PII detection (Presidio)
 │   ├── pii_config.yaml    ← PII scanner config (entity types, custom recognizers)
 │   ├── retention_cleanup.py ← GDPR retention cleanup jobs
+│   ├── sync_service.py    ← Repository sync orchestration (incremental)
+│   ├── repos.yaml.example ← Repository sync configuration template
+│   ├── adapters/
+│   │   ├── base.py        ← NormalizedDocument, SourceAdapter ABC
+│   │   ├── git_adapter.py ← Git adapter (include/exclude, skip patterns)
+│   │   └── providers/
+│   │       └── github.py  ← GitHub REST API (PAT + GitHub App auth)
 │   ├── Dockerfile
 │   └── requirements.txt
 ├── init-db/
@@ -79,7 +86,8 @@ powerbrain/
 │   ├── 014_audit_hashchain.sql ← Tamper-resistant audit log (Art. 12)
 │   ├── 015_human_oversight.sql ← Circuit breaker + approval queue (Art. 14)
 │   ├── 016_data_quality.sql    ← Quality scoring (Art. 10)
-│   └── 017_accuracy_monitoring.sql ← Drift detection (Art. 15)
+│   ├── 017_accuracy_monitoring.sql ← Drift detection (Art. 15)
+│   └── 018_repo_sync_state.sql    ← Repository sync state tracking
 ├── opa-policies/pb/
 │   ├── data.json           ← Policy data (configurable without Rego knowledge)
 │   ├── policy_data_schema.json ← JSON Schema for data.json validation
@@ -118,7 +126,8 @@ powerbrain/
 │   │   ├── accuracy_metrics.py  ← Art. 15 drift + feedback refresh
 │   │   ├── audit_retention.py   ← Art. 12 checkpoint + prune
 │   │   ├── gdpr_retention.py    ← GDPR retention cleanup
-│   │   └── pending_review_timeout.py ← Art. 14 review expiry
+│   │   ├── pending_review_timeout.py ← Art. 14 review expiry
+│   │   └── repo_sync.py        ← GitHub/Git repository sync trigger
 │   ├── Dockerfile
 │   └── requirements.txt
 ├── scripts/
@@ -269,6 +278,24 @@ No separate git container — uses any existing Git server (Forgejo, GitHub, Git
 - `pb-docs` + project repos → Ingestion pipeline
 
 Configured via `FORGEJO_URL` / `OPAL_POLICY_REPO_URL`. The env var names use "Forgejo" for historical reasons but accept any Git server URL.
+
+### GitHub Adapter (Repository Sync)
+Syncs GitHub repository contents into the knowledge base as a data source.
+
+**Configuration:** `ingestion/repos.yaml` (see `repos.yaml.example`). Each entry: name, URL, branch, collection, project, classification, auth mode, include/exclude patterns.
+
+**Sync modes:**
+- **Polling** — pb-worker job every N minutes (configurable via `REPO_SYNC_INTERVAL_MINUTES`, default 5)
+- **Manual** — `POST /sync/{repo_name}` on ingestion service (port 8081)
+- **External webhook** — Tools like [Hookaido](https://github.com/nuetzliches/hookaido) can call the sync endpoint on push events
+
+**Auth:** PAT (via `secrets/github_pat.txt`) or GitHub App (JWT + installation token, requires `app_id`, `installation_id`, `private_key_path` in repos.yaml).
+
+**Incremental sync:** Tracks last commit SHA in `repo_sync_state` table. First sync fetches full tree, subsequent syncs use compare API (only changed files). Modified files: delete old → re-ingest new. Removed files: cascade-delete (Qdrant, PG, vault, graph).
+
+**Pipeline:** All content flows through standard ingestion: chunking → PII scan → OPA policy → quality gate (`github` source_type, threshold 0.3) → embedding → context layers (L0/L1/L2).
+
+**Default skip patterns:** Binary files, `.git/`, `node_modules/`, `vendor/`, `__pycache__/`, lock files. Additional filtering via include/exclude globs in config.
 
 ### LLM Provider Abstraction
 Embedding and Summarization use the OpenAI-compatible API (`/v1/embeddings`, `/v1/chat/completions`).
@@ -482,6 +509,7 @@ All 4 services (mcp-server, proxy, reranker, ingestion) share a common telemetry
 26. ✅ **Policy Management Tool (B-12)** — `manage_policies` MCP tool with list/read/update actions for OPA policy data sections at runtime. JSON Schema validation before writes, cache invalidation, audit logging with old+new values.
 27. ✅ **Correction Boost in Reranking (B-13)** — New `boost_corrections` parameter in `rerank_options`. Documents with `metadata.isCorrection: true` receive a configurable score boost in the heuristic post-rerank phase.
 28. ✅ **OPAL Integration (B-10)** — opal-server + opal-client as Docker Compose profile (`--profile opal`). Watches a git repo for policy changes and pushes to OPA in real-time via WebSocket. Configurable via `OPAL_POLICY_REPO_URL`.
+29. ✅ **GitHub Adapter** — First source adapter. Syncs GitHub repos into KB with incremental updates (commit SHA tracking). Configurable include/exclude patterns, PAT + GitHub App auth. Polling via pb-worker + `POST /sync/{repo}` endpoint for manual/webhook triggers. All content flows through full pipeline (PII, OPA, quality gate, embedding). Removed files cascade-delete across Qdrant, PG, vault, graph. Config: `ingestion/repos.yaml`.
 
 Details on all features: see `docs/architecture.md`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,31 @@ Any Git server for policy and schema repositories. Configured via `FORGEJO_URL` 
 - `pb-docs` — Technical documentation
 - `pb-ingestion-config` — ETL templates
 
+### 2.8 GitHub Adapter (Source Adapter)
+
+First implementation of the source adapter framework (`ingestion/adapters/`). Syncs GitHub repository contents into the knowledge base.
+
+**Architecture:**
+```
+repos.yaml → GitAdapter → GitHubProvider (REST API)
+                ↓
+         NormalizedDocument
+                ↓
+    POST /ingest (standard pipeline: PII → OPA → embed → Qdrant)
+```
+
+**Sync flow:**
+1. pb-worker triggers `POST /sync` on ingestion service (configurable interval)
+2. Sync service loads `repo_sync_state` from PostgreSQL (last commit SHA)
+3. If first sync: fetch full tree via GitHub Trees API
+4. If incremental: compare commits, process only changed files
+5. Removed files: cascade-delete from Qdrant, PG, vault, knowledge graph
+6. Update sync state with new SHA
+
+**Auth:** PAT (Docker Secret) or GitHub App (JWT → installation token). **Config:** `ingestion/repos.yaml` with per-repo settings (branch, collection, classification, include/exclude patterns).
+
+The adapter framework is extensible — future providers (GitLab, Bitbucket) implement the same `SourceAdapter` interface.
+
 ## 3. Search Pipeline
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,6 +186,40 @@ Arguments:
   node_id: "<node_id>"
 ```
 
+## 8. Sync a GitHub Repository
+
+Instead of ingesting documents manually, you can sync an entire GitHub repository:
+
+1. Copy the config template:
+   ```bash
+   cp ingestion/repos.yaml.example ingestion/repos.yaml
+   ```
+
+2. Add your repository:
+   ```yaml
+   repos:
+     - name: "my-docs"
+       url: "https://github.com/your-org/your-repo"
+       branch: "main"
+       collection: "pb_general"
+       project: "my-docs"
+       classification: "internal"
+       auth: "pat"
+       include: ["docs/**", "*.md"]
+   ```
+
+3. Ensure your GitHub PAT is configured:
+   ```bash
+   echo "ghp_your_token_here" > secrets/github_pat.txt
+   ```
+
+4. Trigger the sync:
+   ```bash
+   curl -X POST http://localhost:8081/sync/my-docs
+   ```
+
+The adapter syncs incrementally — only changed files are re-processed. The pb-worker automatically polls for updates every 5 minutes.
+
 ## Next Steps
 
 - **[MCP Tool Reference](mcp-tools.md)** — All 23 tools with parameters

--- a/opa-policies/pb/test_ingestion.rego
+++ b/opa-policies/pb/test_ingestion.rego
@@ -90,3 +90,23 @@ test_reason_empty_on_allow if {
     result.allowed == true
     result.reason == ""
 }
+
+# ── GitHub source type (adapter) ──────────────────────────
+
+test_github_threshold_low_passes if {
+    result := ingestion.quality_gate with input as {
+        "source_type":   "github",
+        "quality_score": 0.35,
+    }
+    result.allowed == true
+    result.min_score == 0.3
+}
+
+test_github_threshold_blocks_below_minimum if {
+    result := ingestion.quality_gate with input as {
+        "source_type":   "github",
+        "quality_score": 0.25,
+    }
+    result.allowed == false
+    result.min_score == 0.3
+}


### PR DESCRIPTION
## Summary
Follow-up to #39 (GitHub Adapter). Adds documentation and OPA tests.

- **CLAUDE.md**: directory structure, features list, GitHub Adapter section, worker jobs
- **architecture.md**: section 2.8 with sync flow diagram
- **getting-started.md**: step 8 "Sync a GitHub Repository" tutorial
- **CHANGELOG.md**: [Unreleased] section
- **OPA tests**: 2 new test cases for `github` source_type quality gate (111 total)

## Test plan
- [x] 838 Python tests pass
- [x] 111 OPA tests pass (109 + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)