### PR TITLE
fix: resolve overlapping Presidio spans before pseudonymising

### DIFF
--- a/ingestion/pii_scanner.py
+++ b/ingestion/pii_scanner.py
@@ -121,6 +121,59 @@ class PIIScanResult:
     pseudonym_map: dict[str, str] = field(default_factory=dict)
 
 
+# ── Span helpers ───────────────────────────────────────────
+
+def _resolve_overlapping_spans(results: list[Any]) -> list[Any]:
+    """Pick at most one result per text span so downstream replacement is safe.
+
+    Presidio readily emits overlapping hits — classic example is the tail
+    of a German IBAN (``0550 1234 5678 90``) which the phone-number
+    recognizer also matches. If we replace both, the second substitution
+    lands in the middle of the first tag and corrupts the output.
+
+    Resolution strategy, applied greedily in descending priority order:
+
+    1. **Higher score wins.** Presidio scores are a calibrated signal —
+       the IBAN custom recognizer scored 0.95 outranks the phone regex's
+       0.85, which is the desired behaviour on the shared digit span.
+    2. **Longer span wins** on score tie. Prefer the hit that covers
+       more characters; it's typically the superset.
+    3. **Earlier start wins** as a final tie-breaker so the result is
+       deterministic across Presidio runs.
+
+    Returns a list of kept results, ordered as they came in (sort-stable).
+    """
+    if not results:
+        return []
+
+    ranked = sorted(
+        results,
+        key=lambda r: (
+            -float(getattr(r, "score", 0.0)),
+            -(int(r.end) - int(r.start)),
+            int(r.start),
+        ),
+    )
+
+    kept: list[Any] = []
+    for candidate in ranked:
+        c_start, c_end = int(candidate.start), int(candidate.end)
+        overlaps_kept = False
+        for k in kept:
+            k_start, k_end = int(k.start), int(k.end)
+            if c_start < k_end and k_start < c_end:
+                overlaps_kept = True
+                break
+        if not overlaps_kept:
+            kept.append(candidate)
+
+    # Preserve caller-visible order (ascending start). Downstream callers
+    # (scan_text, pseudonymize_text) resort anyway, but stable input is
+    # easier to reason about in tests.
+    kept.sort(key=lambda r: int(r.start))
+    return kept
+
+
 # ── Scanner ─────────────────────────────────────────────────
 
 class PIIScanner:
@@ -215,10 +268,15 @@ class PIIScanner:
         if not results:
             return PIIScanResult()
 
+        # Collapse overlapping hits so downstream consumers (the vault
+        # entity-matching hash lookup in particular) never see two rows
+        # covering the same character range.
+        kept = _resolve_overlapping_spans(results)
+
         entity_counts: dict[str, int] = {}
         entity_locations = []
 
