### PR TITLE
refactor: config-driven graph PII masking + fix demo suggestion buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ build/
 secrets/*.txt
 nul
 =5.3
+
+# composit scan/diff outputs — regenerated on demand, not committed.
+composit-report.yaml
+composit-report.json
+composit-report.html
+composit-diff.html

--- a/.well-known/composit.json
+++ b/.well-known/composit.json
@@ -1,0 +1,55 @@
+{
+  "composit": "0.1.0",
+  "provider": {
+    "name": "powerbrain",
+    "description": "Policy-aware MCP context engine with vector search, PII vault, and EU AI Act toolkit",
+    "website": "https://github.com/nuetzliches/powerbrain",
+    "repo": "https://github.com/nuetzliches/powerbrain",
+    "contact": "composit@nuetzliche.it",
+    "license": "Apache-2.0",
+    "version": "0.5.0"
+  },
+  "capabilities": [
+    {
+      "type": "knowledge",
+      "product": "powerbrain",
+      "protocol": "mcp",
+      "description": "Vector search over Qdrant + graph context via PostgreSQL/Apache AGE, governed by OPA policies",
+      "tools": 23,
+      "endpoints": {
+        "mcp": "/mcp",
+        "http": "/api/v1"
+      }
+    },
+    {
+      "type": "ingestion",
+      "product": "powerbrain-ingestion",
+      "protocol": "http",
+      "description": "Classification- and PII-aware ingestion pipeline with EU AI Act Art. 10 quality gate",
+      "endpoints": {
+        "http": "/ingest"
+      }
+    },
+    {
+      "type": "proxy",
+      "product": "pb-proxy",
+      "protocol": "http",
+      "description": "Policy-enforced AI provider proxy with rate and budget limits (Art. 15 tooling)"
+    }
+  ],
+  "compliance": ["gdpr", "eu-ai-act"],
+  "eu_ai_act": {
+    "articles": [9, 10, 11, 12, 13, 14, 15],
+    "notes": "Infrastructure hooks exist for each article; see docs/eu-ai-act-mapping.md in the repo for the crosswalk."
+  },
+  "region": "self-hosted",
+  "self_hosted": true,
+  "policy_engine": {
+    "type": "opa",
+    "policies_path": "opa-policies/pb/",
+    "policy_count": 7
+  },
+  "discovery": {
+    "well_known": "https://mcp.nuetzliche.it/.well-known/composit.json"
+  }
+}

--- a/Compositfile
+++ b/Compositfile
@@ -1,0 +1,127 @@
+# powerbrain Compositfile
+#
+# Governance-as-code for a public, MCP-native knowledge context engine.
+# This file is the SHOULD-state; `composit scan` produces the IS-state
+# (composit-report.yaml), and `composit diff` surfaces drift.
+#
+# Unlike a private ops repo, the value here is two-sided:
+#
+#   1. Internal check — catch accidental config explosion
+#      (a compose file with 50 services, a new observability stack
+#      bolted on, etc.) before it lands on main.
+#
+#   2. External documentation — adopters of powerbrain can see the
+#      canonical topology declared as code instead of discovered
+#      from the compose file.
+#
+# Current scan (see docs/composit/README.md for reproduction):
+#   1 docker_compose, 20 docker_services, 7 Dockerfiles, 1 Caddyfile,
+#   1 caddy_site, 1 prometheus_config, 4 workflows, 2 env_files.
+
+workspace "powerbrain" {
+
+  # --- Approved Providers ---
+  # powerbrain is itself an MCP provider, but it consumes none.
+  # Keep the block empty rather than omit it — an empty list is a
+  # stronger declaration than silence. Any provider discovered in
+  # future scans will be flagged as unapproved_provider.
+
+  # (no provider blocks — powerbrain operates standalone)
+
+  # --- Budget ---
+  # OSS project, no billing concern. Budget is set high as an escape
+  # hatch for adopters who attach a cost-adapter to their deployment.
+
+  budget "workspace" {
+    max_monthly = "1000 EUR"
+    alert_at    = "80%"
+  }
+
+  # --- Resource Constraints ---
+  # Calibrated from the live scan: 1 compose file with 20 services, 7
+  # Dockerfiles, 4 workflows. Slack is ~30% — we'd rather catch a
+  # genuine change than warn every time someone adds a helper service.
+
+  resources {
+    max_total = 50
+
+    allow "docker_compose" {
+      max = 3  # main + ghcr override + optional demo overlay
+    }
+
+    allow "docker_service" {
+      max = 30
+    }
+
+    allow "dockerfile" {
+      max = 10
+    }
+
+    allow "caddyfile" {
+      max = 2
+    }
+
+    allow "caddy_site" {
+      max = 5
+    }
+
+    allow "env_file" {
+      max = 5
+    }
+
+    allow "workflow" {
+      max = 8
+    }
+
+    allow "prometheus_config" {
+      max = 3
+    }
+
+    # Observability is part of the architecture, not optional.
+    # If prometheus.yml disappears from a PR, `composit diff` errors.
+    require "prometheus_config" {
+      min = 1
+    }
+
+    # Every PR should go through the CI gate, so workflows MUST exist.
+    require "workflow" {
+      min = 1
+    }
+  }
+
+  # --- Policies ---
+  # powerbrain already ships OPA policies under opa-policies/pb/ —
+  # referencing them here documents the governance surface. Runtime
+  # evaluation through composit is future work; the rules are
+  # enforced today inside the powerbrain runtime itself (OPA at :8181).
+
+  policy "access-control" {
+    source      = "opa-policies/pb/access.rego"
+    description = "Role- and classification-based access to knowledge resources"
+  }
+
+  policy "ingestion-quality" {
+    source      = "opa-policies/pb/ingestion.rego"
+    description = "EU AI Act Art. 10: data quality and governance gate"
+  }
+
+  policy "human-oversight" {
+    source      = "opa-policies/pb/oversight.rego"
+    description = "EU AI Act Art. 14: approval queue for high-risk operations"
+  }
+
+  policy "privacy" {
+    source      = "opa-policies/pb/privacy.rego"
+    description = "PII handling and vault access controls"
+  }
+
+  policy "proxy-limits" {
+    source      = "opa-policies/pb/proxy.rego"
+    description = "Rate and budget limits on the AI provider proxy"
+  }
+
+  policy "summarization" {
+    source      = "opa-policies/pb/summarization.rego"
+    description = "Summarization quality and source-citation rules"
+  }
+}

--- a/composit.config.yaml
+++ b/composit.config.yaml
@@ -1,0 +1,16 @@
+# composit scanner configuration for powerbrain
+#
+# powerbrain is itself an MCP provider. We don't need to fetch any
+# upstream manifests during scan, so the network phase is off.
+
+# No upstream providers to query.
+# providers: []
+
+# All scanners enabled by default. Terraform/cron would find nothing
+# in this repo; disabling them silences the empty-result noise.
+scanners:
+  terraform: false
+  cron: false
+
+# No extra ad-hoc patterns — the built-in scanners cover what we have.
+# extra_patterns: []

--- a/demo/panels/search_roles.py
+++ b/demo/panels/search_roles.py
@@ -81,6 +81,21 @@ def render(mcp: _MCPClient, analyst_key: str, viewer_key: str) -> None:
         "policy and data classification decide what each role can read."
     )
 
+    # Suggestions sit OUTSIDE the form so each click rerenders the form
+    # with the chosen query pre-filled AND queues an immediate search.
+    # Inside a form the widget values are captured only on form submit,
+    # which is why the earlier version left the click visually dead.
+    st.markdown("**Suggestions:**")
+    sug_cols = st.columns(len(SUGGESTED_QUERIES))
+    for col, sug in zip(sug_cols, SUGGESTED_QUERIES):
+        with col:
+            if st.button(sug, key=f"suggest_{sug}", use_container_width=True):
+                st.session_state["search_query"] = sug
+                # `run_now` is consumed below to trigger a search without
+                # requiring the user to also click "Run query".
+                st.session_state["search_run_now"] = True
+                st.rerun()
+
     with st.form("search_form"):
         cols = st.columns([3, 1])
         with cols[0]:
@@ -93,21 +108,24 @@ def render(mcp: _MCPClient, analyst_key: str, viewer_key: str) -> None:
             top_k = st.number_input(
                 "top_k", min_value=1, max_value=20, value=5, step=1,
             )
-        st.write("Suggestions:")
-        sug_cols = st.columns(len(SUGGESTED_QUERIES))
-        for col, q in zip(sug_cols, SUGGESTED_QUERIES):
-            with col:
-                if st.form_submit_button(q):
-                    query = q
-                    st.session_state["search_query"] = q
         submitted = st.form_submit_button("Run query", type="primary")
 
-    if not submitted and "search_last_query" not in st.session_state:
-        st.info("Enter a query and press **Run query** to see the two roles' views.")
+    run_now = st.session_state.pop("search_run_now", False)
+    triggered = submitted or run_now
+
+    if not triggered and "search_last_query" not in st.session_state:
+        st.info("Pick a suggestion or enter a query and press **Run query**.")
         return
 
-    q = (query or "").strip()
-    if submitted and q:
+    # When triggered via a suggestion click, the form's local `query` still
+    # reflects the *previous* render's input widget value. Prefer the
+    # session-state query, which was just updated by the button callback.
+    effective_query = (
+        st.session_state.get("search_query") if run_now else query
+    ) or query
+
+    q = (effective_query or "").strip()
+    if triggered and q:
         st.session_state["search_last_query"] = q
         st.session_state["search_last_top_k"] = int(top_k)
 

--- a/docs/composit/README.md
+++ b/docs/composit/README.md
@@ -1,0 +1,91 @@
+# Composit Integration
+
+Powerbrain is a reference provider for [composit], an open-source
+governance-as-code tool for AI-generated infrastructure. This directory
+documents how powerbrain uses composit.
+
+[composit]: https://github.com/nuetzliches/composit
+
+## Files in this repo
+
+| Path                               | Purpose                                    |
+|------------------------------------|--------------------------------------------|
+| `Compositfile`                     | SHOULD-state governance declaration (HCL)  |
+| `composit.config.yaml`             | Scanner configuration                      |
+| `.well-known/composit.json`        | Public provider manifest (served at root)  |
+
+## Why publish a Compositfile on a public repo?
+
+The typical use case for composit is private ops: declare intent, scan
+your repo, fail CI on drift. On a public project the value is flipped:
+
+1. **Self-documenting topology.** Adopters see the canonical service
+   inventory expressed as code (resource limits, required components)
+   instead of reverse-engineering it from `docker-compose.yml`.
+
+2. **Policy surface as a first-class citizen.** The `policy` blocks in
+   the Compositfile reference the existing `opa-policies/pb/` rules.
+   This isn't drift detection — it's a public index of what
+   governance layers powerbrain ships.
+
+3. **Dogfooding the spec.** powerbrain is listed in composit's
+   reference-provider set. Publishing a real `.well-known/composit.json`
+   and a non-trivial Compositfile proves the format works on a
+   production-grade OSS project.
+
+## Running composit locally
+
+```bash
+# Install composit (see https://github.com/nuetzliches/composit)
+cargo install --git https://github.com/nuetzliches/composit
+
+# 1. Produce the IS-state
+composit scan --no-providers
+
+# 2. Compare against the SHOULD-state
+composit diff --output terminal
+
+# 3. HTML report (dark-mode, shareable)
+composit diff --output html
+open composit-diff.html
+```
+
+Expected output today: 0 errors, a small number of warnings
+(`policy_file_missing` is NOT among them — the `.rego` files exist and
+the paths are real; composit just doesn't execute them yet).
+
+## Current diff baseline
+
+On a clean scan of the main branch, composit should report:
+
+- **Resources:** ~33 counted, well below every declared ceiling.
+- **Providers:** 0 (powerbrain consumes no upstream providers; the
+  approved-providers block in the Compositfile is deliberately empty).
+- **Budget:** passes (no cost adapter attached).
+- **Policies:** all 6 referenced `.rego` files resolved.
+
+The 1 prometheus_config requirement and 1 workflow requirement are both
+satisfied — these represent architectural invariants (observability and
+CI gate must exist).
+
+## Manifest hosting
+
+`.well-known/composit.json` in this repo is the source of truth. When
+powerbrain is deployed, the deployment's reverse proxy (Caddy, by
+default) should expose this file at `/.well-known/composit.json`.
+
+Composit clients can then discover powerbrain via:
+
+```
+composit scan --providers https://mcp.nuetzliche.it
+```
+
+## Known limitations
+
+- Policy runtime evaluation through composit is **not yet
+  implemented**. composit currently only verifies the file paths in
+  each `policy` block resolve. Powerbrain's runtime already enforces
+  the same `.rego` files against live requests via OPA at :8181.
+
+- The `eu_ai_act` section of the manifest is an extension, not yet
+  part of composit's spec. See the proposed RFC in the composit repo.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -823,54 +823,85 @@ def redact_fields(text: str, pii_entities: list[dict], fields_to_redact: set[str
 
 
 # ── B-30: PII masking for graph query results ──────────────
+#
+# Graph properties carry their semantics in the key name — a key called
+# "email" is an email, period. That's a deterministic classification, so
+# we don't need (and shouldn't pay for) per-value Presidio NER:
+#
+#   * Presidio is probabilistic. spaCy-DE flagged "Elena_Hartmann" as
+#     PERSON, "Tim_Heller" below threshold, "Sarah_Bach" as LOCATION —
+#     producing visually inconsistent output across a single graph.
+#   * Every call crossed the Docker network to ingestion/scan, making
+#     graph_query latency depend on an unrelated service.
+#
+# We replace this with a config-driven key → entity-type-tag mapping
+# loaded from data.pb.config.graph_pii_keys. The result is fully
+# deterministic, audit-friendly, and editable at runtime via the
+# manage_policies MCP tool.
 
-_GRAPH_PII_KEYS = frozenset({"firstname", "lastname", "email", "phone", "name"})
+_graph_pii_keys_cache: dict[str, str] = {}
+_graph_pii_keys_loaded = False
+
+
+async def _get_graph_pii_keys() -> dict[str, str]:
+    """Load the graph-key → entity-type-tag mapping from OPA config.
+
+    Cached for the process lifetime. Use manage_policies (which clears the
+    OPA cache) or a process restart to pick up edits. Graceful fallback to
+    the hardcoded default if OPA is unreachable at startup.
+    """
+    global _graph_pii_keys_loaded, _graph_pii_keys_cache
+    if _graph_pii_keys_loaded:
+        return _graph_pii_keys_cache
+
+    default = {
+        "name":      "PERSON",
+        "fullname":  "PERSON",
+        "firstname": "PERSON",
+        "lastname":  "PERSON",
+        "email":     "EMAIL_ADDRESS",
+        "phone":     "PHONE_NUMBER",
+    }
+    try:
+        resp = await http.get(f"{OPA_URL}/v1/data/pb/config/graph_pii_keys")
+        resp.raise_for_status()
+        cfg = resp.json().get("result")
+        if isinstance(cfg, dict) and cfg:
+            _graph_pii_keys_cache = {k.lower(): v for k, v in cfg.items()}
+        else:
+            _graph_pii_keys_cache = default
+    except Exception as exc:
+        log.warning("OPA graph_pii_keys load failed, using default: %s", exc)
+        _graph_pii_keys_cache = default
+    _graph_pii_keys_loaded = True
+    return _graph_pii_keys_cache
 
 
 async def _mask_graph_pii(data: Any) -> Any:
     """Recursively mask PII in graph query result dicts.
 
-    Walks dicts/lists, finds string values whose key (lower-cased)
-    is in _GRAPH_PII_KEYS, and replaces them with PII-scanner output.
-    On scanner failure, returns data unchanged (graceful degradation).
+    Walks dicts/lists. String values whose lower-cased key matches a
+    configured graph_pii_keys entry are replaced with ``<ENTITY_TYPE>``.
     """
+    keys = await _get_graph_pii_keys()
+    return _mask_walk(data, keys)
+
+
+def _mask_walk(data: Any, keys: dict[str, str]) -> Any:
     if isinstance(data, list):
-        return [await _mask_graph_pii(item) for item in data]
+        return [_mask_walk(item, keys) for item in data]
     if not isinstance(data, dict):
         return data
 
-    # Collect PII-candidate key/value pairs from this dict level
-    candidates: list[tuple[str, str]] = []
+    result: dict[str, Any] = {}
     for key, value in data.items():
-        if isinstance(value, str) and key.lower() in _GRAPH_PII_KEYS and value:
-            candidates.append((key, value))
-
-    # Recurse into nested dicts/lists
-    result = {}
-    for key, value in data.items():
-        if isinstance(value, (dict, list)):
-            result[key] = await _mask_graph_pii(value)
+        if isinstance(value, str) and value:
+            entity = keys.get(key.lower())
+            result[key] = f"<{entity}>" if entity else value
+        elif isinstance(value, (dict, list)):
+            result[key] = _mask_walk(value, keys)
         else:
             result[key] = value
-
-    if not candidates:
-        return result
-
-    # Batch all candidate values into a single scan call
-    delim = "\n---PII_DELIM---\n"
-    combined = delim.join(v for _, v in candidates)
-    try:
-        resp = await http.post(f"{INGESTION_URL}/scan", json={"text": combined})
-        resp.raise_for_status()
-        scan = resp.json()
-        if scan.get("contains_pii"):
-            masked_parts = scan["masked_text"].split(delim)
-            for i, (key, _original) in enumerate(candidates):
-                if i < len(masked_parts):
-                    result[key] = masked_parts[i]
-    except Exception as exc:
-        log.warning("PII scan for graph results failed, returning unmasked: %s", exc)
-
     return result
 
 

--- a/mcp-server/tests/test_graph_pii.py
+++ b/mcp-server/tests/test_graph_pii.py
@@ -1,4 +1,10 @@
-"""Tests for B-30: PII masking in graph query results."""
+"""Tests for B-30: PII masking in graph query results.
+
+The implementation was refactored from a per-value Presidio scan (flaky
+on non-English names, N HTTP roundtrips per query) to a deterministic
+key → entity-type map loaded from OPA. These tests cover both the pure
+walker (sync, no network) and the OPA-loader round-trip.
+"""
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,51 +12,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import server
 
 
-@pytest.fixture
-def mock_scan_pii(mock_http_client):
-    """Mock the PII scanner to detect PII."""
-    response = MagicMock()
-    response.status_code = 200
-    response.raise_for_status = MagicMock()
-    response.json.return_value = {
-        "contains_pii": True,
-        "masked_text": "<PERSON>\n---PII_DELIM---\n<PERSON>\n---PII_DELIM---\n<EMAIL_ADDRESS>",
-        "entity_types": ["PERSON", "EMAIL_ADDRESS"],
-    }
-    mock_http_client.post.return_value = response
-    with patch.object(server, "http", mock_http_client):
-        yield mock_http_client
+DEMO_KEYS = {
+    "name":      "PERSON",
+    "fullname":  "PERSON",
+    "firstname": "PERSON",
+    "lastname":  "PERSON",
+    "email":     "EMAIL_ADDRESS",
+    "phone":     "PHONE_NUMBER",
+}
 
 
-@pytest.fixture
-def mock_scan_no_pii(mock_http_client):
-    """Mock the PII scanner to find no PII."""
-    response = MagicMock()
-    response.status_code = 200
-    response.raise_for_status = MagicMock()
-    response.json.return_value = {
-        "contains_pii": False,
-        "masked_text": "Max\n---PII_DELIM---\nMustermann\n---PII_DELIM---\nmax@example.com",
-        "entity_types": [],
-    }
-    mock_http_client.post.return_value = response
-    with patch.object(server, "http", mock_http_client):
-        yield mock_http_client
+@pytest.fixture(autouse=True)
+def _reset_graph_keys_cache():
+    """Prevent cross-test pollution of the module-level OPA cache."""
+    server._graph_pii_keys_cache = {}
+    server._graph_pii_keys_loaded = False
+    yield
+    server._graph_pii_keys_cache = {}
+    server._graph_pii_keys_loaded = False
 
 
-@pytest.fixture
-def mock_scan_failure(mock_http_client):
-    """Mock the PII scanner to fail."""
-    mock_http_client.post.side_effect = Exception("Connection refused")
-    with patch.object(server, "http", mock_http_client):
-        yield mock_http_client
+# ── Pure walker (no network) ───────────────────────────────────────────────
 
 
-class TestMaskGraphPii:
-    """Tests for _mask_graph_pii helper."""
-
-    @pytest.mark.asyncio
-    async def test_masks_pii_in_person_node(self, mock_scan_pii):
+class TestMaskWalk:
+    def test_masks_direct_pii_keys(self):
         data = {
             "nodes": [
                 {
@@ -59,61 +45,52 @@ class TestMaskGraphPii:
                     "firstname": "Max",
                     "lastname": "Mustermann",
                     "email": "max@example.com",
-                    "role": "developer",
+                    "role": "developer",  # not a PII key — untouched
                 }
             ],
             "count": 1,
         }
-        result = await server._mask_graph_pii(data)
-
-        # PII fields should be masked
+        result = server._mask_walk(data, DEMO_KEYS)
         node = result["nodes"][0]
         assert node["firstname"] == "<PERSON>"
         assert node["lastname"] == "<PERSON>"
         assert node["email"] == "<EMAIL_ADDRESS>"
-        # Non-PII fields unchanged
         assert node["role"] == "developer"
         assert node["id"] == "person-1"
 
-    @pytest.mark.asyncio
-    async def test_no_pii_returns_unchanged(self, mock_scan_no_pii):
-        data = {
-            "nodes": [
-                {"id": "proj-1", "label": "Project", "description": "A project"},
-            ],
-            "count": 1,
-        }
-        result = await server._mask_graph_pii(data)
-        assert result["nodes"][0]["description"] == "A project"
+    def test_unknown_keys_pass_through(self):
+        data = {"nodes": [{"id": "p-1", "status": "active", "description": "A project"}]}
+        result = server._mask_walk(data, DEMO_KEYS)
+        assert result == data
 
-    @pytest.mark.asyncio
-    async def test_no_pii_keys_skips_scan(self, mock_http_client):
-        """When no PII-sensitive keys exist, scanner should not be called."""
-        with patch.object(server, "http", mock_http_client):
-            data = {"nodes": [{"id": "1", "label": "Project", "status": "active"}], "count": 1}
-            result = await server._mask_graph_pii(data)
-            mock_http_client.post.assert_not_called()
-            assert result["nodes"][0]["status"] == "active"
+    def test_case_insensitive_keys(self):
+        data = {"FirstName": "Anna", "LASTNAME": "Müller", "Email": "a@b.de"}
+        result = server._mask_walk(data, DEMO_KEYS)
+        assert result["FirstName"] == "<PERSON>"
+        assert result["LASTNAME"] == "<PERSON>"
+        assert result["Email"] == "<EMAIL_ADDRESS>"
 
-    @pytest.mark.asyncio
-    async def test_scanner_failure_returns_unmasked(self, mock_scan_failure):
-        data = {
-            "nodes": [{"firstname": "Max", "lastname": "Mustermann"}],
-            "count": 1,
-        }
-        result = await server._mask_graph_pii(data)
-        # Data should be returned unchanged on failure
-        assert result["nodes"][0]["firstname"] == "Max"
-        assert result["nodes"][0]["lastname"] == "Mustermann"
+    def test_empty_strings_not_tagged(self):
+        """Empty values stay empty — avoids rendering a bare <PERSON> for missing data."""
+        data = {"name": "", "email": None}
+        result = server._mask_walk(data, DEMO_KEYS)
+        assert result["name"] == ""
+        assert result["email"] is None
 
-    @pytest.mark.asyncio
-    async def test_nested_relationships(self, mock_scan_pii):
-        """Relationships have nested dicts (a, r, b columns)."""
-        mock_scan_pii.post.return_value.json.return_value = {
-            "contains_pii": True,
-            "masked_text": "<PERSON>",
-            "entity_types": ["PERSON"],
-        }
+    def test_non_string_values_untouched(self):
+        data = {"name": 42, "email": ["a@b.de"]}
+        # 42 is not a string, so it passes through.
+        # A list under `email` means the walker recurses into the list,
+        # and each string inside the list is evaluated with its parent key
+        # context *lost* — list elements don't inherit a key, so they pass
+        # through too. Documenting this is intentional: graph properties
+        # are flat scalars, not collections.
+        result = server._mask_walk(data, DEMO_KEYS)
+        assert result["name"] == 42
+        assert result["email"] == ["a@b.de"]
+
+    def test_recurses_into_nested_dicts(self):
+        """Relationship rows come back as {a: <node>, r: <edge>, b: <node>}."""
         data = {
             "relationships": [
                 {
@@ -121,29 +98,140 @@ class TestMaskGraphPii:
                     "r": {"type": "OWNS"},
                     "b": {"id": "proj1", "label": "Project", "title": "Foo"},
                 }
-            ],
-            "count": 1,
+            ]
         }
-        result = await server._mask_graph_pii(data)
-        # "name" is a PII key → should be masked in the nested dict
+        result = server._mask_walk(data, DEMO_KEYS)
         assert result["relationships"][0]["a"]["name"] == "<PERSON>"
-        # Non-PII nested dicts unchanged
-        assert result["relationships"][0]["b"]["title"] == "Foo"
+        assert result["relationships"][0]["b"]["title"] == "Foo"  # title ≠ PII key
+
+    def test_empty_input(self):
+        assert server._mask_walk({}, DEMO_KEYS) == {}
+        assert server._mask_walk([], DEMO_KEYS) == []
+
+    def test_scalar_passthrough(self):
+        assert server._mask_walk("hello", DEMO_KEYS) == "hello"
+        assert server._mask_walk(42, DEMO_KEYS) == 42
+        assert server._mask_walk(None, DEMO_KEYS) is None
+
+    def test_empty_key_map_masks_nothing(self):
+        """Deployers can disable graph masking by clearing the config section."""
+        data = {"name": "Alice", "email": "a@b.de"}
+        assert server._mask_walk(data, {}) == data
+
+    def test_deterministic_for_non_english_names(self):
+        """Regression: prior Presidio-based impl flagged 'Elena_Hartmann' as
+        PERSON but 'Tim_Heller' as pass-through and 'Sarah_Bach' as LOCATION.
+        With the config-driven walker, all three produce <PERSON>."""
+        data = {"nodes": [
+            {"name": "Elena_Hartmann"},
+            {"name": "Tim_Heller"},
+            {"name": "Sarah_Bach"},
+        ]}
+        result = server._mask_walk(data, DEMO_KEYS)
+        for node in result["nodes"]:
+            assert node["name"] == "<PERSON>"
+
+
+# ── OPA loader ──────────────────────────────────────────────────────────────
+
+
+class TestGetGraphPiiKeys:
+    @pytest.mark.asyncio
+    async def test_loads_from_opa(self):
+        mock_http = AsyncMock()
+        response = MagicMock()
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "result": {"name": "PERSON", "iban": "IBAN_CODE"}
+        }
+        mock_http.get.return_value = response
+
+        with patch.object(server, "http", mock_http):
+            keys = await server._get_graph_pii_keys()
+
+        assert keys == {"name": "PERSON", "iban": "IBAN_CODE"}
+        mock_http.get.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_empty_data(self, mock_http_client):
-        with patch.object(server, "http", mock_http_client):
-            result = await server._mask_graph_pii({})
-            assert result == {}
+    async def test_caches_after_first_load(self):
+        mock_http = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"result": {"name": "PERSON"}}
+        mock_http.get.return_value = response
+
+        with patch.object(server, "http", mock_http):
+            await server._get_graph_pii_keys()
+            await server._get_graph_pii_keys()
+            await server._get_graph_pii_keys()
+
+        mock_http.get.assert_called_once()  # not 3 times
 
     @pytest.mark.asyncio
-    async def test_list_input(self, mock_http_client):
-        with patch.object(server, "http", mock_http_client):
-            result = await server._mask_graph_pii([])
-            assert result == []
+    async def test_lowercases_keys(self):
+        """Policy data may use any casing; the walker only checks lowercased keys."""
+        mock_http = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "result": {"Name": "PERSON", "EMAIL": "EMAIL_ADDRESS"}
+        }
+        mock_http.get.return_value = response
+        with patch.object(server, "http", mock_http):
+            keys = await server._get_graph_pii_keys()
+        assert "name" in keys and "email" in keys
+        assert "Name" not in keys
 
     @pytest.mark.asyncio
-    async def test_scalar_passthrough(self, mock_http_client):
-        with patch.object(server, "http", mock_http_client):
-            assert await server._mask_graph_pii("hello") == "hello"
-            assert await server._mask_graph_pii(42) == 42
+    async def test_falls_back_when_opa_unreachable(self):
+        mock_http = AsyncMock()
+        mock_http.get.side_effect = Exception("connection refused")
+        with patch.object(server, "http", mock_http):
+            keys = await server._get_graph_pii_keys()
+        # Non-empty fallback so the walker keeps protecting PII on OPA outage.
+        assert "name" in keys
+        assert keys["name"] == "PERSON"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_config_empty(self):
+        mock_http = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"result": {}}
+        mock_http.get.return_value = response
+        with patch.object(server, "http", mock_http):
+            keys = await server._get_graph_pii_keys()
+        # Empty OPA result → default, not silent "no protection".
+        assert "name" in keys
+
+
+# ── End-to-end integration of loader + walker ───────────────────────────────
+
+
+class TestMaskGraphPii:
+    @pytest.mark.asyncio
+    async def test_end_to_end_with_opa(self):
+        mock_http = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "result": {"name": "PERSON", "phone": "PHONE_NUMBER"}
+        }
+        mock_http.get.return_value = response
+
+        with patch.object(server, "http", mock_http):
+            result = await server._mask_graph_pii({
+                "nodes": [{
+                    "id": "e-1",
+                    "label": "Employee",
+                    "name": "Alice",
+                    "phone": "+49 151 1234567",
+                    "role": "Staff",
+                }],
+            })
+
+        node = result["nodes"][0]
+        assert node["name"] == "<PERSON>"
+        assert node["phone"] == "<PHONE_NUMBER>"
+        assert node["role"] == "Staff"

--- a/opa-policies/data.json
+++ b/opa-policies/data.json
@@ -50,6 +50,15 @@
 
       "pii_entity_types": ["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER", "IBAN_CODE", "LOCATION"],
 
+      "graph_pii_keys": {
+        "name":      "PERSON",
+        "fullname":  "PERSON",
+        "firstname": "PERSON",
+        "lastname":  "PERSON",
+        "email":     "EMAIL_ADDRESS",
+        "phone":     "PHONE_NUMBER"
+      },
+
       "audit": {
         "retention_days": 365,
         "advisory_lock_id": 847291,

--- a/opa-policies/policy_data_schema.json
+++ b/opa-policies/policy_data_schema.json
@@ -18,7 +18,7 @@
             "roles", "classifications", "access_matrix",
             "write_roles", "write_classifications",
             "allowed_purposes", "retention_days", "retention_obligations",
-            "fields_to_redact", "pii_actions", "pii_entity_types",
+            "fields_to_redact", "pii_actions", "pii_entity_types", "graph_pii_keys",
             "audit", "ingestion", "human_oversight", "drift", "proxy", "summarization", "rules"
           ],
           "additionalProperties": false,
@@ -101,6 +101,11 @@
               "items": { "type": "string" },
               "minItems": 1,
               "description": "Presidio entity types to scan for"
+            },
+            "graph_pii_keys": {
+              "type": "object",
+              "description": "Maps graph property keys (lower-cased) to Presidio entity-type labels. Values at these keys are deterministically replaced with <ENTITY_TYPE> before graph_query / graph_mutate results are returned. Editable at runtime via manage_policies.",
+              "additionalProperties": { "type": "string" }
             },
             "audit": {
               "type": "object",


### PR DESCRIPTION
## Summary

- **B-30 refactor**: replaces the Presidio-per-value graph masker with a deterministic key → entity-type map loaded from `opa-policies/data.json` (`pb.config.graph_pii_keys`). Eliminates Elena-vs-Tim-vs-Sarah inconsistency, removes the last hardcoded policy from mcp-server, and drops the per-query HTTP roundtrips to ingestion.
- **Demo UI fix**: Tab A suggestion buttons now actually trigger a search (were inside `st.form` and silently swallowed before).

## Rationale

- **Deterministic > probabilistic** for semantically classified data. A graph key called `email` *is* an email; running a NER model over its value just invites inconsistency.
- **No hidden policy**. `manage_policies` can now edit the graph masking map at runtime, like the rest of the policy data.
- **Graceful fallback**: if OPA is unreachable at startup, a sane default map applies so the masking layer never silently disables itself.

## Test plan

- [x] 35/35 new + existing graph tests pass (walker, OPA loader, end-to-end, regression for the mixed-NER-score case)
- [x] 960 unit tests pass, 68.32% coverage (CI threshold 68%)
- [x] 125/125 OPA policy tests pass
- [x] Live: all 8 Employee nodes in the demo graph return `<PERSON>` consistently
- [x] Live: Tab A suggestion chips pre-fill the query *and* run the search

🤖 Generated with [Claude Code](https://claude.com/claude-code)