### PR TITLE
feat(mcp-server): decouple summarization LLM pool from agent loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,26 @@ LAYER_GENERATION_ENABLED=true
 # LLM_MODEL=qwen2.5:3b
 # LLM_API_KEY=
 
+# ── Summarization Pool (optional, decoupled) ──────────────
+# By default, MCP summarisation reuses LLM_* above. Override these to
+# route the in-pipeline summary call to its own endpoint / model so it
+# never contends with the pb-proxy agent loop on a shared Ollama slot.
+# Common topologies:
+#   1) Sidecar split — second local Ollama with a smaller model:
+#      docker compose --profile local-llm --profile summary-llm up -d
+#      docker exec pb-ollama-summary ollama pull qwen2.5:1.5b
+#      SUMMARIZATION_PROVIDER_URL=http://ollama-summary:11434
+#      SUMMARIZATION_MODEL=qwen2.5:1.5b
+#   2) Hosted summary — keep agent loop local, summarise via OpenAI:
+#      SUMMARIZATION_PROVIDER_URL=https://api.openai.com
+#      SUMMARIZATION_MODEL=gpt-4o-mini
+#      SUMMARIZATION_API_KEY=sk-...
+# See docs/plans/2026-04-20-separate-summary-llm-pool.md.
+# SUMMARIZATION_PROVIDER_URL=
+# SUMMARIZATION_MODEL=
+# SUMMARIZATION_API_KEY=
+# SUMMARIZATION_TIMEOUT=15
+
 # ── GPU Stack (optional, docker compose --profile gpu) ────
 # VLLM_MODEL=llava-hf/llava-1.5-7b-hf
 # TEI_MODEL=nomic-ai/nomic-embed-text-v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Decoupled summarization LLM pool** ([plan](docs/plans/2026-04-20-separate-summary-llm-pool.md)).
+  MCP server now accepts `SUMMARIZATION_PROVIDER_URL` /
+  `SUMMARIZATION_MODEL` / `SUMMARIZATION_API_KEY` so the in-pipeline
+  summary call can run against its own endpoint instead of competing
+  with the pb-proxy agent loop on a shared Ollama slot. Defaults to
+  the existing `LLM_*` values — single-endpoint deployments need no
+  change. Optional sidecar `pb-ollama-summary` ships under
+  `docker compose --profile summary-llm`, exposing port 11435 on the
+  host and an internal `http://ollama-summary:11434` endpoint suitable
+  for a smaller distilled model (e.g. `qwen2.5:1.5b`).
+  `GET /transparency` reports whether the pool is split via
+  `models.llm.pool_split`. Closes the follow-up tracked in 0.7.0
+  release notes.
 - **Grafana dashboard panels for document extraction**
   ([B-53](docs/BACKLOG.md)). Four new panels appended to the
   *Powerbrain Overview* dashboard under a *Document Extraction* row:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ volumes:
   qdrant_data:
   pg_data:
   ollama_data:
+  ollama_summary_data:
   prometheus_data:
   grafana_data:
   tempo_data:
@@ -195,6 +196,32 @@ services:
     #           count: 1
     #           capabilities: [gpu]
 
+  # ── Ollama sidecar for summarization (optional) ───────────
+  # Dedicated Ollama instance so MCP summarisation never contends
+  # with the pb-proxy agent loop. Enable with:
+  #   docker compose --profile local-llm --profile summary-llm up -d
+  # Then point the MCP server at it:
+  #   SUMMARIZATION_PROVIDER_URL=http://ollama-summary:11434
+  #   SUMMARIZATION_MODEL=qwen2.5:1.5b
+  # See docs/plans/2026-04-20-separate-summary-llm-pool.md.
+  ollama-summary:
+    profiles: ["summary-llm"]
+    image: ollama/ollama:latest
+    container_name: pb-ollama-summary
+    ports:
+      - "11435:11434"
+    volumes:
+      - ollama_summary_data:/root/.ollama
+    networks:
+      - pb-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   # ── Reranker (Built-in Cross-Encoder) ──────────────────────
   # Only needed when RERANKER_BACKEND=powerbrain (default).
   # Start explicitly: docker compose --profile local-reranker up
