### PR TITLE
chore: remove TimeCockpit-specific terminology from generic examples

### DIFF
--- a/docs/mcp-integration-checklist.md
+++ b/docs/mcp-integration-checklist.md
@@ -20,12 +20,12 @@ Checklist for connecting a new MCP server to the pb-proxy.
 ## Authentication
 
 - [ ] **Choose auth mode**: `bearer` (user token forwarding), `static` (fixed token from env var), `none`
-- [ ] **Define `forward_headers`**: which client headers must the proxy forward to the MCP? (e.g. `X-TC-PAT` for TimeCockpit)
+- [ ] **Define `forward_headers`**: which client headers must the proxy forward to the MCP? (e.g. `X-Custom-Auth` for a third-party service)
 - [ ] **Extend OPA policy**: add the server to `mcp_servers_allowed` in `proxy.rego` (which roles may access it?)
 
 ## General
 
-- [ ] **Set `prefix`**: unique namespace for tool names (e.g. `tc_`, `jira_`, `slack_`)
+- [ ] **Set `prefix`**: unique namespace for tool names (e.g. `crm_`, `jira_`, `slack_`)
 - [ ] **Set `required`**: must the server be reachable when the proxy starts? (`true` = proxy will not start without this server)
 - [ ] **Check `tool_whitelist`**: should only specific tools be exposed? (default: all tools of the server)
 - [ ] **Docker networking**: server must be reachable in the `proxy-net` network

--- a/docs/plans/2026-03-31-purge-api-for-imports.md
+++ b/docs/plans/2026-03-31-purge-api-for-imports.md
@@ -2,7 +2,7 @@
 
 **Status:** Done (implemented in commit 9895515)
 **Created:** 2026-03-31
-**Context:** The timecockpit-mcp import script needs the ability to delete all data of a specific `source_type` (e.g. `timesheet`, `git-commit`) or all data entirely before a re-import.
+**Context:** Import workflows need the ability to delete all data of a specific `source_type` (e.g. `document`, `git-commit`) or all data entirely before a re-import.
 
 ## Requirement
 
@@ -13,7 +13,7 @@ New MCP tool in the Powerbrain server that deletes documents by filter criteria:
 ```
 Tool: delete_documents
 Parameter:
-  - source_type: string (optional) — e.g. "timesheet", "git-commit", "github-issue"
+  - source_type: string (optional) — e.g. "document", "git-commit", "github-issue"
   - project: string (optional) — e.g. "PROJ-A"
   - confirm: boolean (required) — safety flag, must be true
   - delete_all: boolean (optional) — if true, ignores source_type/project filters
@@ -23,17 +23,17 @@ Parameter:
 
 1. **Qdrant:** Delete all vectors matching the payload filter (`source_type`, `project`)
 2. **PostgreSQL:** Delete associated entries in `documents_meta`
-3. **Graph:** Remove associated nodes (Timesheet, Commit) and their relationships
+3. **Graph:** Remove associated nodes and their relationships
 4. **Response:** Return the number of deleted documents/vectors/nodes
 
-### Use Cases in the Import Script
+### Use Cases for Import Scripts
 
 ```bash
-# Delete only timesheets (for a clean reimport)
-npx tsx scripts/import-from-timecockpit.ts --purge
+# Delete only documents of a given source_type (for a clean reimport)
+import-script --purge --source-type document
 
