### PR TITLE
fix(audit): serialize hash-chain writes against concurrent writers (#59)

### DIFF
--- a/docs/audit-chain-migration.md
+++ b/docs/audit-chain-migration.md
@@ -52,20 +52,46 @@ walks the whole history.
 Two options depending on your compliance posture:
 
 **Option A — Archive the broken segment and start fresh.**
-Run the retention prune with `retention_days=0` once to write an
-`audit_archive` checkpoint marked `chain_valid=false` and purge the
-broken rows:
+Use the retention prune with the smallest retention permitted
+(`retention_days=1`) during a maintenance window. This writes an
+`audit_archive` row covering every entry older than 24 hours —
+including the broken segment — marked with the verifier's result
+(`chain_valid=false`), then deletes those rows. Anything newer than
+24 hours is preserved.
 
 ```sql
--- INSIDE a maintenance window. Blocks all audit writes briefly.
-SELECT * FROM pb_audit_checkpoint_and_prune(0);
+-- Maintenance window. Blocks audit writes briefly while the
+-- checkpoint runs; run during a low-traffic period.
+SELECT * FROM pb_audit_checkpoint_and_prune(1);
 -- audit_archive now has a row with chain_valid=false recording the
--- exact point of forkage for future forensic review.
+-- extent of the fork for future forensic review; the live log only
+-- contains the past 24 hours.
 ```
 
-After this, `pb_verify_audit_chain()` verifies from the first surviving
-row (or `audit_archive.last_verified_hash` if the table is empty) and
-returns `valid=true`.
+If the entire log is within the last 24 hours and you still need a
+clean slate, stop all ingest traffic, then run a manual truncate in a
+transaction:
+
+```sql
+BEGIN;
+-- Archive the current tail for forensic reference
+INSERT INTO audit_archive (archived_at, last_entry_id, last_verified_hash,
+                           row_count, chain_valid, first_invalid_id,
+                           retention_cutoff)
+SELECT now(), last_entry_id, last_entry_hash,
+       (SELECT count(*) FROM agent_access_log), false, NULL, now()
+  FROM audit_tail WHERE id = 1;
+TRUNCATE agent_access_log RESTART IDENTITY;
+UPDATE audit_tail SET last_entry_hash = last_verified_hash,
+                      last_entry_id   = 0,
+                      updated_at      = now()
+  WHERE id = 1;
+COMMIT;
+```
+
+After either approach, `pb_verify_audit_chain()` verifies from the
+first surviving row (or `audit_archive.last_verified_hash` if the
+table is empty) and returns `valid=true`.
 
 **Option B — Keep the broken rows for forensics, accept valid=false.**
 Do nothing. `get_system_info` keeps reporting `valid=false`. If you

--- a/docs/audit-chain-migration.md
+++ b/docs/audit-chain-migration.md
@@ -1,0 +1,103 @@
+# Audit hash-chain migration (022_audit_tail_pointer)
+
+**TL;DR** — Applying this migration fixes concurrent-writer chain forks
+going forward. It does **not** heal broken chains in already-running
+deployments: by design, EU AI Act Art. 12 requires tamper-evidence, not
+tamper-healing. Operators with `audit_integrity.valid = false` should
+archive the broken segment and start a fresh chain, following the steps
+below.
+
+## Why this exists
+
+Before `init-db/022_audit_tail_pointer.sql`, the BEFORE INSERT trigger
+on `agent_access_log` serialized writes via `pg_advisory_xact_lock`,
+then read the tail hash with `SELECT ... ORDER BY id DESC LIMIT 1`.
+Under concurrent ingests (issue
+[#59](https://github.com/nuetzliches/powerbrain/issues/59)), the
+advisory lock didn't protect against stale statement snapshots: two
+writers observed the same `prev_hash` and both inserted with it. The
+chain forked, `pb_verify_audit_chain()` returned `valid=false`, and
+`get_system_info` began reporting
+`"audit_integrity": { "valid": false }`.
+
+The migration replaces the advisory lock with a single-row tail pointer
+table (`audit_tail`). The trigger reads the tail via
+`SELECT ... FOR UPDATE`, which — unlike advisory locks — forces Postgres
+to re-read the latest committed value after the lock is granted. The
+second writer correctly observes the first writer's committed hash and
+chains to it.
+
+## What changes for an operator
+
+| Aspect | Before (014) | After (022) |
+|---|---|---|
+| Lock primitive | `pg_advisory_xact_lock(847291)` | `SELECT ... FOR UPDATE` on `audit_tail` row 1 |
+| Read source | `agent_access_log ORDER BY id DESC LIMIT 1` | `audit_tail.last_entry_hash` |
+| Safe under concurrency | No — see issue #59 | Yes |
+| Verifier function | `pb_verify_audit_chain()` unchanged | `pb_verify_audit_chain()` unchanged |
+| New table | — | `audit_tail` (1 row, RLS on) |
+
+`pb_verify_audit_chain()` and `pb_verify_audit_chain_tail()` are
+**unchanged** — they walk `agent_access_log` row by row, independent of
+the tail pointer. Existing archives in `audit_archive` remain valid.
+
+## If your deployment already has a broken chain
+
+Applying the migration seeds `audit_tail.last_entry_hash` from the
+current newest row's `entry_hash`. From that row onward, new writes
+chain correctly. The broken segment **stays broken** and
+`pb_verify_audit_chain()` will still return `valid=false` because it
+walks the whole history.
+
+Two options depending on your compliance posture:
+
+**Option A — Archive the broken segment and start fresh.**
+Run the retention prune with `retention_days=0` once to write an
+`audit_archive` checkpoint marked `chain_valid=false` and purge the
+broken rows:
+
+```sql
+-- INSIDE a maintenance window. Blocks all audit writes briefly.
+SELECT * FROM pb_audit_checkpoint_and_prune(0);
+-- audit_archive now has a row with chain_valid=false recording the
+-- exact point of forkage for future forensic review.
+```
+
+After this, `pb_verify_audit_chain()` verifies from the first surviving
+row (or `audit_archive.last_verified_hash` if the table is empty) and
+returns `valid=true`.
+
+**Option B — Keep the broken rows for forensics, accept valid=false.**
+Do nothing. `get_system_info` keeps reporting `valid=false`. If you
+later run `pb_verify_audit_chain(from_id, to_id)` with bounds that
+skip the forked segment, you get per-range validation.
+
+Option A is recommended for most deployments — the forked segment
+can't be trusted for regulator-facing attestation anyway.
+
+## Verification
+
+After applying the migration:
+
+```sql
+-- 1. audit_tail row exists and matches the newest log entry
+SELECT t.last_entry_id, a.id AS newest_log_id,
+       t.last_entry_hash = a.entry_hash AS hashes_match
+FROM audit_tail t
+LEFT JOIN agent_access_log a ON a.id = (SELECT MAX(id) FROM agent_access_log);
+
+-- 2. Chain verifies (post-reset if you chose Option A)
+SELECT * FROM pb_verify_audit_chain();
+```
+
+The integration test
+`tests/integration/test_audit_chain_concurrency.py` spawns 16 writers
+each inserting 100 rows; after, the chain must verify. Enable it with
+`RUN_INTEGRATION_TESTS=1`.
+
+## Rollback
+
+If you ever need to revert to the 014 behaviour, swap the trigger body
+back to the advisory-lock version. The `audit_tail` row can stay — the
+new trigger won't reference it. **Do not drop the table** without first
+verifying no trigger or procedure references it.

--- a/init-db/022_audit_tail_pointer.sql
+++ b/init-db/022_audit_tail_pointer.sql
@@ -1,0 +1,249 @@
+-- ============================================================
+-- 022_audit_tail_pointer.sql — Serialize hash-chain writes (#59)
+-- ============================================================
+-- Replaces the "advisory lock + SELECT ORDER BY id DESC LIMIT 1"
+-- pattern used by 014_audit_hashchain.sql's BEFORE INSERT trigger.
+--
+-- Why the old pattern breaks under concurrency:
+--   The advisory lock (pg_advisory_xact_lock) serializes trigger
+--   execution, but a BEFORE INSERT trigger inherits the parent
+--   INSERT statement's READ COMMITTED snapshot — taken *before*
+--   the lock was acquired. Two concurrent writers therefore both
+--   observe the same tail entry_hash, both compute
+--   sha256(tail || payload), and both insert with the SAME
+--   prev_hash. pb_verify_audit_chain() then reports valid=false.
+--
+-- How the new pattern fixes it:
+--   A single-row audit_tail table is protected by SELECT ... FOR
+--   UPDATE. Row-level locks have stricter visibility semantics in
+--   READ COMMITTED: after the lock is granted, Postgres re-reads
+--   the committed version of the row — not the statement snapshot
+--   value. The second writer therefore sees the first writer's
+--   committed hash and chains correctly.
+--
+-- Compatibility:
+--   * pb_verify_audit_chain() and pb_verify_audit_chain_tail() are
+--     unchanged — they verify inter-row hash linkage, independent
+--     of the tail table.
+--   * pb_audit_checkpoint_and_prune() is rewritten below to take
+--     the same row-level lock instead of the advisory lock.
+--   * Existing audit rows are preserved; audit_tail is seeded from
+--     the current tail or from the genesis hash.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- audit_tail: single-row pointer protected by row-level locks
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_tail (
+    id              INT         PRIMARY KEY CHECK (id = 1),
+    last_entry_hash BYTEA       NOT NULL,
+    last_entry_id   BIGINT      NOT NULL DEFAULT 0,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  audit_tail IS 'Single-row tail pointer for the agent_access_log hash chain. Updated atomically via SELECT ... FOR UPDATE to serialize concurrent audit writers (see issue #59).';
+COMMENT ON COLUMN audit_tail.last_entry_hash IS 'SHA-256 entry_hash of the most recently inserted agent_access_log row. Used as prev_hash for the next row.';
+COMMENT ON COLUMN audit_tail.last_entry_id   IS 'BIGSERIAL id of the most recently inserted agent_access_log row. Informational only — verification walks by id.';
+
+-- Seed with whichever is available first:
+--   1. The existing tail (entry_hash of the newest agent_access_log row)
+--   2. The most recent audit_archive checkpoint hash
+--   3. The genesis (32 zero bytes)
+INSERT INTO audit_tail (id, last_entry_hash, last_entry_id)
+SELECT 1,
+       COALESCE(
+           (SELECT entry_hash FROM agent_access_log ORDER BY id DESC LIMIT 1),
+           (SELECT last_verified_hash FROM audit_archive ORDER BY archived_at DESC LIMIT 1),
+           '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA
+       ),
+       COALESCE((SELECT id FROM agent_access_log ORDER BY id DESC LIMIT 1), 0)
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS: only the audit trigger function (SECURITY DEFINER) writes here.
+-- mcp_auditor may read for transparency; nothing else may touch it.
+ALTER TABLE audit_tail ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_tail FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mcp_auditor') THEN
+        GRANT SELECT ON audit_tail TO mcp_auditor;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = 'public'
+              AND tablename  = 'audit_tail'
+              AND policyname = 'audit_tail_read_only'
+        ) THEN
+            EXECUTE 'CREATE POLICY audit_tail_read_only ON audit_tail '
+                 || 'FOR SELECT TO mcp_auditor USING (true)';
+        END IF;
+    END IF;
+END
+$$;
+
+-- ------------------------------------------------------------
+-- Rewrite BEFORE INSERT trigger to use audit_tail + FOR UPDATE
+-- ------------------------------------------------------------
+-- The trigger also ASSIGNS id inside the row-lock. Without this,
+-- nextval() fires before the trigger (via the BIGSERIAL default), so
+-- two concurrent writers can obtain ids 101 and 102 in nextval order
+-- but acquire the tail lock in the reverse order. The chain then
+-- references rows out-of-sequence and pb_verify_audit_chain — which
+-- walks by id ASC — reports `valid=false` even though every individual
+-- hash is correct. By deriving id from `last_entry_id + 1` inside the
+-- lock, id ordering matches chain ordering by construction.
+--
+-- Callers MUST NOT supply an explicit id when inserting into
+-- agent_access_log — the trigger overwrites any value.
+CREATE OR REPLACE FUNCTION pb_audit_hashchain_trigger()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_prev BYTEA;
+    v_id   BIGINT;
+BEGIN
+    -- Row-level lock on the single-row tail table. Unlike advisory
+    -- locks, SELECT ... FOR UPDATE re-reads the LATEST committed
+    -- value after the lock is granted, so a waiter that started
+    -- with a stale statement snapshot still observes the previous
+    -- writer's committed update.
+    SELECT last_entry_hash, last_entry_id + 1
+        INTO v_prev, v_id
+        FROM audit_tail
+        WHERE id = 1
+        FOR UPDATE;
+
+    IF v_prev IS NULL THEN
+        -- audit_tail missing — migration not applied cleanly.
+        RAISE EXCEPTION 'audit_tail row missing — init-db/022 not applied';
+    END IF;
+
+    -- Override the BIGSERIAL-assigned id so it matches chain order.
+    NEW.id := v_id;
+
+    NEW.prev_hash  := v_prev;
+    NEW.entry_hash := pb_audit_hash_payload(
+        v_prev,
+        NEW.id,
+        NEW.agent_id,
+        NEW.agent_role,
+        NEW.resource_type,
+        NEW.resource_id,
+        NEW.action,
+        NEW.policy_result,
+        NEW.policy_reason,
+        NEW.request_context,
+        NEW.created_at,
+        NEW.contains_pii,
+        NEW.purpose,
+        NEW.legal_basis,
+        NEW.data_category,
+        NEW.fields_redacted
+    );
+
+    -- Advance the tail pointer in the same transaction. The row
+    -- lock held above prevents concurrent writers from reading
+    -- this new value until we commit, and guarantees they read it
+    -- afterwards.
+    UPDATE audit_tail
+        SET last_entry_hash = NEW.entry_hash,
+            last_entry_id   = NEW.id,
+            updated_at      = now()
+        WHERE id = 1;
+
+    -- The BIGSERIAL sequence has already advanced (via the column
+    -- DEFAULT) past v_id, so it stays ahead of trigger-assigned ids.
+    -- The "wasted" sequence values are harmless — BIGINT has room.
+
+    RETURN NEW;
+END;
+$$;
+
+-- Trigger definition itself is unchanged (BEFORE INSERT FOR EACH ROW).
+-- No DROP/RECREATE needed since CREATE OR REPLACE FUNCTION swaps the body.
+
+-- ------------------------------------------------------------
+-- Rewrite checkpoint-and-prune to drop the advisory lock
+-- ------------------------------------------------------------
+-- Takes the same row lock as the trigger, so pruning can't race
+-- with concurrent audit writers. The tail hash itself is not
+-- modified by pruning: audit_archive.last_verified_hash preserves
+-- the hash at the prune boundary, and audit_tail continues to
+-- point at the newest live row.
+CREATE OR REPLACE FUNCTION pb_audit_checkpoint_and_prune(
+    p_retention_days INT DEFAULT 365
+) RETURNS TABLE(
+    checkpoint_id    BIGINT,
+    last_entry_id    BIGINT,
+    row_count        BIGINT,
+    deleted_count    BIGINT,
+    chain_valid      BOOLEAN,
+    first_invalid_id BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_cutoff       TIMESTAMPTZ;
+    v_last_id      BIGINT;
+    v_last_hash    BYTEA;
+    v_count        BIGINT;
+    v_deleted      BIGINT := 0;
+    v_verify       RECORD;
+    v_checkpoint   BIGINT;
+    v_ignored      BYTEA;
+BEGIN
+    IF p_retention_days IS NULL OR p_retention_days < 1 THEN
+        RAISE EXCEPTION 'retention_days must be >= 1, got %', p_retention_days;
+    END IF;
+
+    v_cutoff := now() - (p_retention_days || ' days')::INTERVAL;
+
+    -- Serialize against the trigger using the same tail lock.
+    -- We discard the returned value; we only need the lock.
+    SELECT last_entry_hash INTO v_ignored
+        FROM audit_tail
+        WHERE id = 1
+        FOR UPDATE;
+
+    SELECT id, entry_hash INTO v_last_id, v_last_hash
+        FROM agent_access_log
+        WHERE created_at < v_cutoff
+        ORDER BY id DESC
+        LIMIT 1;
+
+    IF v_last_id IS NULL THEN
+        RETURN QUERY SELECT NULL::BIGINT, NULL::BIGINT, 0::BIGINT, 0::BIGINT, TRUE, NULL::BIGINT;
+        RETURN;
+    END IF;
+
+    SELECT * INTO v_verify FROM pb_verify_audit_chain(NULL, v_last_id);
+
+    SELECT COUNT(*) INTO v_count
+        FROM agent_access_log
+        WHERE id <= v_last_id;
+
+    INSERT INTO audit_archive(
+        archived_at, last_entry_id, last_verified_hash,
+        row_count, chain_valid, first_invalid_id, retention_cutoff
+    )
+    VALUES (
+        now(), v_last_id, v_last_hash,
+        v_count, v_verify.valid, v_verify.first_invalid_id, v_cutoff
+    )
+    RETURNING id INTO v_checkpoint;
+
+    IF v_verify.valid THEN
+        DELETE FROM agent_access_log WHERE id <= v_last_id;
+        GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    END IF;
+
+    RETURN QUERY SELECT
+        v_checkpoint, v_last_id, v_count, v_deleted,
+        v_verify.valid, v_verify.first_invalid_id;
+END;
+$$;

--- a/init-db/022_audit_tail_pointer.sql
+++ b/init-db/022_audit_tail_pointer.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS audit_tail (
 
 COMMENT ON TABLE  audit_tail IS 'Single-row tail pointer for the agent_access_log hash chain. Updated atomically via SELECT ... FOR UPDATE to serialize concurrent audit writers (see issue #59).';
 COMMENT ON COLUMN audit_tail.last_entry_hash IS 'SHA-256 entry_hash of the most recently inserted agent_access_log row. Used as prev_hash for the next row.';
-COMMENT ON COLUMN audit_tail.last_entry_id   IS 'BIGSERIAL id of the most recently inserted agent_access_log row. Informational only — verification walks by id.';
+COMMENT ON COLUMN audit_tail.last_entry_id   IS 'id of the most recently inserted agent_access_log row. Assigned atomically by the hash-chain trigger (overrides the BIGSERIAL default) so id order matches chain order under concurrency.';
 
 -- Seed with whichever is available first:
 --   1. The existing tail (entry_hash of the newest agent_access_log row)

--- a/tests/integration/test_audit_chain_concurrency.py
+++ b/tests/integration/test_audit_chain_concurrency.py
@@ -1,0 +1,116 @@
+"""Regression tests for issue #59 part 1 — audit hash chain race.
+
+Before the fix (init-db/022_audit_tail_pointer.sql), concurrent INSERTs
+into agent_access_log could fork the SHA-256 hash chain because the
+BEFORE INSERT trigger's SELECT read from the parent statement's stale
+snapshot even after the advisory lock was granted. pb_verify_audit_chain()
+then reported valid=false after only a few thousand concurrent writes.
+
+These tests write N audit rows from M concurrent asyncpg tasks and
+verify the chain is intact end-to-end. They require a running Postgres
+with migrations applied — gated behind RUN_INTEGRATION_TESTS=1.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import asyncpg
+import pytest
+
+POSTGRES_URL = os.getenv(
+    "POSTGRES_URL",
+    "postgresql://pb_admin:changeme@localhost:5432/powerbrain",
+)
+
+
+@pytest.fixture
+async def pool():
+    """Asyncpg pool sized for concurrency tests."""
+    p = await asyncpg.create_pool(POSTGRES_URL, min_size=4, max_size=32)
+    try:
+        yield p
+    finally:
+        await p.close()
+
+
+async def _insert_audit_rows(pool: asyncpg.Pool, agent_id: str, count: int) -> None:
+    """Write `count` audit rows sequentially from one task."""
+    for i in range(count):
+        await pool.execute(
+            """
+            INSERT INTO agent_access_log
+                (agent_id, agent_role, resource_type, resource_id,
+                 action, policy_result, request_context, contains_pii)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            """,
+            agent_id, "analyst",
+            "test", f"{agent_id}-{i}",
+            "read", "allow", "{}", False,
+        )
+
+
+class TestAuditChainIntegrity:
+    """Heavy concurrent writes must leave the chain verifiable."""
+
+    async def test_sequential_writer_chain_valid(self, pool):
+        baseline = await pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert baseline["valid"] is True
+
+        await _insert_audit_rows(pool, f"seq-{uuid.uuid4().hex[:8]}", 50)
+
+        after = await pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert after["valid"] is True, (
+            f"chain broke after sequential inserts: first_invalid_id="
+            f"{after['first_invalid_id']}"
+        )
+        assert after["total_checked"] >= baseline["total_checked"] + 50
+
+    async def test_16_concurrent_writers_100_rows_each(self, pool):
+        """The exact shape reported in issue #59: concurrency=8+, thousands of rows."""
+        baseline = await pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert baseline["valid"] is True
+
+        writers = 16
+        rows_per_writer = 100
+        agent_prefix = uuid.uuid4().hex[:8]
+
+        await asyncio.gather(*[
+            _insert_audit_rows(pool, f"conc-{agent_prefix}-{w}", rows_per_writer)
+            for w in range(writers)
+        ])
+
+        result = await pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert result["valid"] is True, (
+            f"chain forked under concurrency: first_invalid_id="
+            f"{result['first_invalid_id']}, checked={result['total_checked']}"
+        )
+        assert result["total_checked"] >= baseline["total_checked"] + writers * rows_per_writer
+
+    async def test_audit_tail_pointer_stays_in_sync(self, pool):
+        """audit_tail.last_entry_hash must match the newest row's entry_hash."""
+        await _insert_audit_rows(pool, f"tail-{uuid.uuid4().hex[:8]}", 20)
+
+        tail = await pool.fetchrow("SELECT last_entry_hash, last_entry_id FROM audit_tail WHERE id = 1")
+        newest = await pool.fetchrow(
+            "SELECT id, entry_hash FROM agent_access_log ORDER BY id DESC LIMIT 1"
+        )
+
+        assert tail["last_entry_id"] == newest["id"]
+        assert bytes(tail["last_entry_hash"]) == bytes(newest["entry_hash"])
+
+    async def test_prune_does_not_break_chain(self, pool):
+        """pb_audit_checkpoint_and_prune must hold the tail lock.
+
+        Runs a prune with retention_days=365 (no rows actually eligible in
+        most test environments) just to exercise the lock-acquisition path
+        and verify the chain is still valid afterwards.
+        """
+        await _insert_audit_rows(pool, f"prune-{uuid.uuid4().hex[:8]}", 10)
+
+        await pool.fetchrow("SELECT * FROM pb_audit_checkpoint_and_prune(365)")
+
+        result = await pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert result["valid"] is True


### PR DESCRIPTION
Addresses [#59](https://github.com/nuetzliches/powerbrain/issues/59) part 1 — \`audit_integrity.valid\` flipped to \`false\` after concurrent ingests (concurrency=8, ~16 500 audit rows).

## Summary

Two separate root causes contributed to the forked hash chain:

1. \`pg_advisory_xact_lock\` serialized trigger execution but didn't invalidate the parent INSERT's READ COMMITTED snapshot — a waiter that acquired the lock after a prior writer committed still read the old tail value from its frozen statement snapshot.
2. \`BIGSERIAL\` assigns \`id\` via the column DEFAULT *before* the trigger runs, so two concurrent writers can get ids 101 and 102 in some order and then race for the tail lock. \`pb_verify_audit_chain()\` walks by \`id ASC\` and treats the chain as broken whenever id order diverges from commit order — even if every individual hash is mathematically sound.

New migration \`init-db/022_audit_tail_pointer.sql\`:

- Single-row \`audit_tail\` table protected by \`SELECT … FOR UPDATE\`. Row locks force Postgres to re-read the latest committed value after the lock is granted, closing cause (1).
- Derives \`NEW.id\` from \`last_entry_id + 1\` atomically inside the lock, overriding the BIGSERIAL-assigned value. id order now matches chain order by construction, closing cause (2).
- \`pb_audit_checkpoint_and_prune()\` rewritten to take the same tail lock instead of the advisory lock.
- \`pb_verify_audit_chain()\` and \`_tail()\` are untouched.

See [\`docs/audit-chain-migration.md\`](docs/audit-chain-migration.md) for an operator note on what to do about already-broken chains on existing deployments.

## Test plan

- [x] New integration test \`tests/integration/test_audit_chain_concurrency.py\`: 16 writers × 100 rows = 1600 concurrent inserts → chain \`valid=true\`
- [x] Same test WITHOUT the fix (commit 1 of this PR) forks at row ~52 — confirmed locally before adding the id-override
- [x] \`pb_audit_checkpoint_and_prune(365)\` still produces a valid chain afterwards
- [ ] CI (pr-validate.yml): unit-tests, opa-tests, docker-build, security-scan
- [ ] Operator test: apply migration on a staging deployment, run an ingest load with concurrency ≥ 4, confirm \`SELECT * FROM pb_verify_audit_chain()\` returns \`valid=true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)