### PR TITLE
fix(ci): use BEFORE_SHA for multi-commit push detection

### DIFF
--- a/.forgejo/workflows/build-images.yml
+++ b/.forgejo/workflows/build-images.yml
@@ -20,8 +20,19 @@ jobs:
     steps:
       - name: Checkout repository
         run: |
-          git clone --depth 2 --branch master \
-            "https://oauth2:${GITHUB_TOKEN}@git.nuetzliche.it/nuts/powerbrain.git" workspace
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            DEPTH=2
+          else
+            DEPTH=0
+          fi
+          if [ "$DEPTH" -eq 0 ]; then
+            git clone --branch master \
+              "https://oauth2:${GITHUB_TOKEN}@git.nuetzliche.it/nuts/powerbrain.git" workspace
+          else
+            git clone --depth "$DEPTH" --branch master \
+              "https://oauth2:${GITHUB_TOKEN}@git.nuetzliche.it/nuts/powerbrain.git" workspace
+          fi
           cd workspace
 
       - name: Login to Forgejo Registry
@@ -40,6 +51,7 @@ jobs:
           ORG: nuts
           REPO: powerbrain
           FORCE_BUILD: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
+          BEFORE_SHA: ${{ github.event.before }}
 
       - name: Deploy — pull and restart services
         run: |

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -39,7 +39,11 @@ if [ "${FORCE_BUILD:-false}" = "true" ]; then
   changed="ALL"
   log "FORCE_BUILD=true, rebuilding all images."
 else
-  changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "ALL")
+  BEFORE="${BEFORE_SHA:-}"
+  if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+    BEFORE="HEAD~1"
+  fi
+  changed=$(git diff --name-only "$BEFORE" HEAD 2>/dev/null || echo "ALL")
 fi
 
 # If nothing service-relevant changed, rebuild all (safety net)


### PR DESCRIPTION
## Summary
- Uses `github.event.before` instead of `HEAD~1` for change detection in build-images workflow
- Fixes builds being skipped when a multi-commit push only has relevant changes in earlier commits
- Removes `--depth 2` clone limit so the before-SHA is always available

## Test plan
- [ ] Push multiple commits at once where only earlier commits contain service changes
- [ ] Verify `workflow_dispatch` (FORCE_BUILD) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)