### PR TITLE
fix(ingestion): unblock POST /sync by preserving package layout (#60)

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -20,8 +20,8 @@ RUN python -m spacy download de_core_news_md
 RUN python -m spacy download en_core_web_lg
 
 COPY shared/ /app/shared/
-COPY ingestion/ .
+COPY ingestion/ /app/ingestion/
 
 EXPOSE 8081
 
-CMD ["uvicorn", "ingestion_api:app", "--host", "0.0.0.0", "--port", "8081"]
+CMD ["uvicorn", "ingestion.ingestion_api:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -22,6 +22,11 @@ RUN python -m spacy download en_core_web_lg
 COPY shared/ /app/shared/
 COPY ingestion/ /app/ingestion/
 
+# /app → package imports (from ingestion.X, from shared.X)
+# /app/ingestion → sibling imports (from pii_scanner, from quality, etc.)
+# Both forms are used across production + tests, so both must resolve.
+ENV PYTHONPATH=/app/ingestion:/app
+
 EXPOSE 8081
 
 CMD ["uvicorn", "ingestion.ingestion_api:app", "--host", "0.0.0.0", "--port", "8081"]


### PR DESCRIPTION
Closes [#60](https://github.com/nuetzliches/powerbrain/issues/60)

## Summary

- `POST /sync` returned 500 with `ModuleNotFoundError: No module named 'ingestion'` because the Dockerfile flattened `ingestion/*` into `/app/`, but `ingestion_api.py:1662`, `sync_service.py`, and the adapters all use absolute `from ingestion.*` imports.
- Fix: copy the directory as `/app/ingestion/`, add the missing top-level `ingestion/__init__.py`, and point uvicorn at `ingestion.ingestion_api:app`. A new `ENV PYTHONPATH=/app/ingestion:/app` keeps the pre-existing sibling imports (`from pii_scanner import …`) working without rewriting 40+ statements.
- Side benefit: the already-existing compose mount `./ingestion/repos.yaml:/app/ingestion/repos.yaml:ro` now targets a real path inside the image.

No application code changes.

## Test plan

- [x] `docker build -f ingestion/Dockerfile .` succeeds
- [x] `docker run --rm <image> python -c "import ingestion.sync_service; import ingestion.adapters.git_adapter; import pii_scanner; import quality; import snapshot_service"` — OK
- [x] `POST /sync` and `POST /sync/{repo_name}` routes are registered by FastAPI
- [ ] CI (pr-validate.yml): unit-tests, opa-tests, docker-build, security-scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)