### PR TITLE
fix(audit): preserve verify visibility + clean stale snapshot rendering

### DIFF
--- a/mcp-server/compliance_doc.py
+++ b/mcp-server/compliance_doc.py
@@ -160,12 +160,17 @@ def _render_section_3_monitoring(ctx: ComplianceDocContext) -> str:
     t = ctx.transparency or {}
     h = ctx.health or {}
     audit = t.get("audit_integrity", {}) or {}
+    # `total_checked` is null when the worker cache is empty / stale (#104).
+    # Render that as "unknown" instead of "None" to avoid the misleading
+    # "verified: 0" or "verified: None" Annex IV rendering.
+    total_checked = audit.get("total_checked")
+    total_checked_disp = total_checked if total_checked is not None else "unknown"
 
     lines = [
         "## 3. Monitoring, Functioning and Control\n",
         "### 3.1 Audit log integrity (Art. 12)\n",
         f"- Hash chain valid: `{audit.get('valid')}`\n",
-        f"- Total entries verified at last check: `{audit.get('total_checked')}`\n",
+        f"- Total entries verified at last check: `{total_checked_disp}`\n",
         "\nAudit entries form a SHA-256 hash chain enforced by a "
         "PostgreSQL `BEFORE INSERT` trigger and an append-only "
         "`BEFORE UPDATE` block. Retention pruning preserves chain "

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -3506,9 +3506,13 @@ async def _transparency_audit_snapshot() -> dict:
             "  FROM audit_integrity_status WHERE id = 1"
         )
         if row is None:
+            # `total_checked: null` (not 0) so consumers can distinguish
+            # "no check has run" from "check ran, found 0 entries". The
+            # `stale` flag is the primary signal; the null value avoids
+            # the misleading "verified: 0" rendering downstream (#104).
             return {
                 "valid":         None,
-                "total_checked": 0,
+                "total_checked": None,
                 "stale":         True,
                 "detail":        "no integrity check has run yet",
             }

--- a/mcp-server/tests/test_compliance_doc.py
+++ b/mcp-server/tests/test_compliance_doc.py
@@ -119,6 +119,23 @@ class TestRenderDoc:
         assert "Hash chain valid: `True`" in body
         assert "verified at last check: `42`" in body
 
+    def test_section_3_renders_stale_audit_as_unknown(self):
+        """When the worker cache is empty, transparency reports
+        `total_checked: null`. The renderer must render that as
+        "unknown" — not the literal "None" — so the Annex IV doc is
+        not misleading. See issue #104."""
+        ctx = _full_ctx(transparency={
+            "audit_integrity": {
+                "valid":         None,
+                "total_checked": None,
+                "stale":         True,
+            },
+        })
+        body = render_doc(ctx)
+        assert "verified at last check: `unknown`" in body
+        assert "verified at last check: `None`" not in body
+        assert "verified at last check: `0`" not in body
+
     def test_section_3_lists_indicators(self):
         ctx = _full_ctx()
         body = render_doc(ctx)

--- a/mcp-server/tests/test_transparency.py
+++ b/mcp-server/tests/test_transparency.py
@@ -369,6 +369,9 @@ class TestAuditIntegritySnapshot:
         mock_pool.fetchrow.return_value = None
         snap = await _transparency_audit_snapshot()
         assert snap["valid"] is None
+        # `total_checked` is null (not 0) so consumers can distinguish
+        # "no check run" from "checked, found 0 entries". See issue #104.
+        assert snap["total_checked"] is None
         assert snap["stale"] is True
         assert "no integrity check has run yet" in snap["detail"]
 

--- a/worker/jobs/audit_integrity_status.py
+++ b/worker/jobs/audit_integrity_status.py
@@ -26,6 +26,20 @@ async def run(ctx) -> dict[str, Any]:
             "FROM pb_verify_audit_chain_tail($1)",
             tail_rows,
         )
