### PR TITLE
fix(opa): surface missing policies instead of silent deny (#59)

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -28,6 +28,7 @@ import asyncpg
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from shared.config import build_postgres_url
+from shared.opa_client import OpaPolicyMissingError, opa_query
 
 log = logging.getLogger("pb-eval")
 
@@ -135,20 +136,22 @@ async def check_opa_access(client: httpx.AsyncClient,
     if classification in _opa_access_cache:
         return _opa_access_cache[classification]
     try:
-        resp = await client.post(
-            f"{OPA_URL}/v1/data/pb/access/allow",
-            json={"input": {
+        raw = await opa_query(
+            client, OPA_URL, "pb/access/allow",
+            {
                 "agent_id": EVAL_AGENT_ID,
                 "agent_role": EVAL_AGENT_ROLE,
                 "resource": "eval/search",
                 "classification": classification,
                 "action": "read",
-            }},
+            },
         )
-        resp.raise_for_status()
-        result = resp.json().get("result", False)
+        result = bool(raw)
         _opa_access_cache[classification] = result
         return result
+    except OpaPolicyMissingError as exc:
+        log.error("OPA policy %s not loaded — denying eval access", exc.package_path)
+        return False
     except Exception as e:
         log.warning("OPA check failed, denying access: %s", e)
         return False

--- a/ingestion/ingestion_api.py
+++ b/ingestion/ingestion_api.py
@@ -75,6 +75,11 @@ from shared.pii_verify_provider import (
     apply_verdicts_to_scan_result,
     VerifyStats,
 )
+from shared.opa_client import (
+    OpaPolicyMissingError,
+    opa_query,
+    verify_required_policies,
+)
 
 POSTGRES_URL = build_postgres_url()
 
@@ -268,6 +273,13 @@ EXTRACT_MAX_BYTES = int(os.getenv("EXTRACT_MAX_BYTES", str(25 * 1024 * 1024)))  
 EXTRACT_TIMEOUT_SECONDS = float(os.getenv("EXTRACT_TIMEOUT_SECONDS", "30"))
 
 
+REQUIRED_OPA_POLICIES = [
+    "pb/ingestion/quality_gate",
+    "pb/privacy",
+    "pb/config/ingestion/pii_verifier",
+]
+
+
 @app.on_event("startup")
 async def startup():
     global qdrant, http_client, pg_pool
@@ -279,6 +291,17 @@ async def startup():
     except Exception as e:
         log.error(f"PostgreSQL connection failed: {e}")
         pg_pool = None
+
+    # Fail loudly if required OPA policies are not loaded — otherwise the
+    # runtime helpers would fail-closed with misleading diagnostics
+    # (see issue #59: "quality_score 0.629 < required 0.000").
+    # Disabled only for test runs where OPA is not reachable.
+    if os.getenv("SKIP_OPA_STARTUP_CHECK", "false").lower() != "true":
+        try:
+            await verify_required_policies(http_client, OPA_URL, REQUIRED_OPA_POLICIES)
+        except Exception as exc:
+            log.error("OPA startup verification failed: %s", exc)
+            raise
 
 
 @app.on_event("shutdown")
@@ -482,27 +505,42 @@ async def check_opa_quality_gate(
     Returns a dict with ``allowed`` (bool), ``min_score`` (float) and
     ``reason`` (str). On OPA failure we fail-closed (allowed=False) so a
     broken policy engine cannot silently bypass the quality gate.
+
+    ``min_score`` uses the sentinel ``-1.0`` when the policy package is
+    not loaded or OPA is unreachable. The normal minimum is never
+    negative, so ``-1.0`` in logs or the ``ingestion_rejections`` table
+    flags a configuration problem rather than a threshold comparison.
     """
     input_data = {
         "source_type":    source_type or "default",
         "quality_score":  float(quality_score),
     }
     try:
-        resp = await http_client.post(
-            f"{OPA_URL}/v1/data/pb/ingestion/quality_gate",
-            json={"input": input_data},
+        result = await opa_query(
+            http_client, OPA_URL, "pb/ingestion/quality_gate", input_data,
         )
-        resp.raise_for_status()
-        result = resp.json().get("result") or {}
+    except OpaPolicyMissingError as exc:
+        log.error("OPA policy missing: %s", exc.package_path)
         return {
-            "allowed":   bool(result.get("allowed", False)),
-            "min_score": float(result.get("min_score", 0.0)),
-            "reason":    result.get("reason", ""),
+            "allowed":   False,
+            "min_score": -1.0,
+            "reason":    f"opa_policy_missing: {exc.package_path}",
         }
     except Exception as e:
-        log.warning(f"OPA quality_gate check failed, fail-closed: {e}")
-        return {"allowed": False, "min_score": 0.0,
+        log.warning("OPA quality_gate check failed, fail-closed: %s", e)
+        return {"allowed": False, "min_score": -1.0,
                 "reason": f"opa_unreachable: {e}"}
+
+    if not isinstance(result, dict):
+        log.warning("OPA quality_gate returned non-dict %r, fail-closed", result)
+        return {"allowed": False, "min_score": -1.0,
+                "reason": "opa_unexpected_shape"}
+
+    return {
+        "allowed":   bool(result.get("allowed", False)),
+        "min_score": float(result.get("min_score", 0.0)),
+        "reason":    result.get("reason", ""),
+    }
 
 
 async def check_opa_pii_verifier() -> dict:
@@ -518,24 +556,29 @@ async def check_opa_pii_verifier() -> dict:
         "min_confidence_keep": 0.5,
     }
     try:
-        resp = await http_client.post(
-            f"{OPA_URL}/v1/data/pb/config/ingestion/pii_verifier",
-            json={"input": {}},
+        data = await opa_query(
+            http_client, OPA_URL, "pb/config/ingestion/pii_verifier",
         )
-        resp.raise_for_status()
-        data = resp.json().get("result") or {}
-        if not isinstance(data, dict):
-            return fallback
-        return {
-            "enabled":  bool(data.get("enabled", fallback["enabled"])),
-            "backend":  str(data.get("backend", fallback["backend"])),
-            "min_confidence_keep": float(
-                data.get("min_confidence_keep", fallback["min_confidence_keep"])
-            ),
-        }
+    except OpaPolicyMissingError as exc:
+        log.warning(
+            "OPA policy %s not loaded — falling back to env defaults "
+            "(enabled=%s, backend=%s)",
+            exc.package_path, fallback["enabled"], fallback["backend"],
+        )
+        return fallback
     except Exception as exc:
         log.warning("OPA pii_verifier policy lookup failed, using env defaults: %s", exc)
         return fallback
+
+    if not isinstance(data, dict):
+        return fallback
+    return {
+        "enabled":  bool(data.get("enabled", fallback["enabled"])),
+        "backend":  str(data.get("backend", fallback["backend"])),
+        "min_confidence_keep": float(
+            data.get("min_confidence_keep", fallback["min_confidence_keep"])
+        ),
+    }
 
 
 async def apply_pii_verifier(
@@ -619,7 +662,9 @@ async def check_opa_privacy(
 ) -> dict:
     """Queries OPA for pii_action and dual_storage_enabled.
 
-    OPA endpoint: /v1/data/pb/privacy/pii_action, /v1/data/pb/privacy/dual_storage_enabled
+    OPA endpoint: /v1/data/pb/privacy. Fail-closed on missing policy or
+    unreachable OPA — privacy decisions must never silently default
+    to a more permissive action than ``block``.
     """
     input_data = {
         "classification": classification,
@@ -628,17 +673,22 @@ async def check_opa_privacy(
     }
     result = {"pii_action": "block", "dual_storage_enabled": False}
     try:
-        resp = await http_client.post(
-            f"{OPA_URL}/v1/data/pb/privacy",
-            json={"input": input_data},
+        data = await opa_query(http_client, OPA_URL, "pb/privacy", input_data)
+    except OpaPolicyMissingError as exc:
+        log.error(
+            "OPA privacy policy not loaded (%s) — defaulting to block",
+            exc.package_path,
         )
-        resp.raise_for_status()
-        data = resp.json().get("result", {})
+        result["reason"] = f"opa_policy_missing: {exc.package_path}"
+        return result
+    except Exception as e:
+        log.warning("OPA privacy check failed, defaulting to block: %s", e)
+        return result
+
+    if isinstance(data, dict):
         result["pii_action"] = data.get("pii_action", "block")
         result["dual_storage_enabled"] = data.get("dual_storage_enabled", False)
         result["retention_days"] = data.get("retention_days", 365)
-    except Exception as e:
-        log.warning(f"OPA privacy check failed, defaulting to block: {e}")
     return result
 
 
@@ -977,10 +1027,13 @@ async def ingest_text_chunks(
     gate = await check_opa_quality_gate(source_type, quality_report.score)
 
     if not gate["allowed"]:
-        log.warning(
-            f"Quality gate rejected document source={source!r} "
-            f"score={quality_report.score:.3f} min={gate['min_score']:.3f} "
-            f"reason={gate['reason']!r}"
+        # `min_score == -1.0` is the sentinel for "policy missing / OPA
+        # unreachable" — log at ERROR so the cause is obvious. Any other
+        # threshold rejection is normal.
+        _log = log.error if gate["min_score"] < 0 else log.warning
+        _log(
+            "Quality gate rejected document source=%r score=%.3f min=%.3f reason=%r",
+            source, quality_report.score, gate["min_score"], gate["reason"],
         )
         # Audit the rejection and remove the pre-created documents_meta row.
         if pg_pool:

--- a/ingestion/tests/conftest.py
+++ b/ingestion/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for ingestion tests."""
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -7,6 +8,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# The startup OPA policy verification (issue #59 part 2) requires a live
+# OPA instance. Unit tests that spin up FastAPI's TestClient would
+# otherwise fail during the lifespan event. Set the opt-out before the
+# app is imported anywhere in the test session.
+os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")
 
 
 @pytest.fixture

--- a/ingestion/tests/test_opa_missing_policy.py
+++ b/ingestion/tests/test_opa_missing_policy.py
@@ -1,0 +1,113 @@
+"""Regression tests for issue #59 part 2.
+
+When an OPA policy package is not loaded, OPA returns a body without a
+``result`` field. Before the fix, the ingestion helpers silently
+collapsed this to ``allowed=False, min_score=0.0``, producing the
+misleading log ``"quality_score 0.629 < required 0.000"`` that cost
+operators hours of debugging. These tests lock in the new behaviour:
+
+* ``check_opa_quality_gate`` returns the ``-1.0`` sentinel for
+  ``min_score`` and a reason starting with ``"opa_policy_missing"``.
+* ``check_opa_privacy`` defaults to ``block`` with an explicit reason.
+* ``check_opa_pii_verifier`` falls back to the env defaults but logs
+  the missing policy path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import ingestion_api
+
+
+@pytest.fixture
+def http_missing_policy(monkeypatch):
+    """Return a mock client whose OPA response has no 'result' field."""
+    mock = AsyncMock()
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"decision_id": "abc-no-policy"}
+    mock.post.return_value = response
+    monkeypatch.setattr(ingestion_api, "http_client", mock)
+    return mock
+
+
+class TestQualityGateMissingPolicy:
+
+    async def test_returns_allowed_false(self, http_missing_policy):
+        gate = await ingestion_api.check_opa_quality_gate("code", 0.75)
+        assert gate["allowed"] is False
+
+    async def test_min_score_is_sentinel(self, http_missing_policy):
+        """Sentinel -1.0 makes it obvious the comparison is nonsense.
+
+        A real threshold is always >= 0. Seeing ``min=-1.000`` in logs or
+        the ``ingestion_rejections`` table immediately flags a
+        configuration problem.
+        """
+        gate = await ingestion_api.check_opa_quality_gate("code", 0.75)
+        assert gate["min_score"] == -1.0
+
+    async def test_reason_names_missing_package(self, http_missing_policy):
+        gate = await ingestion_api.check_opa_quality_gate("code", 0.75)
+        assert gate["reason"].startswith("opa_policy_missing:")
+        assert "pb/ingestion/quality_gate" in gate["reason"]
+
+
+class TestPrivacyMissingPolicy:
+
+    async def test_defaults_to_block(self, http_missing_policy):
+        privacy = await ingestion_api.check_opa_privacy("internal", True, "consent")
+        assert privacy["pii_action"] == "block"
+        assert privacy["dual_storage_enabled"] is False
+
+    async def test_reason_surfaces_missing_package(self, http_missing_policy):
+        privacy = await ingestion_api.check_opa_privacy("internal", True)
+        assert "reason" in privacy
+        assert "opa_policy_missing" in privacy["reason"]
+        assert "pb/privacy" in privacy["reason"]
+
+
+class TestPIIVerifierMissingPolicy:
+    """The verifier is optional — missing policy should fall back to env
+    defaults rather than raise or block."""
+
+    async def test_falls_back_to_env_defaults(self, http_missing_policy):
+        got = await ingestion_api.check_opa_pii_verifier()
+        assert "enabled" in got
+        assert "backend" in got
+        assert "min_confidence_keep" in got
+
+    async def test_no_exception_propagates(self, http_missing_policy):
+        # Missing policy must not surface as an exception from this
+        # helper — the caller relies on always getting a dict.
+        result = await ingestion_api.check_opa_pii_verifier()
+        assert isinstance(result, dict)
+
+
+class TestQualityGateDenyIsDistinctFromMissing:
+    """A real deny decision must NOT be confused with a missing policy.
+
+    If the policy returns {"allowed": false, "min_score": 0.5}, we
+    should pass those values through unchanged — the existing
+    ``test_denied_propagates`` in test_quality.py already covers the
+    happy path; this test adds the contrast to the new sentinel.
+    """
+
+    async def test_explicit_deny_keeps_positive_min_score(self, monkeypatch):
+        mock = AsyncMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "result": {"allowed": False, "min_score": 0.5, "reason": "too_low"}
+        }
+        mock.post.return_value = response
+        monkeypatch.setattr(ingestion_api, "http_client", mock)
+
+        gate = await ingestion_api.check_opa_quality_gate("default", 0.3)
+
+        assert gate["allowed"] is False
+        assert gate["min_score"] == 0.5  # real threshold, not -1.0 sentinel
+        assert gate["reason"] == "too_low"

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -52,6 +52,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from shared.llm_provider import EmbeddingProvider, CompletionProvider
 from shared.rerank_provider import create_rerank_provider, RerankDocument
 from shared.config import read_secret, build_postgres_url, PG_POOL_MIN, PG_POOL_MAX
+from shared.opa_client import (
+    OpaPolicyMissingError,
+    opa_query,
+    verify_required_policies,
+)
 from shared.telemetry import (
     init_telemetry, setup_auto_instrumentation, trace_operation,
     request_telemetry_context, get_current_telemetry,
@@ -508,39 +513,40 @@ async def check_opa_summarization_policy(
     agent_role: str,
     classification: str,
 ) -> dict:
-    """Check OPA summarization policy. Returns {allowed, required, detail}."""
+    """Check OPA summarization policy. Returns {allowed, required, detail}.
+
+    Fail-closed on missing policy or transport error: summarization is
+    an extra permission, so denying by default is the safe fallback.
+    """
     input_data = {
         "agent_role": agent_role,
         "classification": classification,
     }
     try:
-        allowed_resp = await http.post(
-            f"{OPA_URL}/v1/data/pb/summarization/summarize_allowed",
-            json={"input": input_data},
+        allowed = await opa_query(
+            http, OPA_URL, "pb/summarization/summarize_allowed", input_data,
         )
-        allowed_resp.raise_for_status()
-        allowed = allowed_resp.json().get("result", False)
-
-        required_resp = await http.post(
-            f"{OPA_URL}/v1/data/pb/summarization/summarize_required",
-            json={"input": input_data},
+        required = await opa_query(
+            http, OPA_URL, "pb/summarization/summarize_required", input_data,
         )
-        required_resp.raise_for_status()
-        required = required_resp.json().get("result", False)
-
-        detail_resp = await http.post(
-            f"{OPA_URL}/v1/data/pb/summarization/summarize_detail",
-            json={"input": input_data},
+        detail = await opa_query(
+            http, OPA_URL, "pb/summarization/summarize_detail", input_data,
         )
-        detail_resp.raise_for_status()
-        detail = detail_resp.json().get("result", "standard")
+    except OpaPolicyMissingError as exc:
+        log.error(
+            "OPA summarization policy not loaded (%s) — denying by default",
+            exc.package_path,
+        )
+        return {"allowed": False, "required": False, "detail": "standard"}
     except Exception as e:
-        log.warning(f"OPA summarization policy check failed: {e}")
-        allowed = False
-        required = False
-        detail = "standard"
+        log.warning("OPA summarization policy check failed: %s", e)
+        return {"allowed": False, "required": False, "detail": "standard"}
 
-    return {"allowed": allowed, "required": required, "detail": detail}
+    return {
+        "allowed":  bool(allowed) if allowed is not None else False,
+        "required": bool(required) if required is not None else False,
+        "detail":   detail if isinstance(detail, str) else "standard",
+    }
 
 
 def _apply_heuristic_boosts(
@@ -633,13 +639,22 @@ async def check_opa_policy(agent_id: str, agent_role: str,
             "resource": resource, "classification": classification, "action": action,
         }
         try:
-            resp = await http.post(
-                f"{OPA_URL}/v1/data/pb/access/allow", json={"input": input_data}
+            result = await opa_query(
+                http, OPA_URL, "pb/access/allow", input_data,
             )
-            resp.raise_for_status()
-            allowed = resp.json().get("result", False)
+            allowed = bool(result)
         except (httpx.ConnectError, httpx.TimeoutException):
             raise  # Let tenacity retry these
+        except OpaPolicyMissingError as exc:
+            # The access gate is the MOST critical OPA policy. If it's
+            # not loaded, we MUST fail-closed — a silent default of
+            # "deny" is correct, but surface the cause loudly so
+            # operators can fix the misconfiguration.
+            log.error(
+                "OPA access policy %s not loaded — denying all requests. "
+                "Fix OPA config and restart.", exc.package_path,
+            )
+            allowed = False
         except Exception as e:
             log.warning(f"OPA check failed, defaulting to deny: {e}")
             allowed = False
@@ -766,7 +781,11 @@ async def check_opa_vault_access(
     agent_role: str, purpose: str, classification: str,
     data_category: str, token_valid: bool, token_expired: bool,
 ) -> dict:
-    """Checks via OPA whether vault access is allowed."""
+    """Checks via OPA whether vault access is allowed.
+
+    Fail-closed on missing policy: the vault holds original PII, so a
+    silent default of "allow" would be unacceptable.
+    """
     input_data = {
         "agent_role": agent_role,
         "purpose": purpose,
@@ -776,18 +795,21 @@ async def check_opa_vault_access(
         "token_expired": token_expired,
     }
     try:
-        resp = await http.post(
-            f"{OPA_URL}/v1/data/pb/privacy/vault_access_allowed",
-            json={"input": input_data},
+        allowed_raw = await opa_query(
+            http, OPA_URL, "pb/privacy/vault_access_allowed", input_data,
         )
-        resp.raise_for_status()
-        allowed = resp.json().get("result", False)
-        fields_resp = await http.post(
-            f"{OPA_URL}/v1/data/pb/privacy/vault_fields_to_redact",
-            json={"input": input_data},
+        fields_raw = await opa_query(
+            http, OPA_URL, "pb/privacy/vault_fields_to_redact", input_data,
         )
-        fields_resp.raise_for_status()
-        fields_to_redact = list(fields_resp.json().get("result", []))
+        allowed = bool(allowed_raw)
+        fields_to_redact = list(fields_raw) if isinstance(fields_raw, list) else []
+    except OpaPolicyMissingError as exc:
+        log.error(
+            "OPA vault policy not loaded (%s) — denying vault access",
+            exc.package_path,
+        )
+        allowed = False
+        fields_to_redact = []
     except Exception as e:
         log.warning(f"OPA vault access check failed: {e}")
         allowed = False
@@ -3524,6 +3546,18 @@ if __name__ == "__main__":
         pg_pool = await asyncpg.create_pool(POSTGRES_URL, min_size=PG_POOL_MIN, max_size=PG_POOL_MAX)
         await pg_pool.fetchval("SELECT 1")
         log.info("PostgreSQL pool ready (%s)", POSTGRES_URL.split("@")[-1])
+
+        # Refuse to start if OPA is unreachable or a required policy
+        # package is not loaded (issue #59 part 2).
+        if os.getenv("SKIP_OPA_STARTUP_CHECK", "false").lower() != "true":
+            await verify_required_policies(
+                http, OPA_URL,
+                [
+                    "pb/access/allow",
+                    "pb/summarization/summarize_allowed",
+                    "pb/privacy/vault_access_allowed",
+                ],
+            )
 
         oauth_provider.start_cleanup()
         async with session_manager.run():

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for mcp-server tests."""
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -8,6 +9,12 @@ import pytest
 
 # Add mcp-server to path so we can import server, graph_service
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# The lifespan OPA policy verification (issue #59 part 2) requires a
+# running OPA server. Unit tests that exercise the ASGI stack via
+# TestClient would otherwise fail at startup. Set the opt-out before
+# any test imports the module under test.
+os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")
 
 
 @pytest.fixture

--- a/pb-proxy/proxy.py
+++ b/pb-proxy/proxy.py
@@ -41,6 +41,12 @@ _shared_parent = os.path.join(os.path.dirname(__file__), "..")
 if _shared_parent not in sys.path:
     sys.path.insert(0, _shared_parent)
 
+from shared.opa_client import (
+    OpaPolicyMissingError,
+    opa_query,
+    verify_required_policies,
+)
+
 try:
     from shared.telemetry import (
         init_telemetry, setup_auto_instrumentation, trace_operation,
@@ -184,26 +190,30 @@ provider_key_config: dict[str, str] = {}
 async def check_opa_policy(
     agent_role: str, provider: str, configured_servers: list[str],
 ) -> dict:
-    """Check proxy policies via OPA."""
+    """Check proxy policies via OPA.
+
+    Fail-closed on missing policy: the proxy gates which LLM providers
+    and MCP servers each role may call. A silent permissive default
+    would be a policy-bypass.
+    """
     if http_client is None:
         raise RuntimeError("http_client not initialized (lifespan not started)")
-    opa_input = {
-        "input": {
-            "agent_role": agent_role,
-            "provider": provider,
-            "configured_servers": configured_servers,
-        }
+    input_data = {
+        "agent_role": agent_role,
+        "provider": provider,
+        "configured_servers": configured_servers,
     }
     try:
-        resp = await http_client.post(
-            f"{config.OPA_URL}/v1/data/pb/proxy",
-            json=opa_input,
+        result = await opa_query(http_client, config.OPA_URL, "pb/proxy", input_data)
+        return result if isinstance(result, dict) else {}
+    except OpaPolicyMissingError as exc:
+        log.error(
+            "OPA proxy policy not loaded (%s) — denying provider access",
+            exc.package_path,
         )
-        resp.raise_for_status()
-        return resp.json().get("result", {})
+        return {"provider_allowed": False, "max_iterations": 0}
     except Exception as e:
         log.error("OPA policy check failed: %s", e)
-        # Fail closed: deny if OPA is unreachable
         return {"provider_allowed": False, "max_iterations": 0}
 
 
@@ -305,6 +315,12 @@ async def lifespan(app: FastAPI):
             log.error("Cannot start: MCP server unreachable and FAIL_MODE=closed: %s", e)
             raise
         log.warning("MCP server unreachable, starting in degraded mode: %s", e)
+
+    # Refuse to start if the proxy's OPA policy package is missing — a
+    # permissive silent default would bypass provider/MCP-server gating
+    # (issue #59 part 2).
+    if os.getenv("SKIP_OPA_STARTUP_CHECK", "false").lower() != "true":
+        await verify_required_policies(http_client, config.OPA_URL, ["pb/proxy"])
 
     log.info("pb-proxy started on %s:%d", config.PROXY_HOST, config.PROXY_PORT)
     yield

--- a/pb-proxy/tests/conftest.py
+++ b/pb-proxy/tests/conftest.py
@@ -1,8 +1,14 @@
 """Shared fixtures for pb-proxy tests."""
 
+import os
 import sys
 from pathlib import Path
 
 # Add pb-proxy to sys.path so bare imports (config, proxy, etc.) work
 # with pytest's --import-mode=importlib.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Skip the lifespan OPA policy verification (issue #59 part 2) in unit
+# tests — TestClient would otherwise fail to start because no OPA is
+# running in the CI container.
+os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")

--- a/shared/opa_client.py
+++ b/shared/opa_client.py
@@ -1,0 +1,142 @@
+"""OPA query helper — distinguishes missing policies from deny decisions.
+
+When an OPA data path has no evaluated rule (policy package not loaded,
+or rule missing without a `default`), OPA's response has **no** ``result``
+field — just ``{"decision_id": "..."}``. Callers that do
+``resp.json().get("result", {})`` silently treat this as "rule returned
+empty dict", which then collapses to ``allowed=False``, ``min_score=0.0``,
+etc. — a silent deny with misleading diagnostics.
+
+This module surfaces that situation explicitly:
+
+* :func:`opa_query` raises :class:`OpaPolicyMissingError` when ``result``
+  is absent so callers can log the real cause and still fail-closed.
+* :func:`verify_required_policies` is called once at service startup
+  to refuse to boot if any required data path is unreachable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+
+class OpaPolicyMissingError(RuntimeError):
+    """Raised when an OPA data path returns no ``result`` field.
+
+    Attributes:
+        package_path: The policy path that was queried (e.g.
+            ``"pb/ingestion/quality_gate"``), so callers can include it
+            in log messages and rejection reasons.
+    """
+
+    def __init__(self, package_path: str):
+        self.package_path = package_path
+        super().__init__(
+            f"OPA policy {package_path!r} not loaded — response has no 'result' "
+            f"field. Check that opa-policies/ is mounted and the package is "
+            f"declared in a .rego file."
+        )
+
+
+async def opa_query(
+    client: httpx.AsyncClient,
+    opa_url: str,
+    package_path: str,
+    input_data: dict[str, Any] | None = None,
+    *,
+    timeout: float | None = None,
+) -> Any:
+    """POST an input to an OPA data path and return the evaluated ``result``.
+
+    Args:
+        client: An existing :class:`httpx.AsyncClient` (typically the
+            service-wide client used elsewhere).
+        opa_url: Base URL of the OPA server, e.g. ``http://opa:8181``.
+        package_path: The rule/data path to evaluate, without leading
+            ``/v1/data/`` — e.g. ``"pb/ingestion/quality_gate"`` or
+            ``"pb/access/allow"``. Dots are also accepted and normalized
+            to slashes so callers can use the Rego form
+            (``"pb.ingestion.quality_gate"``) interchangeably.
+        input_data: The OPA ``input`` payload. Defaults to ``{}``.
+        timeout: Optional per-call override for the HTTP timeout. When
+            ``None`` (default), the client's configured timeout applies.
+
+    Returns:
+        Whatever OPA evaluated the rule to. The exact shape depends on
+        the rule — callers are responsible for validating it.
+
+    Raises:
+        OpaPolicyMissingError: The response body had no ``result`` field,
+            indicating the policy package or rule is not loaded.
+        httpx.HTTPError: Any transport-level failure. Callers typically
+            wrap this in a fail-closed branch with a diagnostic log.
+    """
+    path = package_path.strip("/").replace(".", "/")
+    kwargs: dict[str, Any] = {"json": {"input": input_data or {}}}
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+
+    resp = await client.post(f"{opa_url}/v1/data/{path}", **kwargs)
+    resp.raise_for_status()
+    body = resp.json()
+
+    if "result" not in body:
+        raise OpaPolicyMissingError(path)
+    return body["result"]
+
+
+async def verify_required_policies(
+    client: httpx.AsyncClient,
+    opa_url: str,
+    required_paths: list[str],
+    *,
+    timeout: float | None = 5.0,
+) -> None:
+    """Probe each required OPA data path once; raise if any are unreachable.
+
+    Intended for FastAPI startup hooks: if a service depends on specific
+    OPA rules, missing them should be a loud boot-time failure rather
+    than a confusing runtime deny.
+
+    Implementation: POSTs ``{"input": {}}`` to each path. If the response
+    has no ``result`` field or the request errors, the path is
+    considered unavailable. Having a ``result`` that evaluates to
+    ``false`` or ``{}`` is **fine** — that only means the rule
+    legitimately says "no" for the empty input, which is a valid
+    configuration.
+
+    Args:
+        client: Shared httpx client.
+        opa_url: Base URL of the OPA server.
+        required_paths: Data paths to probe, in Rego or slash form.
+        timeout: Optional per-probe timeout. Short default (5s) so
+            startup doesn't hang on an unreachable OPA.
+
+    Raises:
+        RuntimeError: One or more required paths are not loaded or
+            the OPA server is unreachable. The message lists every
+            failing path so operators see the full picture.
+    """
+    missing: list[str] = []
+    for path in required_paths:
+        try:
+            await opa_query(client, opa_url, path, input_data={}, timeout=timeout)
+        except OpaPolicyMissingError as exc:
+            missing.append(exc.package_path)
+        except Exception as exc:  # network, HTTP, parse — all treated as "not loaded"
+            missing.append(f"{path} (probe error: {exc})")
+
+    if missing:
+        joined = ", ".join(missing)
+        raise RuntimeError(
+            f"OPA startup check failed — required policies missing or unreachable: "
+            f"{joined}. Check that opa-policies/ is mounted at OPA and that "
+            f"the server at {opa_url} is healthy."
+        )
+
+    log.info("OPA startup check OK (%d required paths loaded)", len(required_paths))

--- a/shared/tests/test_opa_client.py
+++ b/shared/tests/test_opa_client.py
@@ -1,0 +1,175 @@
+"""Tests for shared.opa_client module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from shared.opa_client import (
+    OpaPolicyMissingError,
+    opa_query,
+    verify_required_policies,
+)
+
+
+def _response(body: dict | None, status: int = 200) -> MagicMock:
+    """Build a mock httpx.Response with the given JSON body."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = body if body is not None else {}
+    resp.raise_for_status = MagicMock()
+    if status >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"{status}", request=MagicMock(), response=resp,
+        )
+    return resp
+
+
+def _client(response: MagicMock) -> AsyncMock:
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.post.return_value = response
+    return client
+
+
+# ---------------------------------------------------------------------------
+# opa_query
+# ---------------------------------------------------------------------------
+
+class TestOpaQueryReturnsResult:
+
+    @pytest.mark.asyncio
+    async def test_unwraps_result_field(self):
+        client = _client(_response({"result": {"allowed": True, "min_score": 0.7}}))
+
+        got = await opa_query(client, "http://opa:8181", "pb/ingestion/quality_gate",
+                              input_data={"source_type": "code"})
+
+        assert got == {"allowed": True, "min_score": 0.7}
+        # URL is built via path form with slashes
+        client.post.assert_called_once()
+        assert client.post.call_args.args[0] == "http://opa:8181/v1/data/pb/ingestion/quality_gate"
+
+    @pytest.mark.asyncio
+    async def test_accepts_dot_notation(self):
+        client = _client(_response({"result": True}))
+
+        got = await opa_query(client, "http://opa:8181", "pb.access.allow",
+                              input_data={"agent_role": "analyst"})
+
+        assert got is True
+        assert client.post.call_args.args[0] == "http://opa:8181/v1/data/pb/access/allow"
+
+    @pytest.mark.asyncio
+    async def test_accepts_leading_slash(self):
+        client = _client(_response({"result": 1}))
+        await opa_query(client, "http://opa:8181", "/pb/access/allow")
+        assert client.post.call_args.args[0].endswith("/v1/data/pb/access/allow")
+
+    @pytest.mark.asyncio
+    async def test_empty_input_defaults_to_empty_dict(self):
+        client = _client(_response({"result": 1}))
+        await opa_query(client, "http://opa:8181", "pb/access/allow")
+        assert client.post.call_args.kwargs["json"] == {"input": {}}
+
+    @pytest.mark.asyncio
+    async def test_passes_through_false_result(self):
+        """A `result: false` is a valid deny decision — must NOT raise."""
+        client = _client(_response({"result": False}))
+        got = await opa_query(client, "http://opa:8181", "pb/access/allow")
+        assert got is False
+
+    @pytest.mark.asyncio
+    async def test_passes_through_empty_dict_result(self):
+        """`result: {}` is valid (rule returned empty dict) — must NOT raise."""
+        client = _client(_response({"result": {}}))
+        got = await opa_query(client, "http://opa:8181", "pb/ingestion/quality_gate")
+        assert got == {}
+
+
+class TestOpaQueryRaisesOnMissingResult:
+
+    @pytest.mark.asyncio
+    async def test_missing_result_field_raises(self):
+        """OPA returns only decision_id when no rule matches — must raise."""
+        client = _client(_response({"decision_id": "abc-123"}))
+
+        with pytest.raises(OpaPolicyMissingError) as exc_info:
+            await opa_query(client, "http://opa:8181", "pb/ingestion/quality_gate")
+
+        assert exc_info.value.package_path == "pb/ingestion/quality_gate"
+        assert "not loaded" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_empty_body_raises(self):
+        client = _client(_response({}))
+        with pytest.raises(OpaPolicyMissingError):
+            await opa_query(client, "http://opa:8181", "pb/access/allow")
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self):
+        client = _client(_response({"error": "bad"}, status=500))
+        with pytest.raises(httpx.HTTPStatusError):
+            await opa_query(client, "http://opa:8181", "pb/access/allow")
+
+
+# ---------------------------------------------------------------------------
+# verify_required_policies
+# ---------------------------------------------------------------------------
+
+class TestVerifyRequiredPolicies:
+
+    @pytest.mark.asyncio
+    async def test_all_loaded_returns_normally(self):
+        client = _client(_response({"result": {}}))
+        # Should not raise
+        await verify_required_policies(
+            client, "http://opa:8181",
+            ["pb/access/allow", "pb/ingestion/quality_gate"],
+        )
+        assert client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_one_missing_raises_runtime_error(self):
+        responses = iter([
+            _response({"result": True}),          # pb/access/allow → loaded
+            _response({"decision_id": "x"}),      # pb/ingestion/quality_gate → missing
+        ])
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.post.side_effect = lambda *a, **k: next(responses)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await verify_required_policies(
+                client, "http://opa:8181",
+                ["pb/access/allow", "pb/ingestion/quality_gate"],
+            )
+
+        assert "pb/ingestion/quality_gate" in str(exc_info.value)
+        assert "pb/access/allow" not in str(exc_info.value) or "missing" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_network_error_surfaces_as_missing(self):
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.post.side_effect = httpx.ConnectError("refused")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await verify_required_policies(
+                client, "http://opa:8181", ["pb/access/allow"],
+            )
+
+        msg = str(exc_info.value)
+        assert "pb/access/allow" in msg
+        assert "probe error" in msg
+
+    @pytest.mark.asyncio
+    async def test_false_result_is_not_missing(self):
+        """A rule returning `false` for empty input means 'loaded, denies default'.
+
+        The startup check must NOT treat that as missing — otherwise legitimate
+        deny-by-default rules would prevent boot.
+        """
+        client = _client(_response({"result": False}))
+        await verify_required_policies(
+            client, "http://opa:8181", ["pb/access/allow"],
+        )


### PR DESCRIPTION
Addresses [#59](https://github.com/nuetzliches/powerbrain/issues/59) part 2 — OPA policy-not-loaded produced a silent deny with the misleading log line \`quality_score 0.629 < required 0.000\`.

## Summary

- Adds \`shared/opa_client.py\`:
  - \`opa_query()\` raises a new \`OpaPolicyMissingError\` when OPA's response has no \`result\` field, so callers distinguish *policy missing* from *policy says deny*.
  - \`verify_required_policies()\` is called once on service startup to refuse to boot if any required data path is unreachable.
- Refactors every OPA helper across ingestion, mcp-server, pb-proxy, and evaluation to use the shared helper.
- Quality gate now returns \`min_score=-1.0\` as a sentinel when the policy is missing — the comparison \`score < -1.0\` is never true, so the value itself makes the misconfiguration obvious in logs and the \`ingestion_rejections\` table instead of the nonsense \`min=0.000\`.
- \`SKIP_OPA_STARTUP_CHECK=true\` env var opts out for unit tests.

## Test plan

- [x] 13 new unit tests for \`shared.opa_client\` (\`shared/tests/test_opa_client.py\`)
- [x] 8 new regression tests for the missing-policy path (\`ingestion/tests/test_opa_missing_policy.py\`)
- [x] Full suite: 888 passed locally (ingestion / mcp-server / pb-proxy / shared)
- [ ] CI (pr-validate.yml): unit-tests, opa-tests, docker-build, security-scan
- [ ] Manual: boot a service with \`OPA_URL\` pointing at an OPA instance missing \`pb.ingestion\` — service must refuse to start with an error naming the missing package

🤖 Generated with [Claude Code](https://claude.com/claude-code)