-# Delete everything (timesheets + commits + issues + graph nodes)
-npx tsx scripts/import-from-timecockpit.ts --purge-all
+# Delete everything (all source types + graph nodes)
+import-script --purge-all
 ```
 
 ### Existing Infrastructure
@@ -41,7 +41,3 @@ npx tsx scripts/import-from-timecockpit.ts --purge-all
 - `ingestion/retention_cleanup.py` already has `delete_dataset()` — deletes individual datasets by ID
 - The pattern can be extended to bulk deletion by `source_type`
 - Qdrant filter on `source_type` is already present in the payload
-
-## Dependency
-
-The `--purge` / `--purge-all` flag in the timecockpit-mcp import script will be implemented once this tool is available.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1396,7 +1396,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "source_type": {"type": "string",
-                                    "description": "Filter by source_type (e.g. 'timesheet', 'git-commit')"},
+                                    "description": "Filter by source_type (e.g. 'document', 'git-commit')"},
                     "project":     {"type": "string",
                                     "description": "Filter by project ID"},
                     "confirm":     {"type": "boolean",

--- a/mcp-server/tests/test_delete_documents.py
+++ b/mcp-server/tests/test_delete_documents.py
@@ -61,7 +61,7 @@ class TestDeleteDocumentsValidation:
     async def test_confirm_required(self, patch_server):
         result = await _dispatch(
             "delete_documents",
-            {"confirm": False, "source_type": "timesheet"},
+            {"confirm": False, "source_type": "document"},
             "agent-1", "admin",
         )
         data = _parse_result(result)
@@ -82,7 +82,7 @@ class TestDeleteDocumentsValidation:
         patch_server["opa"].return_value = {"allowed": False}
         result = await _dispatch(
             "delete_documents",
-            {"confirm": True, "source_type": "timesheet"},
+            {"confirm": True, "source_type": "document"},
             "agent-1", "viewer",
         )
         data = _parse_result(result)
@@ -109,7 +109,7 @@ class TestDeleteDocumentsSuccess:
 
         result = await _dispatch(
             "delete_documents",
-            {"confirm": True, "source_type": "timesheet"},
+            {"confirm": True, "source_type": "document"},
             "agent-1", "developer",
         )
         data = _parse_result(result)
@@ -119,7 +119,7 @@ class TestDeleteDocumentsSuccess:
         assert data["deleted"]["qdrant"]["pb_general"] == 5
         assert data["deleted"]["qdrant"]["pb_code"] == 5
         assert data["deleted"]["qdrant"]["pb_rules"] == 5
-        assert data["filters"]["source_type"] == "timesheet"
+        assert data["filters"]["source_type"] == "document"
         assert "errors" not in data
 
         # Verify Qdrant delete called for all 3 collections
@@ -209,7 +209,7 @@ class TestDeleteDocumentsPartialFailure:
 
         result = await _dispatch(
             "delete_documents",
-            {"confirm": True, "source_type": "timesheet"},
+            {"confirm": True, "source_type": "document"},
             "agent-1", "admin",
         )
         data = _parse_result(result)
@@ -244,7 +244,7 @@ class TestDeleteDocumentsPartialFailure:
 
         result = await _dispatch(
             "delete_documents",
-            {"confirm": True, "source_type": "timesheet"},
+            {"confirm": True, "source_type": "document"},
             "agent-1", "admin",
         )
         data = _parse_result(result)
@@ -257,11 +257,11 @@ class TestDeleteDocumentsPartialFailure:
 
 class TestBuildDeleteFilter:
     def test_source_type_filter(self):
-        qf, where, params = _build_delete_filter("timesheet", None, False)
+        qf, where, params = _build_delete_filter("document", None, False)
         assert qf is not None
         assert len(qf.must) == 1
         assert "source_type" in where
-        assert params == ["timesheet"]
+        assert params == ["document"]
 
     def test_project_filter(self):
         qf, where, params = _build_delete_filter(None, "PROJ-A", False)
@@ -271,10 +271,10 @@ class TestBuildDeleteFilter:
         assert params == ["PROJ-A"]
 
     def test_combined_filter(self):
-        qf, where, params = _build_delete_filter("timesheet", "PROJ-A", False)
+        qf, where, params = _build_delete_filter("document", "PROJ-A", False)
         assert qf is not None
         assert len(qf.must) == 2
-        assert params == ["timesheet", "PROJ-A"]
+        assert params == ["document", "PROJ-A"]
         assert "$1" in where and "$2" in where
 
     def test_delete_all_returns_none_filter(self):

--- a/pb-proxy/tests/test_mcp_config.py
+++ b/pb-proxy/tests/test_mcp_config.py
@@ -155,13 +155,13 @@ servers:
   - name: powerbrain
     url: http://mcp:8080/mcp
     pii_status: scanned
-  - name: timecockpit
-    url: http://tc:3000/mcp
-    prefix: tc
+  - name: crm
+    url: http://crm:3000/mcp
+    prefix: crm
     pii_status: mixed
     pii_scanned_tools:
-      - tc_find_similar_entries
-      - tc_analyze_patterns
+      - crm_find_similar_records
+      - crm_analyze_patterns
 """
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         f.write(yaml_content)
@@ -174,7 +174,7 @@ servers:
     assert servers[0].pii_scanned_tools is None
 
     assert servers[1].pii_status == "mixed"
-    assert servers[1].pii_scanned_tools == ["tc_find_similar_entries", "tc_analyze_patterns"]
+    assert servers[1].pii_scanned_tools == ["crm_find_similar_records", "crm_analyze_patterns"]
 
 
 def test_pii_status_defaults_to_unscanned():
@@ -232,17 +232,17 @@ def test_tool_entry_needs_pii_scan():
 
     # mixed server, tool in scanned list → no scan
     mixed_config = McpServerConfig(
-        name="tc", url="http://tc:3000/mcp", pii_status="mixed",
-        pii_scanned_tools=["tc_find_similar_entries", "tc_analyze_patterns"],
+        name="crm", url="http://crm:3000/mcp", pii_status="mixed",
+        pii_scanned_tools=["crm_find_similar_records", "crm_analyze_patterns"],
     )
-    entry = ToolEntry(server_name="tc", original_name="tc_find_similar_entries", schema={}, server_config=mixed_config)
+    entry = ToolEntry(server_name="crm", original_name="crm_find_similar_records", schema={}, server_config=mixed_config)
     assert entry.needs_pii_scan is False
 
     # mixed server, tool NOT in scanned list → scan needed
-    entry = ToolEntry(server_name="tc", original_name="tc_list_timesheets", schema={}, server_config=mixed_config)
+    entry = ToolEntry(server_name="crm", original_name="crm_list_contacts", schema={}, server_config=mixed_config)
     assert entry.needs_pii_scan is True
 
     # mixed server, empty scanned list → all need scan
-    mixed_empty = McpServerConfig(name="tc2", url="http://tc:3000/mcp", pii_status="mixed")
-    entry = ToolEntry(server_name="tc2", original_name="any_tool", schema={}, server_config=mixed_empty)
+    mixed_empty = McpServerConfig(name="crm2", url="http://crm:3000/mcp", pii_status="mixed")
+    entry = ToolEntry(server_name="crm2", original_name="any_tool", schema={}, server_config=mixed_empty)
     assert entry.needs_pii_scan is True

--- a/scripts/backfill-source-type.py
+++ b/scripts/backfill-source-type.py
@@ -3,7 +3,7 @@
 Backfill source_type payload field in Qdrant for existing points.
 
 Derives source_type from the existing 'source' metadata field:
-  - "timesheet:inline" → source_type = "timesheet"
+  - "document:inline" → source_type = "document"
   - "git-commit:inline" → source_type = "git-commit"
 
 Uses Qdrant REST API directly. Run inside the pb-net Docker network:
@@ -71,7 +71,7 @@ def derive_source_type(payload: dict) -> str | None:
     if not source:
         return None
 
-    # source format: "timesheet:inline", "git-commit:inline", etc.
+    # source format: "document:inline", "git-commit:inline", etc.
     if ":" in source:
         return source.split(":")[0]
 


### PR DESCRIPTION
## Summary
- Powerbrain is a generic context engine; TimeCockpit-specific tools live in the separate `timecockpit-mcp` repo
- This sweep neutralizes remaining TC terminology (`timecockpit`, `tc_`, `timesheet`, `X-TC-PAT`) in test fixtures, tool descriptions, inline comments and docs
- **No functional changes** — only string replacements in examples/fixtures

## Changes
- `pb-proxy/tests/test_mcp_config.py` — `tc_*` fixtures → `crm_*`
- `mcp-server/server.py` — `delete_documents` tool description example `timesheet` → `document`
- `mcp-server/tests/test_delete_documents.py` — `"timesheet"` → `"document"` (10 occurrences)
- `scripts/backfill-source-type.py` — docstring + inline comment
- `docs/mcp-integration-checklist.md` — `X-TC-PAT for TimeCockpit` + `tc_` prefix examples neutralized
- `docs/plans/2026-03-31-purge-api-for-imports.md` — rewritten without TC framing (Status stays Done)

## Test plan
- [x] `rg -i 'timecockpit|tc_|timesheet|X-TC-PAT|planio'` returns no matches (outside `testdata/`)
- [x] Affected unit tests pass: `pb-proxy/tests/test_mcp_config.py` + `mcp-server/tests/test_delete_documents.py` (24 passed)
- [x] `py_compile` clean on all changed Python files
- [ ] CI `pr-validate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)