+        summary = {
+            "valid":            row["valid"],
+            "total_checked":    row["total_checked"],
+            "first_invalid_id": row["first_invalid_id"],
+            "tail_rows":        tail_rows,
+        }
+        # Log the verify result BEFORE the UPSERT so operators retain
+        # visibility even if the cache table is missing or write-broken
+        # (e.g. mid-rollback, BYPASSRLS misconfig). See issue #102.
+        if not row["valid"]:
+            log.error("audit chain invalid: %s", summary)
+        else:
+            log.info("audit chain verified: %s", summary)
+
         await ctx.pg_pool.execute(
             """
             INSERT INTO audit_integrity_status (
@@ -47,16 +61,6 @@ async def run(ctx) -> dict[str, Any]:
             row["first_invalid_id"],
             row["last_valid_hash"],
         )
-        summary = {
-            "valid":            row["valid"],
-            "total_checked":    row["total_checked"],
-            "first_invalid_id": row["first_invalid_id"],
-            "tail_rows":        tail_rows,
-        }
-        if not row["valid"]:
-            log.error("audit chain invalid! cached: %s", summary)
-        else:
-            log.info("audit_integrity_status refresh: %s", summary)
         return summary
     except Exception as e:
         log.exception("audit_integrity_status refresh failed: %s", e)

--- a/worker/tests/test_jobs.py
+++ b/worker/tests/test_jobs.py
@@ -174,6 +174,29 @@ class TestAuditIntegrityStatus:
         with pytest.raises(RuntimeError, match="primary failure"):
             await audit_integrity_status.run(ctx)
 
+    async def test_verify_logged_before_upsert_failure(self, caplog):
+        """When verify SUCCEEDED but the cache UPSERT fails (e.g. table
+        missing during partial migration), the verify result must still
+        appear in operator logs. See issue #102."""
+        import logging
+        ctx = _ctx()
+        ctx.pg_pool.fetchrow.return_value = self._verify_row(
+            valid=True, total=42,
+        )
+        # Simulate "relation audit_integrity_status does not exist"
+        ctx.pg_pool.execute.side_effect = RuntimeError(
+            'relation "audit_integrity_status" does not exist'
+        )
+        with caplog.at_level(logging.INFO,
+                             logger="pb-worker.audit_integrity_status"):
+            with pytest.raises(RuntimeError, match="does not exist"):
+                await audit_integrity_status.run(ctx)
+        # The verify result must be in the log before the failure
+        verified = [r for r in caplog.records
+                    if "audit chain verified" in r.message]
+        assert verified, "verify result should be logged before UPSERT"
+        assert "'total_checked': 42" in verified[0].message
+
 
 # ── pending_review_timeout ─────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two small follow-ups from the v0.8.0 review.

- **[#102](https://github.com/nuetzliches/powerbrain/issues/102)** — audit-worker now logs the verify summary at INFO/ERROR **before** the cache UPSERT, so operators retain visibility even when the cache table is missing or write-broken (e.g. mid-rollback, BYPASSRLS misconfig). Previously the verify result was silently lost in those edge cases.
- **[#104](https://github.com/nuetzliches/powerbrain/issues/104)** — `_transparency_audit_snapshot()` now returns `total_checked: null` (not `0`) when the worker cache is empty, so consumers can distinguish "no check has run" from "checked, found 0 entries". The Annex IV renderer maps that to "unknown" instead of the literal "None"/"0".

Both are pure logging / JSON-contract fixes — no schema or behavior changes.

## Files

| File | Change |
|---|---|
| [worker/jobs/audit_integrity_status.py](worker/jobs/audit_integrity_status.py) | Move log.info / log.error of verify summary before the UPSERT |
| [mcp-server/server.py](mcp-server/server.py) (`_transparency_audit_snapshot`) | `total_checked: 0` → `None` on stale-cache branch |
| [mcp-server/compliance_doc.py](mcp-server/compliance_doc.py) (`_render_section_3_monitoring`) | Render `None` as `"unknown"` |
| [worker/tests/test_jobs.py](worker/tests/test_jobs.py) | New test: `test_verify_logged_before_upsert_failure` |
| [mcp-server/tests/test_transparency.py](mcp-server/tests/test_transparency.py) | Assert `total_checked is None` on stale snapshot |
| [mcp-server/tests/test_compliance_doc.py](mcp-server/tests/test_compliance_doc.py) | New test: `test_section_3_renders_stale_audit_as_unknown` |

## Test plan
- [x] Targeted tests pass (24 / 24): `worker/tests/test_jobs.py::TestAuditIntegrityStatus`, `mcp-server/tests/test_transparency.py::TestAuditIntegritySnapshot`, `mcp-server/tests/test_compliance_doc.py::TestRenderDoc`
- [x] Full CI command passes locally: 1065 passed, 0 failed, 69.7% coverage (>68% threshold)
- [x] No OPA / Rego changes (audit-worker is Python-only)

Closes #102, closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)