### PR TITLE
fix(audit): chain bugs (#93, #94, #95, #96)

### DIFF
--- a/docs/audit-chain-migration.md
+++ b/docs/audit-chain-migration.md
@@ -56,42 +56,83 @@ Use the retention prune with the smallest retention permitted
 (`retention_days=1`) during a maintenance window. This writes an
 `audit_archive` row covering every entry older than 24 hours —
 including the broken segment — marked with the verifier's result
-(`chain_valid=false`), then deletes those rows. Anything newer than
-24 hours is preserved.
+(`chain_valid=false`).
 
 ```sql
 -- Maintenance window. Blocks audit writes briefly while the
 -- checkpoint runs; run during a low-traffic period.
 SELECT * FROM pb_audit_checkpoint_and_prune(1);
 -- audit_archive now has a row with chain_valid=false recording the
--- extent of the fork for future forensic review; the live log only
--- contains the past 24 hours.
+-- extent of the fork for future forensic review.
 ```
 
-If the entire log is within the last 24 hours and you still need a
-clean slate, stop all ingest traffic, then run a manual truncate in a
-transaction:
+> **Caveat — broken chains are not pruned.** `pb_audit_checkpoint_and_prune`
+> only deletes rows after a successful end-to-end verify
+> (`IF v_verify.valid THEN DELETE`, fail-closed). On a broken chain the
+> archive entry is recorded but the rows stay in `agent_access_log`, and
+> `pb_verify_audit_chain()` continues to report `valid=false`. Fall through
+> to the manual TRUNCATE below.
+
+For a complete clean slate (or whenever the prune above could not
+delete because the chain is broken), stop all ingest traffic, then
+run a manual truncate in a transaction:
 
 ```sql
 BEGIN;
--- Archive the current tail for forensic reference
-INSERT INTO audit_archive (archived_at, last_entry_id, last_verified_hash,
-                           row_count, chain_valid, first_invalid_id,
-                           retention_cutoff)
-SELECT now(), last_entry_id, last_entry_hash,
-       (SELECT count(*) FROM agent_access_log), false, NULL, now()
-  FROM audit_tail WHERE id = 1;
+-- Archive the current tail for forensic reference. The CTE feeds the
+-- archive's last_verified_hash back into audit_tail so the next chain
+-- continues from the same checkpoint hash without a genesis reseed.
+WITH archived AS (
+    INSERT INTO audit_archive (archived_at, last_entry_id, last_verified_hash,
+                                row_count, chain_valid, first_invalid_id,
+                                retention_cutoff)
+    SELECT now(), last_entry_id, last_entry_hash,
+           (SELECT count(*) FROM agent_access_log), false, NULL, now()
+      FROM audit_tail WHERE id = 1
+    RETURNING last_verified_hash
+)
+UPDATE audit_tail
+   SET last_entry_hash = (SELECT last_verified_hash FROM archived),
+       last_entry_id   = 0,
+       updated_at      = now()
+ WHERE id = 1;
 TRUNCATE agent_access_log RESTART IDENTITY;
-UPDATE audit_tail SET last_entry_hash = last_verified_hash,
-                      last_entry_id   = 0,
-                      updated_at      = now()
-  WHERE id = 1;
 COMMIT;
 ```
+
+For a full genesis reset (test/staging only), the `audit_tail` AND
+`audit_archive` must both be reset, otherwise `pb_verify_audit_chain()`
+seeds `expected_prev` from the most recent archive row's
+`last_verified_hash` and the next inserted row — which carries the
+Genesis `prev_hash` from the trigger — fails verification at id=1:
+
+```sql
+BEGIN;
+TRUNCATE agent_access_log RESTART IDENTITY;
+DELETE FROM audit_archive;     -- discard the forensic trail too
+UPDATE audit_tail
+   SET last_entry_hash = '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA,
+       last_entry_id   = 0,
+       updated_at      = now()
+ WHERE id = 1;
+COMMIT;
+```
+
+If preserving the forensic archive matters (regulator-facing or
+post-mortem reviews), use the Continuity-reset above instead — the
+new chain cross-links to the archive's `last_verified_hash`, so
+`pb_verify_audit_chain()` walks straight through.
 
 After either approach, `pb_verify_audit_chain()` verifies from the
 first surviving row (or `audit_archive.last_verified_hash` if the
 table is empty) and returns `valid=true`.
+
+> **From migration 023 onward**, the verifier additionally cross-checks
+> `audit_tail.last_entry_hash` against the resolved seed when the log
+> is empty. If they disagree (e.g. a genesis reset that forgot to
+> truncate `audit_archive`), it now returns
+> `valid=false, first_invalid_id=1` instead of silently passing —
+> see [#94](https://github.com/nuetzliches/powerbrain/issues/94).
 
 **Option B — Keep the broken rows for forensics, accept valid=false.**
 Do nothing. `get_system_info` keeps reporting `valid=false`. If you

--- a/init-db/023_audit_verifier_seed_check.sql
+++ b/init-db/023_audit_verifier_seed_check.sql
@@ -1,0 +1,137 @@
+-- ============================================================
+-- 023_audit_verifier_seed_check.sql — Detect inconsistent seeds
+-- on an empty agent_access_log (#94).
+-- ============================================================
+-- Background:
+--   pb_verify_audit_chain() seeds v_expected_prev from
+--   audit_archive.last_verified_hash and walks agent_access_log
+--   row-by-row. When the log is empty the FOR loop body never runs
+--   and the function unconditionally returns valid=true. That's
+--   wrong if audit_tail.last_entry_hash (the seed for the *next*
+--   insert via the trigger) disagrees with the archive seed used
+--   by the verifier — the next insert is guaranteed to fail
+--   verification at id=1 because Genesis != archive checkpoint.
+--
+--   Operators relying on pb_verify_audit_chain() as a pre-flight
+--   health check after a genesis-style reset got a green light
+--   immediately followed by valid=false on the first write.
+--
+-- Fix:
+--   In the empty-log path (v_count = 0 AND p_start_id resolves to
+--   the chain head), look up audit_tail.last_entry_hash and compare
+--   it to the resolved seed. If they differ, return
+--   valid=false, first_invalid_id=1 with a synthetic last_valid_hash
+--   carrying the (incorrect) archive seed for diagnostics.
+--
+-- Compatibility:
+--   * Function signature is unchanged — CREATE OR REPLACE FUNCTION.
+--   * Range-scoped calls (p_start_id > 1) keep their existing
+--     behaviour: the caller is asking about a specific window, not
+--     the chain head, so a tail comparison would be misleading.
+--   * audit_tail exists since migration 022 — the lookup is safe.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION pb_verify_audit_chain(
+    p_start_id BIGINT DEFAULT NULL,
+    p_end_id   BIGINT DEFAULT NULL
+) RETURNS TABLE(
+    valid            BOOLEAN,
+    first_invalid_id BIGINT,
+    total_checked    BIGINT,
+    last_valid_hash  BYTEA
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_expected_prev BYTEA;
+    v_row           agent_access_log%ROWTYPE;
+    v_count         BIGINT := 0;
+    v_computed      BYTEA;
+    v_last_valid    BYTEA;
+    v_tail_hash     BYTEA;
+BEGIN
+    -- Resolve starting prev_hash
+    IF p_start_id IS NULL OR p_start_id <= 1 THEN
+        SELECT last_verified_hash INTO v_expected_prev
+            FROM audit_archive
+            ORDER BY archived_at DESC
+            LIMIT 1;
+    ELSE
+        SELECT entry_hash INTO v_expected_prev
+            FROM agent_access_log
+            WHERE id = p_start_id - 1;
+        IF v_expected_prev IS NULL THEN
+            SELECT last_verified_hash INTO v_expected_prev
+                FROM audit_archive
+                ORDER BY archived_at DESC
+                LIMIT 1;
+        END IF;
+    END IF;
+
+    IF v_expected_prev IS NULL THEN
+        v_expected_prev := '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA;
+    END IF;
+
+    v_last_valid := v_expected_prev;
+
+    FOR v_row IN
+        SELECT * FROM agent_access_log
+        WHERE (p_start_id IS NULL OR id >= p_start_id)
+          AND (p_end_id   IS NULL OR id <= p_end_id)
+        ORDER BY id ASC
+    LOOP
+        v_computed := pb_audit_hash_payload(
+            v_expected_prev,
+            v_row.id,
+            v_row.agent_id,
+            v_row.agent_role,
+            v_row.resource_type,
+            v_row.resource_id,
+            v_row.action,
+            v_row.policy_result,
+            v_row.policy_reason,
+            v_row.request_context,
+            v_row.created_at,
+            v_row.contains_pii,
+            v_row.purpose,
+            v_row.legal_basis,
+            v_row.data_category,
+            v_row.fields_redacted
+        );
+
+        IF v_row.prev_hash  IS DISTINCT FROM v_expected_prev
+           OR v_row.entry_hash IS DISTINCT FROM v_computed THEN
+            RETURN QUERY SELECT FALSE, v_row.id, v_count, v_last_valid;
+            RETURN;
+        END IF;
+
+        v_last_valid    := v_row.entry_hash;
+        v_expected_prev := v_row.entry_hash;
+        v_count         := v_count + 1;
+    END LOOP;
+
+    -- ── Seed-mismatch detection on an empty range (#94) ──
+    -- The walk above terminated without examining any rows. If the
+    -- caller is asking about the chain head (p_start_id NULL or <=1),
+    -- the next insert via the trigger will use audit_tail.last_entry_hash
+    -- as prev_hash. If that disagrees with the archive seed we just
+    -- resolved, the chain will break on the very first write. Surface
+    -- it now instead of silently passing.
+    IF v_count = 0 AND (p_start_id IS NULL OR p_start_id <= 1) THEN
+        SELECT last_entry_hash INTO v_tail_hash
+            FROM audit_tail WHERE id = 1;
+        IF v_tail_hash IS NOT NULL
+           AND v_tail_hash IS DISTINCT FROM v_expected_prev THEN
+            RETURN QUERY SELECT FALSE, 1::BIGINT, 0::BIGINT, v_expected_prev;
+            RETURN;
+        END IF;
+    END IF;
+
+    RETURN QUERY SELECT TRUE, NULL::BIGINT, v_count, v_last_valid;
+END;
+$$;
+
+COMMENT ON FUNCTION pb_verify_audit_chain(BIGINT, BIGINT) IS
+'Verifies the agent_access_log hash chain. Resolves the starting prev_hash from the previous row (or audit_archive.last_verified_hash, or genesis). On an empty range with chain-head bounds, additionally checks that audit_tail.last_entry_hash matches the resolved seed — guards against post-reset states where the next insert would fail at id=1 (issue #94).';

--- a/init-db/024_audit_integrity_status.sql
+++ b/init-db/024_audit_integrity_status.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- 024_audit_integrity_status.sql — Cache for the transparency
+-- report's audit_integrity field (#95).
+-- ============================================================
+-- Background:
+--   _transparency_audit_snapshot() in mcp-server runs
+--   pb_verify_audit_chain() inside the get_system_info request
+--   handler. The request's own audit-log INSERT happens AFTER the
+--   handler returns, so the verifier always sees committed state
+--   from BEFORE the request — total_checked underreports by 1
+--   relative to the chain length immediately after the request
+--   returns. This made get_system_info inconsistent with a follow-up
+--   verify_audit_integrity call on the same DB at the same instant.
+--
+-- Fix:
+--   Decouple the snapshot from the request path. A new single-row
+--   table stores the most recent verifier result. The pb-worker
+--   refreshes it periodically (~ every 60 s by default). The server
+--   reads this cache → snapshot reflects committed state independent
+--   of the current request, and consumers see a `checked_at`
+--   timestamp so they can judge staleness themselves.
+--   Live answers remain available through the
+--   verify_audit_integrity MCP tool.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS audit_integrity_status (
+    id               INT          PRIMARY KEY CHECK (id = 1),
+    valid            BOOLEAN,
+    total_checked    BIGINT       NOT NULL DEFAULT 0,
+    first_invalid_id BIGINT,
+    last_valid_hash  BYTEA,
+    checked_at       TIMESTAMPTZ,
+    error            TEXT,
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  audit_integrity_status IS
+    'Single-row cache holding the most recent pb_verify_audit_chain_tail() result. Refreshed periodically by the pb-worker job audit_integrity_status_refresh (~60 s). Read by mcp-server _transparency_audit_snapshot() to decouple the snapshot from the request path (issue #95).';
+COMMENT ON COLUMN audit_integrity_status.valid            IS 'TRUE/FALSE result of the last pb_verify_audit_chain_tail() call; NULL if the worker has not run yet or the last call errored.';
+COMMENT ON COLUMN audit_integrity_status.total_checked    IS 'Rows verified during the last refresh (capped at AUDIT_INTEGRITY_TAIL_ROWS).';
+COMMENT ON COLUMN audit_integrity_status.first_invalid_id IS 'id of the first row that failed verification, NULL if chain is valid.';
+COMMENT ON COLUMN audit_integrity_status.last_valid_hash  IS 'Hash up to which the chain has been verified (entry_hash of the last validated row, or the seed if the verified range was empty).';
+COMMENT ON COLUMN audit_integrity_status.checked_at       IS 'Timestamp at which the last successful refresh ran. Consumers should compare with now() to assess staleness.';
+COMMENT ON COLUMN audit_integrity_status.error            IS 'Last refresh-error message (truncated to 500 chars), NULL on success.';
+
+-- RLS: only the worker (DB owner / superuser) writes; mcp_auditor reads.
+ALTER TABLE audit_integrity_status ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_integrity_status FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mcp_auditor') THEN
+        GRANT SELECT ON audit_integrity_status TO mcp_auditor;
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = 'public'
+              AND tablename  = 'audit_integrity_status'
+              AND policyname = 'audit_integrity_status_read_only'
+        ) THEN
+            EXECUTE 'CREATE POLICY audit_integrity_status_read_only ON audit_integrity_status '
+                 || 'FOR SELECT TO mcp_auditor USING (true)';
+        END IF;
+    END IF;
+END
+$$;

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -741,6 +741,31 @@ async def log_access(agent_id: str, agent_role: str,
 VAULT_HMAC_SECRET = read_secret("VAULT_HMAC_SECRET", "change-me-in-production")
 
 
+def _parse_iso_datetime(s, *, field: str):
+    """Parse an ISO-8601 datetime string into an aware `datetime`.
+
+    Accepts the variants commonly emitted by clients:
+      * `2026-04-30T00:00:00Z`         (Z suffix)
+      * `2026-04-30T00:00:00+00:00`    (explicit offset)
+      * `2026-04-30T00:00:00`          (naive — assumed UTC)
+
+    Returns None for None/empty input. Raises ValueError with the
+    field name and the offending value on parse failure (so callers
+    can surface a 422-style error to the client).
+    """
+    from datetime import datetime, timezone
+    if not s:
+        return None
+    try:
+        # Python 3.11+ accepts "Z" natively, but normalise anyway.
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError) as e:
+        raise ValueError(f"{field}: invalid ISO-8601 datetime: {s!r} ({e})")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def validate_pii_access_token(token: dict) -> dict:
     """
     Validates a PII access token (HMAC-signed, short-lived).
@@ -1612,9 +1637,9 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "format":   {"type": "string", "enum": ["json", "csv"], "default": "json"},
-                    "since":    {"type": "string",
+                    "since":    {"type": "string", "format": "date-time",
                                  "description": "ISO-8601 lower bound on created_at (inclusive)"},
-                    "until":    {"type": "string",
+                    "until":    {"type": "string", "format": "date-time",
                                  "description": "ISO-8601 upper bound on created_at (exclusive)"},
                     "agent_id": {"type": "string",
                                  "description": "Filter by exact agent_id"},
@@ -3065,17 +3090,26 @@ async def _dispatch(name: str, arguments: dict[str, Any],
         requested_limit = int(arguments.get("limit") or export_default_rows)
         limit = min(max(1, requested_limit), export_max_rows)
 
+        # Parse + bind ISO-8601 datetimes to real datetime objects so
+        # asyncpg's TIMESTAMPTZ type-check accepts them (#96).
+        try:
+            since_dt = _parse_iso_datetime(arguments.get("since"), field="since")
+            until_dt = _parse_iso_datetime(arguments.get("until"), field="until")
+        except ValueError as e:
+            return [TextContent(type="text",
+                text=json.dumps({"error": str(e)}, ensure_ascii=False))]
+
         # Build filter
         where_parts: list[str] = []
         params: list = []
         idx = 1
-        if arguments.get("since"):
+        if since_dt is not None:
             where_parts.append(f"created_at >= ${idx}")
-            params.append(arguments["since"])
+            params.append(since_dt)
             idx += 1
-        if arguments.get("until"):
+        if until_dt is not None:
             where_parts.append(f"created_at < ${idx}")
-            params.append(arguments["until"])
+            params.append(until_dt)
             idx += 1
         if arguments.get("agent_id"):
             where_parts.append(f"agent_id = ${idx}")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -3419,15 +3419,43 @@ async def _transparency_pii_snapshot() -> dict:
 
 
 async def _transparency_audit_snapshot() -> dict:
-    """Short audit-chain integrity status for the transparency report."""
+    """Audit-chain integrity from the worker-maintained cache.
+
+    Reads `audit_integrity_status` (single-row table refreshed by the
+    `audit_integrity_status_refresh` worker job, ~ every 60 s by
+    default). Decoupling the snapshot from the request path means the
+    reported state is always *committed* and not affected by the
+    request's own audit-log INSERT (issue #95). Consumers see
+    `checked_at` and can decide for themselves how stale is too stale;
+    a live answer is available through the `verify_audit_integrity`
+    MCP tool.
+    """
     try:
         pool = await get_pg_pool()
         row = await pool.fetchrow(
-            "SELECT valid, total_checked FROM pb_verify_audit_chain()"
+            "SELECT valid, total_checked, first_invalid_id, "
+            "       checked_at, error "
+            "  FROM audit_integrity_status WHERE id = 1"
         )
         if row is None:
-            return {"valid": None, "total_checked": 0}
-        return {"valid": row["valid"], "total_checked": row["total_checked"]}
+            return {
+                "valid":         None,
+                "total_checked": 0,
+                "stale":         True,
+                "detail":        "no integrity check has run yet",
+            }
+        if row["error"]:
+            return {
+                "valid":      None,
+                "detail":     row["error"][:200],
+                "checked_at": row["checked_at"].isoformat() if row["checked_at"] else None,
+            }
+        return {
+            "valid":            row["valid"],
+            "total_checked":    row["total_checked"],
+            "first_invalid_id": row["first_invalid_id"],
+            "checked_at":       row["checked_at"].isoformat() if row["checked_at"] else None,
+        }
     except Exception as e:
         return {"valid": None, "detail": str(e)[:200]}
 

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -245,10 +245,90 @@ class TestExportAuditLog:
         assert "created_at <" in sql
         assert "agent_id =" in sql
         assert "action =" in sql
-        assert "2026-04-01T00:00:00Z" in params
-        assert "2026-04-08T00:00:00Z" in params
+        # since/until are now bound as datetime objects, not strings (#96)
+        assert isinstance(params[0], datetime)
+        assert params[0] == datetime(2026, 4, 1, tzinfo=timezone.utc)
+        assert isinstance(params[1], datetime)
+        assert params[1] == datetime(2026, 4, 8, tzinfo=timezone.utc)
         assert "agent-42" in params
         assert "search" in params
+
+    async def test_since_iso_with_offset(self, _patch_globals):
+        """Explicit timezone offset is preserved (#96)."""
+        mock_http, mock_pool = _patch_globals
+        mock_http.get.return_value = self._opa_response()
+        mock_pool.fetch.return_value = []
+
+        await _dispatch(
+            "export_audit_log",
+            {"since": "2026-04-30T00:00:00+02:00"},
+            "admin-1", "admin",
+        )
+        params = list(mock_pool.fetch.call_args[0][1:])
+        assert isinstance(params[0], datetime)
+        assert params[0].utcoffset().total_seconds() == 7200
+
+    async def test_since_iso_naive_treated_as_utc(self, _patch_globals):
+        """Naive datetime is coerced to UTC (no silent tz drift) (#96)."""
+        mock_http, mock_pool = _patch_globals
+        mock_http.get.return_value = self._opa_response()
+        mock_pool.fetch.return_value = []
+
+        await _dispatch(
+            "export_audit_log",
+            {"since": "2026-04-30T12:34:56"},
+            "admin-1", "admin",
+        )
+        params = list(mock_pool.fetch.call_args[0][1:])
+        assert isinstance(params[0], datetime)
+        assert params[0].tzinfo is timezone.utc
+        assert params[0] == datetime(2026, 4, 30, 12, 34, 56, tzinfo=timezone.utc)
+
+    async def test_since_invalid_returns_error(self, _patch_globals):
+        """Invalid ISO-8601 strings get a clear 422-style error, not a
+        500 from asyncpg's type-check (#96)."""
+        mock_http, mock_pool = _patch_globals
+        mock_http.get.return_value = self._opa_response()
+
+        result = await _dispatch(
+            "export_audit_log",
+            {"since": "not-a-datetime"},
+            "admin-1", "admin",
+        )
+        payload = json.loads(result[0].text)
+        assert "error" in payload
+        assert "since" in payload["error"]
+        assert "invalid ISO-8601" in payload["error"]
+        # The DB must not be touched
+        mock_pool.fetch.assert_not_called()
+
+    async def test_until_invalid_returns_error(self, _patch_globals):
+        mock_http, mock_pool = _patch_globals
+        mock_http.get.return_value = self._opa_response()
+
+        result = await _dispatch(
+            "export_audit_log",
+            {"until": "not-a-datetime"},
+            "admin-1", "admin",
+        )
+        payload = json.loads(result[0].text)
+        assert "error" in payload
+        assert "until" in payload["error"]
+        mock_pool.fetch.assert_not_called()
+
+    async def test_empty_since_skipped(self, _patch_globals):
+        """Empty/missing since still works (no filter applied)."""
+        mock_http, mock_pool = _patch_globals
+        mock_http.get.return_value = self._opa_response()
+        mock_pool.fetch.return_value = []
+
+        await _dispatch(
+            "export_audit_log",
+            {"since": ""},
+            "admin-1", "admin",
+        )
+        sql = mock_pool.fetch.call_args[0][0]
+        assert "created_at >=" not in sql
 
     async def test_unknown_format_rejected(self, _patch_globals):
         mock_http, mock_pool = _patch_globals

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -427,3 +427,68 @@ class TestHashChainLive:
 
         v = await live_pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
         assert v["valid"] is True
+
+    # ── Issue #94: verifier must detect inconsistent seed ─────────
+    async def test_verify_detects_inconsistent_seed(self, live_pool):
+        """An empty agent_access_log with audit_tail.last_entry_hash
+        out of sync with the archive's last_verified_hash is a guaranteed
+        chain break on the next insert. The verifier must surface that
+        proactively (#94)."""
+        # Setup: archive carries a non-genesis hash, tail is genesis.
+        archive_hash = b"\xab" * 32
+        await live_pool.execute(
+            "INSERT INTO audit_archive ("
+            "    archived_at, last_entry_id, last_verified_hash, "
+            "    row_count, chain_valid, first_invalid_id, retention_cutoff"
+            ") VALUES (now(), 0, $1, 0, true, NULL, now())",
+            archive_hash,
+        )
+        await live_pool.execute(
+            "UPDATE audit_tail SET last_entry_hash = $1, last_entry_id = 0 "
+            "WHERE id = 1",
+            b"\x00" * 32,
+        )
+
+        v = await live_pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert v["valid"] is False
+        assert v["first_invalid_id"] == 1
+        assert v["total_checked"] == 0
+        assert v["last_valid_hash"] == archive_hash
+
+    async def test_verify_consistent_empty_chain(self, live_pool):
+        """Empty log + tail and archive both at genesis is a valid
+        post-genesis-reset state. Verifier must return valid=true."""
+        await live_pool.execute(
+            "UPDATE audit_tail SET last_entry_hash = $1, last_entry_id = 0 "
+            "WHERE id = 1",
+            b"\x00" * 32,
+        )
+        v = await live_pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
+        assert v["valid"] is True
+        assert v["total_checked"] == 0
+        assert v["last_valid_hash"] == b"\x00" * 32
+
+    async def test_verify_seed_check_skipped_for_range_query(self, live_pool):
+        """When the caller asks about a specific id range (p_start_id > 1),
+        the tail-mismatch check must NOT trigger — they're not asking
+        about chain-head consistency."""
+        # Empty log, mismatched seeds (would trigger if scope were head)
+        archive_hash = b"\xcd" * 32
+        await live_pool.execute(
+            "INSERT INTO audit_archive ("
+            "    archived_at, last_entry_id, last_verified_hash, "
+            "    row_count, chain_valid, first_invalid_id, retention_cutoff"
+            ") VALUES (now(), 0, $1, 0, true, NULL, now())",
+            archive_hash,
+        )
+        await live_pool.execute(
+            "UPDATE audit_tail SET last_entry_hash = $1 WHERE id = 1",
+            b"\x00" * 32,
+        )
+
+        v = await live_pool.fetchrow(
+            "SELECT * FROM pb_verify_audit_chain($1, $2)", 100, 200,
+        )
+        # Range scope, empty result → still considered valid
+        assert v["valid"] is True
+        assert v["total_checked"] == 0

--- a/mcp-server/tests/test_transparency.py
+++ b/mcp-server/tests/test_transparency.py
@@ -86,9 +86,20 @@ def _ingestion_health_response(body: dict | None = None):
     return r
 
 
-def _chain_row(valid=True, total=5):
+def _chain_row(valid=True, total=5, first_invalid_id=None,
+               checked_at=None, error=None):
+    """Build a mock row matching the audit_integrity_status schema (#95)."""
+    from datetime import datetime, timezone
+    if checked_at is None:
+        checked_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
     row = MagicMock()
-    row.__getitem__ = lambda s, k: {"valid": valid, "total_checked": total}[k]
+    row.__getitem__ = lambda s, k: {
+        "valid":            valid,
+        "total_checked":    total,
+        "first_invalid_id": first_invalid_id,
+        "checked_at":       checked_at,
+        "error":            error,
+    }[k]
     return row
 
 
@@ -287,3 +298,72 @@ class TestTransparencyRouteAuth:
             "/transparency must be auth-required — do not add it to "
             "AUTH_BYPASS_PATHS."
         )
+
+
+class TestAuditIntegritySnapshot:
+    """Coverage for `_transparency_audit_snapshot()` after #95.
+
+    The function now reads from `audit_integrity_status` (worker-cache)
+    instead of running pb_verify_audit_chain() inline. Snapshot reflects
+    committed state, decoupled from the request-path INSERT, with a
+    `checked_at` timestamp consumers can use to gauge staleness.
+    """
+
+    async def test_reads_from_cache(self, _patch_globals):
+        from server import _transparency_audit_snapshot
+        from datetime import datetime, timezone
+        _, mock_pool, _ = _patch_globals
+        ts = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+        mock_pool.fetchrow.return_value = _chain_row(
+            valid=True, total=42, checked_at=ts,
+        )
+        snap = await _transparency_audit_snapshot()
+        assert snap["valid"] is True
+        assert snap["total_checked"] == 42
+        assert snap["first_invalid_id"] is None
+        assert snap["checked_at"] == ts.isoformat()
+        # SQL should target the cache table, not pb_verify_audit_chain
+        sql = mock_pool.fetchrow.call_args[0][0]
+        assert "audit_integrity_status" in sql
+        assert "pb_verify_audit_chain" not in sql
+
+    async def test_stale_when_cache_empty(self, _patch_globals):
+        from server import _transparency_audit_snapshot
+        _, mock_pool, _ = _patch_globals
+        mock_pool.fetchrow.return_value = None
+        snap = await _transparency_audit_snapshot()
+        assert snap["valid"] is None
+        assert snap["stale"] is True
+        assert "no integrity check has run yet" in snap["detail"]
+
+    async def test_surfaces_worker_error(self, _patch_globals):
+        from server import _transparency_audit_snapshot
+        from datetime import datetime, timezone
+        _, mock_pool, _ = _patch_globals
+        ts = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+        mock_pool.fetchrow.return_value = _chain_row(
+            valid=None, total=0, error="connection refused",
+            checked_at=ts,
+        )
+        snap = await _transparency_audit_snapshot()
+        assert snap["valid"] is None
+        assert "connection refused" in snap["detail"]
+        assert snap["checked_at"] == ts.isoformat()
+
+    async def test_db_failure_returns_none(self, _patch_globals):
+        from server import _transparency_audit_snapshot
+        _, mock_pool, _ = _patch_globals
+        mock_pool.fetchrow.side_effect = RuntimeError("db down")
+        snap = await _transparency_audit_snapshot()
+        assert snap["valid"] is None
+        assert "db down" in snap["detail"]
+
+    async def test_invalid_chain_in_cache(self, _patch_globals):
+        from server import _transparency_audit_snapshot
+        _, mock_pool, _ = _patch_globals
+        mock_pool.fetchrow.return_value = _chain_row(
+            valid=False, total=5, first_invalid_id=42,
+        )
+        snap = await _transparency_audit_snapshot()
+        assert snap["valid"] is False
+        assert snap["first_invalid_id"] == 42

--- a/worker/context.py
+++ b/worker/context.py
@@ -17,6 +17,7 @@ class WorkerContext:
     opa_url:        str
     qdrant_url:     str
     audit_retention_days: int = 365
+    audit_status_tail_rows: int = 1000
     pending_review_grace_minutes: int = 0
     extra:          dict = field(default_factory=dict)
 
@@ -45,5 +46,6 @@ class WorkerContext:
             opa_url=os.getenv("OPA_URL", "http://opa:8181"),
             qdrant_url=os.getenv("QDRANT_URL", "http://qdrant:6333"),
             audit_retention_days=int(os.getenv("AUDIT_RETENTION_DAYS", "365")),
+            audit_status_tail_rows=int(os.getenv("AUDIT_INTEGRITY_TAIL_ROWS", "1000")),
             pending_review_grace_minutes=int(os.getenv("PENDING_REVIEW_GRACE_MINUTES", "0")),
         )

--- a/worker/jobs/audit_integrity_status.py
+++ b/worker/jobs/audit_integrity_status.py
@@ -1,0 +1,76 @@
+"""Job: audit_integrity_status_refresh (#95).
+
+Runs pb_verify_audit_chain_tail() periodically and UPSERTs the result
+into audit_integrity_status (single-row cache). The mcp-server reads
+that cache for its transparency snapshot, decoupling the
+audit_integrity field from the request path.
+
+On any error, the cache row's `error` column is updated so consumers
+of the snapshot can see what went wrong; the exception is re-raised
+so the scheduler logs and metrics reflect the failure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("pb-worker.audit_integrity_status")
+
+
+async def run(ctx) -> dict[str, Any]:
+    tail_rows = ctx.audit_status_tail_rows
+    try:
+        row = await ctx.pg_pool.fetchrow(
+            "SELECT valid, first_invalid_id, total_checked, last_valid_hash "
+            "FROM pb_verify_audit_chain_tail($1)",
+            tail_rows,
+        )
+        await ctx.pg_pool.execute(
+            """
+            INSERT INTO audit_integrity_status (
+                id, valid, total_checked, first_invalid_id, last_valid_hash,
+                checked_at, error, updated_at
+            )
+            VALUES (1, $1, $2, $3, $4, now(), NULL, now())
+            ON CONFLICT (id) DO UPDATE SET
+                valid            = EXCLUDED.valid,
+                total_checked    = EXCLUDED.total_checked,
+                first_invalid_id = EXCLUDED.first_invalid_id,
+                last_valid_hash  = EXCLUDED.last_valid_hash,
+                checked_at       = EXCLUDED.checked_at,
+                error            = NULL,
+                updated_at       = now()
+            """,
+            row["valid"],
+            row["total_checked"],
+            row["first_invalid_id"],
+            row["last_valid_hash"],
+        )
+        summary = {
+            "valid":            row["valid"],
+            "total_checked":    row["total_checked"],
+            "first_invalid_id": row["first_invalid_id"],
+            "tail_rows":        tail_rows,
+        }
+        if not row["valid"]:
+            log.error("audit chain invalid! cached: %s", summary)
+        else:
+            log.info("audit_integrity_status refresh: %s", summary)
+        return summary
+    except Exception as e:
+        log.exception("audit_integrity_status refresh failed: %s", e)
+        try:
+            await ctx.pg_pool.execute(
+                """
+                INSERT INTO audit_integrity_status (id, error, updated_at)
+                VALUES (1, $1, now())
+                ON CONFLICT (id) DO UPDATE SET
+                    error      = EXCLUDED.error,
+                    updated_at = now()
+                """,
+                str(e)[:500],
+            )
+        except Exception as e2:
+            log.error("could not persist audit_integrity_status error: %s", e2)
+        raise

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -28,6 +28,7 @@ from prometheus_client import start_http_server
 from worker.context import WorkerContext
 from worker.jobs import (
     accuracy_metrics,
+    audit_integrity_status,
     audit_retention,
     gdpr_retention,
     pending_review_timeout,
@@ -73,6 +74,14 @@ JOB_SPECS: list[dict] = [
         "trigger": IntervalTrigger(
             minutes=int(os.getenv("REPO_SYNC_INTERVAL_MINUTES", "5")),
             jitter=30,
+        ),
+    },
+    {
+        "id":      "audit_integrity_status_refresh",
+        "func":    audit_integrity_status.run,
+        "trigger": IntervalTrigger(
+            seconds=int(os.getenv("AUDIT_INTEGRITY_INTERVAL_SECONDS", "60")),
+            jitter=10,
         ),
     },
 ]

--- a/worker/tests/test_jobs.py
+++ b/worker/tests/test_jobs.py
@@ -9,6 +9,7 @@ import pytest
 from worker import scheduler as scheduler_mod
 from worker.jobs import (
     accuracy_metrics,
+    audit_integrity_status,
     audit_retention,
     pending_review_timeout,
     gdpr_retention,
@@ -24,6 +25,7 @@ def _ctx(**overrides):
         opa_url="http://opa:8181",
         qdrant_url="http://qdrant:6333",
         audit_retention_days=365,
+        audit_status_tail_rows=1000,
         pending_review_grace_minutes=0,
         extra={},
     )
@@ -91,6 +93,86 @@ class TestAuditRetention:
         ctx.pg_pool.fetchrow.side_effect = RuntimeError("connection lost")
         with pytest.raises(RuntimeError, match="connection lost"):
             await audit_retention.run(ctx)
+
+
+# ── audit_integrity_status ─────────────────────────────────
+
+class TestAuditIntegrityStatus:
+    def _verify_row(self, valid=True, total=10, first_invalid=None,
+                    last_hash=b"\xab" * 32):
+        row = MagicMock()
+        row.__getitem__ = lambda s, k: {
+            "valid":            valid,
+            "total_checked":    total,
+            "first_invalid_id": first_invalid,
+            "last_valid_hash":  last_hash,
+        }[k]
+        return row
+
+    async def test_happy_path_upserts_cache(self):
+        ctx = _ctx()
+        ctx.pg_pool.fetchrow.return_value = self._verify_row(
+            valid=True, total=42,
+        )
+        summary = await audit_integrity_status.run(ctx)
+        assert summary["valid"] is True
+        assert summary["total_checked"] == 42
+        assert summary["tail_rows"] == 1000
+        # Verifier called with tail_rows
+        ctx.pg_pool.fetchrow.assert_called_once()
+        verify_args = ctx.pg_pool.fetchrow.call_args[0]
+        assert "pb_verify_audit_chain_tail" in verify_args[0]
+        assert verify_args[1] == 1000
+        # UPSERT executed
+        ctx.pg_pool.execute.assert_called_once()
+        upsert_sql = ctx.pg_pool.execute.call_args[0][0]
+        assert "audit_integrity_status" in upsert_sql
+        assert "ON CONFLICT (id) DO UPDATE" in upsert_sql
+
+    async def test_invalid_chain_logged(self, caplog):
+        import logging
+        ctx = _ctx()
+        ctx.pg_pool.fetchrow.return_value = self._verify_row(
+            valid=False, total=10, first_invalid=5,
+        )
+        with caplog.at_level(logging.ERROR,
+                             logger="pb-worker.audit_integrity_status"):
+            summary = await audit_integrity_status.run(ctx)
+        assert summary["valid"] is False
+        assert summary["first_invalid_id"] == 5
+        assert any("audit chain invalid" in r.message
+                   for r in caplog.records)
+
+    async def test_custom_tail_rows(self):
+        ctx = _ctx(audit_status_tail_rows=500)
+        ctx.pg_pool.fetchrow.return_value = self._verify_row(total=500)
+        summary = await audit_integrity_status.run(ctx)
+        assert summary["tail_rows"] == 500
+        verify_args = ctx.pg_pool.fetchrow.call_args[0]
+        assert verify_args[1] == 500
+
+    async def test_db_failure_persists_error_and_raises(self):
+        ctx = _ctx()
+        ctx.pg_pool.fetchrow.side_effect = RuntimeError("db unreachable")
+        # The error-path execute() must succeed
+        ctx.pg_pool.execute.return_value = None
+        with pytest.raises(RuntimeError, match="db unreachable"):
+            await audit_integrity_status.run(ctx)
+        # Error UPSERT call after the verify failure
+        ctx.pg_pool.execute.assert_called_once()
+        sql = ctx.pg_pool.execute.call_args[0][0]
+        assert "audit_integrity_status" in sql
+        assert "error" in sql.lower()
+        assert "db unreachable" in ctx.pg_pool.execute.call_args[0][1]
+
+    async def test_error_persistence_failure_swallowed(self):
+        """If the error UPSERT itself fails, the original exception
+        must still propagate; the secondary failure must not mask it."""
+        ctx = _ctx()
+        ctx.pg_pool.fetchrow.side_effect = RuntimeError("primary failure")
+        ctx.pg_pool.execute.side_effect = RuntimeError("secondary failure")
+        with pytest.raises(RuntimeError, match="primary failure"):
+            await audit_integrity_status.run(ctx)
 
 
 # ── pending_review_timeout ─────────────────────────────────
@@ -429,6 +511,7 @@ class TestSchedulerRegistration:
             "gdpr_retention_cleanup",
             "audit_retention_cleanup",
             "repo_sync",
+            "audit_integrity_status_refresh",
         }
 
     def test_register_jobs_attaches_all(self):
@@ -443,6 +526,7 @@ class TestSchedulerRegistration:
             "gdpr_retention_cleanup",
             "audit_retention_cleanup",
             "repo_sync",
+            "audit_integrity_status_refresh",
         }
 
     async def test_run_with_logging_swallows_exceptions(self):
@@ -468,3 +552,4 @@ class TestSchedulerRegistration:
         assert trigger_map["pending_review_timeout"] is IntervalTrigger
         assert trigger_map["gdpr_retention_cleanup"] is CronTrigger
         assert trigger_map["audit_retention_cleanup"] is CronTrigger
+        assert trigger_map["audit_integrity_status_refresh"] is IntervalTrigger


### PR DESCRIPTION
## Summary

Bundles four audit-chain bug fixes found during a recovery walkthrough after the concurrency fix in #63. Each fix is a small, self-contained commit; the bundle keeps them in one PR because they all touch the same verifier / recovery / transparency surface and benefit from being reviewed together.

- **#93 — Recovery doc bugs.** Option A previously claimed `pb_audit_checkpoint_and_prune` deletes the broken segment (it does not — DELETE is fail-closed behind `IF v_verify.valid`). Option B referenced a non-existent column `audit_tail.last_verified_hash`. Genesis-reset path was undocumented, leaving the system in a misleading state where the next insert breaks at id=1.
- **#94 — Verifier false-positive on empty log.** `pb_verify_audit_chain()` returned `valid=true, total_checked=0` even when `audit_tail.last_entry_hash` was inconsistent with the resolved seed (e.g. genesis reset that forgot to truncate `audit_archive`). Migration 023 cross-checks the tail in the empty-range path and now returns `valid=false, first_invalid_id=1` proactively.
- **#95 — `audit_integrity` off-by-one in transparency report.** `_transparency_audit_snapshot` ran `pb_verify_audit_chain()` inline, *before* `log_access` for the request itself committed. Underreport by 1 was structural. Decoupled via a worker-maintained cache table (`audit_integrity_status`, migration 024 + new `audit_integrity_status_refresh` job, default 60 s).
- **#96 — `export_audit_log` rejected every ISO-8601 datetime.** `since` / `until` were passed as raw strings to asyncpg; TIMESTAMPTZ binding requires `datetime` instances. New `_parse_iso_datetime` helper accepts `Z` / `+00:00` / naive variants and returns a structured 422-style error for malformed input.

## Migrations

| # | File | Purpose |
|---|------|---------|
| 023 | `init-db/023_audit_verifier_seed_check.sql` | `CREATE OR REPLACE pb_verify_audit_chain` with seed-mismatch detection (#94) |
| 024 | `init-db/024_audit_integrity_status.sql` | Single-row cache table for the transparency snapshot (#95) |

## Test plan

- [x] `mcp-server/tests/test_audit_integrity.py` — new live-PG cases for #94 (`test_verify_detects_inconsistent_seed`, `test_verify_consistent_empty_chain`, `test_verify_seed_check_skipped_for_range_query`); new unit cases for #96 (`test_since_iso_with_offset`, `_naive`, `_invalid_returns_error`, etc.); existing `test_filters_applied` updated to assert `datetime` instances.
- [x] `mcp-server/tests/test_transparency.py` — new `TestAuditIntegritySnapshot` covers cache-hit / stale / worker-error / DB-failure / invalid-chain branches; existing `_chain_row` helper extended for the new schema.
- [x] `worker/tests/test_jobs.py` — new `TestAuditIntegrityStatus` covers UPSERT happy path, custom tail rows, error persistence, error-on-error swallowing; `TestSchedulerRegistration` extended with the new job ID.
- [x] Full local pytest run: 391 passed, 9 skipped (live PG-gated).
- [ ] CI: `unit-tests` (≥ 68 % coverage), `opa-tests`, `docker-build`, `security-scan`.
- [ ] E2E manual checks once a Postgres + worker stack is up:
  - [ ] `verify_audit_integrity` after a genesis-only reset returns `valid=false, first_invalid_id=1` (#94).
  - [ ] `get_system_info` after worker has run shows `audit_integrity.checked_at` and a non-decreasing `total_checked` (#95).
  - [ ] `export_audit_log` accepts `2026-04-30T00:00:00Z`, `+00:00`, and naive forms (#96).

## Out of scope

- The `pb_audit_force_reset()` operator helper from #97 follows in a separate PR (`feat/issue-97-audit-force-reset`) — it builds on the verifier semantics introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)