-        for r in results:
+        for r in kept:
             entity_counts[r.entity_type] = entity_counts.get(r.entity_type, 0) + 1
             entity_locations.append({
                 "type": r.entity_type,
@@ -265,9 +323,16 @@ class PIIScanner:
             score_threshold=self.config.min_confidence,
         )
 
+        # Reconcile overlapping hits the same way the pseudonymiser does
+        # so consumers get consistent ``<TYPE>`` placeholders regardless
+        # of which path ran. Presidio's default anonymizer splits on
+        # overlaps and produces "<DE_DATE_OF_BIRTH><LOCATION>" for the
+        # adjacent DOB/LOCATION pair spaCy emits on dotted dates.
+        kept = _resolve_overlapping_spans(results)
+
         anonymized = self.anonymizer.anonymize(
             text=text,
-            analyzer_results=results,
+            analyzer_results=kept,
         )
         return anonymized.text
 
@@ -277,6 +342,13 @@ class PIIScanner:
         """
         Replaces PII with deterministic pseudonyms.
         Same input + salt → same pseudonym (for linkability).
+
+        Overlapping Presidio hits are resolved before replacement (highest
+        score wins; ties go to the longer span). Without this, two hits
+        like ``IBAN_CODE[161..188]`` and ``PHONE_NUMBER[171..188]`` both
+        get substituted in descending-position order, which leaves the
+        PHONE tag pointing into the middle of the freshly-inserted IBAN
+        tag and produces artefacts like ``[IBAN_CODE:abc]db0d4]``.
 
         Returns:
             Tuple of (pseudonymized text, mapping {original → pseudonym})
@@ -288,23 +360,27 @@ class PIIScanner:
             score_threshold=self.config.min_confidence,
         )
 
+        kept = _resolve_overlapping_spans(results)
+
         def make_pseudonym(entity_text: str, entity_type: str) -> str:
             h = hashlib.sha256(f"{salt}:{entity_text}".encode()).hexdigest()[:8]
             return f"[{entity_type}:{h}]"
 
-        # Build individual pseudonyms per result (not per entity type),
+        # Build individual pseudonyms per kept result (not per entity type),
         # so that multiple entities of the same type get different pseudonyms.
         mapping: dict[str, str] = {}
-        for r in results:
+        for r in kept:
             original = text[r.start:r.end]
             pseudo = make_pseudonym(original, r.entity_type)
             mapping[original] = pseudo
 
-        # Manual replacement instead of Presidio's anonymizer (which requires per-type operators).
-        # Sort by position descending for stable offsets.
+        # Manual replacement (position-descending is safe now that spans
+        # don't overlap). We index into the original ``text`` slice for
+        # ``original`` — using the mutating ``pseudonymized`` would still
+        # work but is needlessly fragile.
         pseudonymized = text
-        for r in sorted(results, key=lambda x: x.start, reverse=True):
-            original = pseudonymized[r.start:r.end]
+        for r in sorted(kept, key=lambda x: x.start, reverse=True):
+            original = text[r.start:r.end]
             pseudo = mapping.get(original, make_pseudonym(original, r.entity_type))
             pseudonymized = pseudonymized[:r.start] + pseudo + pseudonymized[r.end:]
 

--- a/ingestion/tests/test_pii_scanner.py
+++ b/ingestion/tests/test_pii_scanner.py
@@ -14,6 +14,7 @@ from pii_scanner import (
     RecognizerConfig,
     LanguageConfig,
     load_config,
+    _resolve_overlapping_spans,
 )
 
 
@@ -206,6 +207,104 @@ class TestPseudonymizeText:
         assert pseudo.endswith("]")
         assert "[EMAIL_ADDRESS:" in result
         assert "max@example.com" not in result
+
+
+def _span(entity_type: str, start: int, end: int, score: float):
+    """Small helper — Presidio AnalyzerResult-alike."""
+    m = MagicMock()
+    m.entity_type = entity_type
+    m.start = start
+    m.end = end
+    m.score = score
+    return m
+
+
+class TestResolveOverlappingSpans:
+    """Standalone tests for the span-overlap resolver.
+
+    Exercises the three tie-breakers independently plus the no-op case.
+    """
+
+    def test_empty(self):
+        assert _resolve_overlapping_spans([]) == []
+
+    def test_non_overlapping_kept_as_is(self):
+        a = _span("PERSON", 0, 5, 0.95)
+        b = _span("EMAIL_ADDRESS", 10, 25, 0.99)
+        out = _resolve_overlapping_spans([a, b])
+        assert len(out) == 2
+        assert [r.entity_type for r in out] == ["PERSON", "EMAIL_ADDRESS"]
+
+    def test_higher_score_wins_on_overlap(self):
+        # Regression: the IBAN tail overlap with the phone recognizer.
+        # IBAN 161..188 (score 0.95) vs PHONE_NUMBER 171..188 (score 0.85).
+        iban = _span("IBAN_CODE", 161, 188, 0.95)
+        phone = _span("PHONE_NUMBER", 171, 188, 0.85)
+        kept = _resolve_overlapping_spans([iban, phone])
+        assert len(kept) == 1
+        assert kept[0].entity_type == "IBAN_CODE"
+
+    def test_longer_span_wins_on_score_tie(self):
+        short = _span("LOCATION", 100, 106, 0.85)
+        long = _span("DE_DATE_OF_BIRTH", 88, 114, 0.85)
+        kept = _resolve_overlapping_spans([short, long])
+        assert len(kept) == 1
+        assert kept[0].entity_type == "DE_DATE_OF_BIRTH"
+
+    def test_earlier_start_wins_on_full_tie(self):
+        first = _span("PERSON", 5, 10, 0.9)
+        second = _span("LOCATION", 7, 12, 0.9)
+        kept = _resolve_overlapping_spans([first, second])
+        assert len(kept) == 1
+        assert kept[0].start == 5
+
+    def test_chain_of_overlaps_resolved_greedily(self):
+        """Three overlapping spans in sequence — highest-score wins all."""
+        a = _span("A", 0, 10, 0.7)
+        b = _span("B", 5, 15, 0.95)
+        c = _span("C", 12, 20, 0.8)
+        kept = _resolve_overlapping_spans([a, b, c])
+        # B covers 5..15, so A (0..10) and C (12..20) both overlap with B
+        # and are dropped. Result: [B] only.
+        assert [r.entity_type for r in kept] == ["B"]
+
+    def test_result_sorted_by_start(self):
+        """Caller-visible order is ascending by start regardless of input order."""
+        a = _span("A", 30, 35, 0.9)
+        b = _span("B", 0, 5, 0.9)
+        c = _span("C", 50, 60, 0.9)
+        kept = _resolve_overlapping_spans([a, b, c])
+        assert [r.start for r in kept] == [0, 30, 50]
+
+
+class TestPseudonymizeTextOverlap:
+    """Integration tests covering the overlap fix end-to-end."""
+
+    def test_iban_phone_overlap_no_artefacts(self, scanner):
+        """Regression for the `[IBAN_CODE:abc]db0d4]` artefact seen live."""
+        text = "Bankverbindung: DE68 2005 0550 1234 5678 90. Vertrag: abc"
+        # IBAN covers the full formatted number (start=16, end=43).
+        iban = _span("IBAN_CODE", 16, 43, 0.95)
+        # Phone recognizer matches the trailing digit run `0550 1234 5678 90`
+        # (start=26, end=43) — a proper subset / overlap with the IBAN.
+        phone = _span("PHONE_NUMBER", 26, 43, 0.85)
+        scanner.analyzer.analyze.return_value = [iban, phone]
+
+        result, mapping = scanner.pseudonymize_text(text, "salt")
+
+        # The full IBAN was replaced exactly once, nothing leaked.
+        iban_original = text[16:43]
+        assert iban_original in mapping
+        assert mapping[iban_original].startswith("[IBAN_CODE:")
+        # No dangling ']' or trailing digit fragments that used to come
+        # from the second, overlapping substitution writing into the tag.
+        assert "]db0d4]" not in result
+        assert result.count("[IBAN_CODE:") == 1
+        # Phone was discarded — lower score.
+        assert "[PHONE_NUMBER:" not in result
+        # Sanity: the prefix / suffix around the IBAN still match.
+        assert result.startswith("Bankverbindung: [IBAN_CODE:")
+        assert result.endswith(". Vertrag: abc")
 
 
 class TestPIIScannerConfig:


### PR DESCRIPTION
## Problem

Live demo surfaced nested tag artefacts like `[IBAN_CODE:73c1acb4]db0d4]` in the vault-stored chunks. The IBAN and phone recognisers emit overlapping hits on the same digit run (IBAN covers the full formatted number, phone regex matches the trailing digit block). The pseudonymiser replaced both in descending-position order and the second substitution landed inside the freshly-inserted IBAN tag.

## Fix

New `_resolve_overlapping_spans` helper that picks at most one result per overlapping range — higher Presidio score first, longer span on score tie, earlier start on full tie. Applied in `scan_text`, `mask_text`, and `pseudonymize_text` so the vault's hash-matching lookup never has to guess which of two candidates generated a given pseudonym.

## Test plan

- [x] 7 new unit tests (empty / no overlap / score-wins / length-wins / start-wins / chain of overlaps / sort order)
- [x] Regression test reproducing the live IBAN-vs-PHONE case — asserts no `]…]` artefact
- [x] 36/36 in `ingestion/tests/test_pii_scanner.py`
- [x] Live: re-ingested NovaTech customer records; Qdrant chunks are clean. `/vault/resolve` with `purpose=support` returns clean resolved text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)