@@ -251,6 +278,12 @@ services:
       LLM_PROVIDER_URL: ${LLM_PROVIDER_URL:-http://ollama:11434}
       LLM_MODEL:       ${LLM_MODEL:-qwen2.5:3b}
       LLM_API_KEY:     ${LLM_API_KEY:-}
+      # Optional: route summarization to a dedicated endpoint so it
+      # never contends with the pb-proxy agent loop on the same model.
+      # Defaults to LLM_* (single-pool) when unset.
+      SUMMARIZATION_PROVIDER_URL: ${SUMMARIZATION_PROVIDER_URL:-${LLM_PROVIDER_URL:-http://ollama:11434}}
+      SUMMARIZATION_MODEL:        ${SUMMARIZATION_MODEL:-${LLM_MODEL:-qwen2.5:3b}}
+      SUMMARIZATION_API_KEY:      ${SUMMARIZATION_API_KEY:-${LLM_API_KEY:-}}
       FORGEJO_URL:     ${FORGEJO_URL:-http://forgejo.local:3000}
       FORGEJO_TOKEN_FILE: /run/secrets/forgejo_token
       VAULT_HMAC_SECRET_FILE: /run/secrets/vault_hmac_secret

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,17 @@ Any OpenAI-compatible endpoint for embeddings and summarization. Configured via 
 
 Default model: `nomic-embed-text` (768d). For higher accuracy: `mxbai-embed-large` (1024d) — requires adjustment of the Qdrant collection dimension.
 
+**Decoupled summarization pool.** The MCP server consumes an LLM only
+for in-pipeline summarisation; the pb-proxy agent loop runs on its own
+config. To keep the two paths off the same Ollama slot, mcp-server
+accepts `SUMMARIZATION_PROVIDER_URL` / `SUMMARIZATION_MODEL` /
+`SUMMARIZATION_API_KEY` (defaults: `LLM_*` for back-compat).
+An optional sidecar service ships under `--profile summary-llm`
+(`ollama-summary` container, port 11435 on the host) so a smaller
+distilled model — e.g. `qwen2.5:1.5b` — can serve summaries while the
+main `pb-ollama` keeps handling the agent loop. `GET /transparency`
+reports the split via `models.llm.pool_split`.
+
 ### 2.7 Git Server (external, optional)
 
 Any Git server for policy and schema repositories. Configured via `FORGEJO_URL` / `OPAL_POLICY_REPO_URL`. Supports Forgejo, GitHub, GitLab, Gitea, Bitbucket, etc. Repositories:

--- a/docs/plans/2026-04-20-separate-summary-llm-pool.md
+++ b/docs/plans/2026-04-20-separate-summary-llm-pool.md
@@ -1,6 +1,6 @@
 # Plan: Separate LLM Pool for Summarization
 
-**Status:** Backlog — pick up next session
+**Status:** Shipped 2026-04-25 — see CHANGELOG `[Unreleased]`.
 **Origin:** Live sales-demo debug session 2026-04-19/20 (Tab D, pb-proxy MCP vs Proxy)
 
 ## Problem

--- a/docs/playbook-sales-demo.md
+++ b/docs/playbook-sales-demo.md
@@ -185,11 +185,33 @@ LLM exception and the caller keeps the raw chunks — the policy story
 (confidential ⇒ summary preferred) is preserved, but the demo no
 longer deadlocks when summary can't complete in time.
 
-**Follow-up:** a proper separation of LLM pools (summary via a second,
-smaller endpoint like Haiku-mini or a sidecar Ollama with
-qwen2.5:1.5b) removes the contention entirely. Design + work
-breakdown in
-[docs/plans/2026-04-20-separate-summary-llm-pool.md](plans/2026-04-20-separate-summary-llm-pool.md).
+**Permanent fix (shipped):** the MCP server now accepts a separate
+`SUMMARIZATION_PROVIDER_URL` / `SUMMARIZATION_MODEL` /
+`SUMMARIZATION_API_KEY` triplet. These default to the existing `LLM_*`
+values, so single-endpoint deployments need no change. Pointing them at
+a second endpoint removes the contention entirely.
+
+| Topology | Agent loop (pb-proxy) | Summarisation (mcp-server) |
+|---|---|---|
+| Single CPU Ollama (default) | qwen2.5:3b | qwen2.5:3b (contends) |
+| **Sidecar split** | qwen2.5:3b | qwen2.5:1.5b on `ollama-summary` |
+| **Hosted agent** | claude-haiku-4-5 / gpt-4o-mini | qwen2.5:3b local |
+| **Fully hosted** | claude-haiku-4-5 | gpt-4o-mini |
+| **GPU box** | vLLM qwen 14b | TEI / small distilled model |
+
+The sidecar split lights up with two compose profiles:
+
+```bash
+docker compose --profile local-llm --profile summary-llm up -d
+docker exec pb-ollama-summary ollama pull qwen2.5:1.5b
+
+# .env:
+SUMMARIZATION_PROVIDER_URL=http://ollama-summary:11434
+SUMMARIZATION_MODEL=qwen2.5:1.5b
+```
+
+`GET /transparency` exposes whether the pool is split (`models.llm.pool_split`).
+Original design: [docs/plans/2026-04-20-separate-summary-llm-pool.md](plans/2026-04-20-separate-summary-llm-pool.md).
 
 ### Why only 5 MCP tools are injected (context-size constraint)
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -88,20 +88,33 @@ EMBEDDING_PROVIDER_URL = os.getenv("EMBEDDING_PROVIDER_URL", _OLLAMA_URL)
 EMBEDDING_MODEL        = os.getenv("EMBEDDING_MODEL", "nomic-embed-text")
 EMBEDDING_API_KEY      = os.getenv("EMBEDDING_API_KEY", "")
 
-# ── LLM / Summarization provider ──
+# ── LLM provider (legacy single-pool fallback) ──
+# Kept as the default for SUMMARIZATION_* below so single-endpoint
+# deployments keep working without env changes. The MCP server itself
+# only consumes an LLM for summarization — agent-loop calls live in
+# pb-proxy, on a separate provider config.
 LLM_PROVIDER_URL       = os.getenv("LLM_PROVIDER_URL", _OLLAMA_URL)
 LLM_MODEL              = os.getenv("LLM_MODEL", "qwen2.5:3b")
 LLM_API_KEY            = os.getenv("LLM_API_KEY", "")
-SUMMARIZATION_ENABLED  = os.getenv("SUMMARIZATION_ENABLED", "true").lower() == "true"
+
+# ── Summarization provider (decoupled pool) ──
+# Setting these lets the in-pipeline summary call route to its own
+# endpoint / model so it never contends with the pb-proxy agent loop
+# on a shared Ollama slot. See
+# docs/plans/2026-04-20-separate-summary-llm-pool.md.
+SUMMARIZATION_PROVIDER_URL = os.getenv("SUMMARIZATION_PROVIDER_URL", LLM_PROVIDER_URL)
+SUMMARIZATION_MODEL        = os.getenv("SUMMARIZATION_MODEL", LLM_MODEL)
+SUMMARIZATION_API_KEY      = os.getenv("SUMMARIZATION_API_KEY", LLM_API_KEY)
+SUMMARIZATION_ENABLED      = os.getenv("SUMMARIZATION_ENABLED", "true").lower() == "true"
 # Per-call timeout for summarization LLM requests. Kept well below the
 # proxy's TOOL_CALL_TIMEOUT so the graceful fallback to raw chunks
 # ([server.py] summarize_text → except → return None) lands before the
 # upstream caller abandons the connection. See
 # docs/playbook-sales-demo.md → "Tuning the local LLM".
-SUMMARIZATION_TIMEOUT  = float(os.getenv("SUMMARIZATION_TIMEOUT", "15"))
+SUMMARIZATION_TIMEOUT      = float(os.getenv("SUMMARIZATION_TIMEOUT", "15"))
 
-embedding_provider = EmbeddingProvider(base_url=EMBEDDING_PROVIDER_URL, api_key=EMBEDDING_API_KEY)
-llm_provider       = CompletionProvider(base_url=LLM_PROVIDER_URL, api_key=LLM_API_KEY)
+embedding_provider     = EmbeddingProvider(base_url=EMBEDDING_PROVIDER_URL, api_key=EMBEDDING_API_KEY)
+summarization_provider = CompletionProvider(base_url=SUMMARIZATION_PROVIDER_URL, api_key=SUMMARIZATION_API_KEY)
 _rerank_provider   = create_rerank_provider(
     backend=RERANKER_BACKEND, base_url=RERANKER_URL,
     api_key=RERANKER_API_KEY, model=RERANKER_MODEL_NAME,
@@ -495,11 +508,11 @@ async def summarize_text(
     user_prompt = f"Query: {query}\n\nText chunks to summarize:\n\n{combined}"
 
     with trace_operation(tracer, "summarization", "mcp-server",
-                         model=LLM_MODEL):
+                         model=SUMMARIZATION_MODEL):
         try:
-            return await llm_provider.generate(
+            return await summarization_provider.generate(
                 http,
-                model=LLM_MODEL,
+                model=SUMMARIZATION_MODEL,
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
                 timeout=SUMMARIZATION_TIMEOUT,
@@ -3446,14 +3459,23 @@ async def _build_transparency_payload() -> dict:
         _transparency_audit_snapshot(),
     )
 
+    summarization_split = (
+        SUMMARIZATION_PROVIDER_URL != LLM_PROVIDER_URL
+        or SUMMARIZATION_MODEL != LLM_MODEL
+    )
     models = {
         "embedding": {
             "name":        EMBEDDING_MODEL,
             "provider_url": EMBEDDING_PROVIDER_URL,
         },
         "llm": {
-            "name":        LLM_MODEL,
-            "provider_url": LLM_PROVIDER_URL,
+            # mcp-server consumes an LLM only for summarization. Field
+            # name kept as "llm" for back-compat with consumers like
+            # compliance_doc.py; the values reflect SUMMARIZATION_*.
+            "name":        SUMMARIZATION_MODEL,
+            "provider_url": SUMMARIZATION_PROVIDER_URL,
+            "purpose":     "summarization",
+            "pool_split":  summarization_split,
         },
         "reranker": {
             "backend":     RERANKER_BACKEND,

--- a/mcp-server/tests/test_summarize.py
+++ b/mcp-server/tests/test_summarize.py
@@ -16,7 +16,7 @@ def _patch_http(monkeypatch):
 
 class TestSummarizeText:
     async def test_returns_summary(self, _patch_http, monkeypatch):
-        monkeypatch.setattr(server, "LLM_MODEL", "qwen2.5:3b")
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "qwen2.5:3b")
 
         response = MagicMock()
         response.raise_for_status = MagicMock()
@@ -33,7 +33,7 @@ class TestSummarizeText:
         assert result == "This is a summary."
 
     async def test_sends_correct_payload(self, _patch_http, monkeypatch):
-        monkeypatch.setattr(server, "LLM_MODEL", "test-model")
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "test-model")
 
         response = MagicMock()
         response.raise_for_status = MagicMock()
@@ -58,7 +58,7 @@ class TestSummarizeText:
         assert "concise" in system_msg.lower() or "brief" in system_msg.lower()
 
     async def test_graceful_fallback_on_error(self, _patch_http, monkeypatch):
-        monkeypatch.setattr(server, "LLM_MODEL", "test-model")
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "test-model")
         _patch_http.post.side_effect = Exception("LLM provider down")
 
         result = await summarize_text(
@@ -69,7 +69,7 @@ class TestSummarizeText:
         assert result is None
 
     async def test_empty_chunks_returns_none(self, _patch_http, monkeypatch):
-        monkeypatch.setattr(server, "LLM_MODEL", "test-model")
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "test-model")
 
         result = await summarize_text(
             chunks=[],
@@ -77,6 +77,33 @@ class TestSummarizeText:
             detail="standard",
         )
         assert result is None
+
+    async def test_uses_dedicated_summarization_provider(
+        self, _patch_http, monkeypatch
+    ):
+        """summarize_text must dispatch via summarization_provider so a
+        split LLM-pool deployment routes to the configured endpoint."""
+        from shared.llm_provider import CompletionProvider
+
+        sentinel_url = "http://summary-sidecar:11434"
+        sidecar = CompletionProvider(base_url=sentinel_url, api_key="")
+        monkeypatch.setattr(server, "summarization_provider", sidecar)
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "qwen2.5:1.5b")
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "choices": [{"message": {"content": "Summary"}}],
+        }
+        _patch_http.post.return_value = response
+
+        await summarize_text(
+            chunks=["A", "B"], query="q", detail="brief",
+        )
+
+        call_args = _patch_http.post.call_args
+        assert call_args[0][0].startswith(sentinel_url)
+        assert call_args[1]["json"]["model"] == "qwen2.5:1.5b"
 
 
 class TestCheckOpaSummarizationPolicy:

--- a/mcp-server/tests/test_transparency.py
+++ b/mcp-server/tests/test_transparency.py
@@ -139,7 +139,11 @@ class TestBuildTransparencyPayload:
         assert "system_purpose" in payload
         assert isinstance(payload["deployment_constraints"], list)
         assert payload["models"]["embedding"]["name"] == server.EMBEDDING_MODEL
-        assert payload["models"]["llm"]["name"] == server.LLM_MODEL
+        # mcp-server's only LLM consumer is summarization; the field is
+        # kept under "llm" for back-compat (compliance_doc reads it).
+        assert payload["models"]["llm"]["name"] == server.SUMMARIZATION_MODEL
+        assert payload["models"]["llm"]["purpose"] == "summarization"
+        assert payload["models"]["llm"]["pool_split"] is False
         assert payload["opa"]["roles"] == ["viewer", "analyst", "developer", "admin"]
         assert payload["opa"]["audit_retention_days"] == 365
         assert len(payload["collections"]) == 3

--- a/mcp-server/tests/test_transparency.py
+++ b/mcp-server/tests/test_transparency.py
@@ -152,6 +152,38 @@ class TestBuildTransparencyPayload:
         assert payload["audit_integrity"]["total_checked"] == 10
         assert payload["risk_register"] == "docs/risk-management.md"
 
+    async def test_pool_split_reported_when_summary_endpoint_differs(
+        self, _patch_globals, monkeypatch
+    ):
+        """models.llm.pool_split flips to True when SUMMARIZATION_*
+        diverges from LLM_* (e.g. sidecar Ollama for summarisation)."""
+        mock_http, mock_pool, _ = _patch_globals
+
+        async def _get(url, **kwargs):
+            if "opa" in url or "8181" in url or "/v1/data/pb/config" in url:
+                return _opa_config_response()
+            if "ingestion" in url or "8081" in url:
+                return _ingestion_health_response()
+            raise AssertionError(f"unexpected URL: {url}")
+        mock_http.get.side_effect = _get
+        mock_pool.fetchrow.return_value = _chain_row()
+
+        monkeypatch.setattr(server, "LLM_PROVIDER_URL", "http://ollama:11434")
+        monkeypatch.setattr(server, "LLM_MODEL", "qwen2.5:3b")
+        monkeypatch.setattr(
+            server, "SUMMARIZATION_PROVIDER_URL", "http://ollama-summary:11434"
+        )
+        monkeypatch.setattr(server, "SUMMARIZATION_MODEL", "qwen2.5:1.5b")
+
+        payload = await _build_transparency_payload()
+
+        assert payload["models"]["llm"]["pool_split"] is True
+        assert payload["models"]["llm"]["name"] == "qwen2.5:1.5b"
+        assert (
+            payload["models"]["llm"]["provider_url"]
+            == "http://ollama-summary:11434"
+        )
+
     async def test_opa_down_graceful(self, _patch_globals):
         mock_http, mock_pool, _ = _patch_globals
 


### PR DESCRIPTION
## Summary

- Adds `SUMMARIZATION_PROVIDER_URL` / `SUMMARIZATION_MODEL` / `SUMMARIZATION_API_KEY` (defaults to existing `LLM_*`) so the in-pipeline summary call can route to its own endpoint instead of competing with the pb-proxy agent loop on a shared Ollama slot.
- Ships an optional sidecar `pb-ollama-summary` under `docker compose --profile summary-llm` (host port 11435, dedicated volume).
- `GET /transparency` exposes the new state via `models.llm.pool_split`.
- Closes the follow-up tracked in v0.7.0 release notes ([plan](https://github.com/nuetzliches/powerbrain/blob/feat/separate-summary-llm-pool/docs/plans/2026-04-20-separate-summary-llm-pool.md)).

Single-endpoint deployments need no env change — the new vars fall back to `LLM_*`.

## Activation example

```bash
docker compose --profile local-llm --profile summary-llm up -d
docker exec pb-ollama-summary ollama pull qwen2.5:1.5b
# .env:
SUMMARIZATION_PROVIDER_URL=http://ollama-summary:11434
SUMMARIZATION_MODEL=qwen2.5:1.5b
```

## Test plan

- [x] `pytest mcp-server/tests/test_summarize.py mcp-server/tests/test_transparency.py -v` — 20 passed (incl. new `test_uses_dedicated_summarization_provider` that asserts the sidecar URL/model are used end-to-end)
- [x] `pytest mcp-server/tests/ -q` — 335 passed, 6 skipped
- [x] `docker compose --profile local-llm --profile summary-llm config` — env values, container, and volume all resolve as expected
- [ ] Manual: spin up sidecar with `qwen2.5:1.5b`, run Tab D `"Fasse die Daten zu Julia Weber zusammen"`, confirm no `Summarization failed, returning raw chunks` warnings + `models.llm.pool_split=true` in `/transparency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)