### PR TITLE
docs+tests(audit): document BYPASSRLS dependency + cover worker writes

### DIFF
--- a/init-db/022_audit_tail_pointer.sql
+++ b/init-db/022_audit_tail_pointer.sql
@@ -61,6 +61,11 @@ ON CONFLICT (id) DO NOTHING;
 
 -- RLS: only the audit trigger function (SECURITY DEFINER) writes here.
 -- mcp_auditor may read for transparency; nothing else may touch it.
+-- Note: trigger-driven UPDATEs from pb_audit_hashchain_trigger() bypass
+-- RLS because the function is SECURITY DEFINER, owned by pb_admin
+-- (SUPERUSER → BYPASSRLS). pb_audit_checkpoint_and_prune() relies on
+-- the same chain. Running the trigger function under a non-superuser
+-- owner would require an explicit policy. See issue #103.
 ALTER TABLE audit_tail ENABLE ROW LEVEL SECURITY;
 ALTER TABLE audit_tail FORCE ROW LEVEL SECURITY;
 

--- a/init-db/024_audit_integrity_status.sql
+++ b/init-db/024_audit_integrity_status.sql
@@ -44,6 +44,14 @@ COMMENT ON COLUMN audit_integrity_status.checked_at       IS 'Timestamp at which
 COMMENT ON COLUMN audit_integrity_status.error            IS 'Last refresh-error message (truncated to 500 chars), NULL on success.';
 
 -- RLS: only the worker (DB owner / superuser) writes; mcp_auditor reads.
+-- Note: there is NO INSERT/UPDATE policy. Writes succeed only via
+-- BYPASSRLS, which `pb_admin` inherits as SUPERUSER (default in the
+-- pb-postgres image). If the deployment runs the worker as a
+-- non-superuser role (e.g. a future least-privilege `pb_worker`),
+-- the audit_integrity_status_refresh job will silently fail and the
+-- transparency snapshot will degrade to `stale: true`. In that case
+-- add an explicit `CREATE POLICY ... FOR INSERT, UPDATE TO pb_worker
+-- USING (true) WITH CHECK (true)`. See issue #103.
 ALTER TABLE audit_integrity_status ENABLE ROW LEVEL SECURITY;
 ALTER TABLE audit_integrity_status FORCE ROW LEVEL SECURITY;
 

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -724,3 +724,102 @@ class TestForceReset:
         assert await live_pool.fetchval(
             "SELECT COUNT(*) FROM audit_archive"
         ) == 1
+
+
+@pytest.mark.skipif(not _PG_INTEGRATION,
+                    reason="set PG_INTEGRATION=1 to run live PG tests")
+class TestAuditIntegrityStatusLive:
+    """Live tests for the audit_integrity_status worker cache (#105).
+
+    Mocks in worker/tests/test_jobs.py cover the job logic. These tests
+    cover the parts that mocks cannot:
+    - The worker's DB role (pb_admin) can actually UPSERT despite
+      FORCE ROW LEVEL SECURITY (relies on BYPASSRLS — see #103).
+    - The mcp_auditor role can SELECT via the read-only policy created
+      in migration 024.
+    """
+
+    @pytest.fixture
+    async def live_pool(self):
+        import asyncpg
+        url = _os.environ.get(
+            "POSTGRES_URL",
+            "postgresql://pb_admin:pb_admin@localhost:5432/powerbrain",
+        )
+        pool = await asyncpg.create_pool(url, min_size=1, max_size=2)
+        # Reset the cache row so each test starts from a clean state
+        await pool.execute("DELETE FROM audit_integrity_status")
+        yield pool
+        await pool.execute("DELETE FROM audit_integrity_status")
+        await pool.close()
+
+    async def test_worker_can_upsert(self, live_pool):
+        """The worker job runs end-to-end: pb_verify_audit_chain_tail()
+        produces a row, the UPSERT writes it to audit_integrity_status,
+        and a SELECT recovers it. Without BYPASSRLS this would fail
+        silently because the table has no INSERT policy."""
+        # Run the worker job. We import lazily so PG_INTEGRATION=0
+        # collection still works without `apscheduler` etc. installed.
+        import sys
+        from types import SimpleNamespace
+        sys.path.insert(0, str(_os.path.join(
+            _os.path.dirname(__file__), "..", "..")))
+        from worker.jobs import audit_integrity_status as job
+
+        ctx = SimpleNamespace(
+            pg_pool=live_pool,
+            audit_status_tail_rows=1000,
+        )
+        summary = await job.run(ctx)
+        assert summary["valid"] in (True, False)  # depends on chain state
+        assert summary["tail_rows"] == 1000
+
+        # Cache row exists with the same data
+        row = await live_pool.fetchrow(
+            "SELECT valid, total_checked, checked_at, error "
+            "FROM audit_integrity_status WHERE id = 1"
+        )
+        assert row is not None
+        assert row["valid"] == summary["valid"]
+        assert row["total_checked"] == summary["total_checked"]
+        assert row["checked_at"] is not None
+        assert row["error"] is None
+
+    async def test_mcp_auditor_can_select(self, live_pool):
+        """mcp_auditor must be able to read via the read-only policy.
+        We can't LOGIN as mcp_auditor (NOLOGIN role), so the test uses
+        SET ROLE inside a transaction to assume the role's privileges."""
+        # Seed a row first (as pb_admin / superuser, BYPASSRLS)
+        await live_pool.execute(
+            """
+            INSERT INTO audit_integrity_status (
+                id, valid, total_checked, checked_at, updated_at
+            )
+            VALUES (1, TRUE, 7, now(), now())
+            ON CONFLICT (id) DO UPDATE SET
+                valid = EXCLUDED.valid,
+                total_checked = EXCLUDED.total_checked,
+                updated_at = now()
+            """
+        )
+
+        async with live_pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("SET LOCAL ROLE mcp_auditor")
+                row = await conn.fetchrow(
+                    "SELECT valid, total_checked "
+                    "FROM audit_integrity_status WHERE id = 1"
+                )
+                assert row is not None
+                assert row["valid"] is True
+                assert row["total_checked"] == 7
+
+                # Negative: mcp_auditor must NOT be able to write —
+                # both the explicit GRANT (only SELECT) and the missing
+                # INSERT policy would block this.
+                import asyncpg
+                with pytest.raises(asyncpg.PostgresError):
+                    await conn.execute(
+                        "UPDATE audit_integrity_status SET valid = FALSE "
+                        "WHERE id = 1"
+                    )


### PR DESCRIPTION
## Summary

- **[#103](https://github.com/nuetzliches/powerbrain/issues/103)** — Documents the BYPASSRLS dependency on `audit_tail` and `audit_integrity_status` writes. Adds inline comments at the `FORCE ROW LEVEL SECURITY` lines explaining that writes succeed only because `pb_admin` is `SUPERUSER` by default; non-superuser worker setups need an explicit INSERT/UPDATE policy.
- **[#105](https://github.com/nuetzliches/powerbrain/issues/105)** — Adds live PG coverage for the `audit_integrity_status_refresh` worker writes. Two new tests under `PG_INTEGRATION=1`:
  - `test_worker_can_upsert` — runs the worker job end-to-end and asserts the cache row is written. Catches future regressions if the worker role loses BYPASSRLS.
  - `test_mcp_auditor_can_select` — verifies the read-only policy works for `mcp_auditor` (via `SET LOCAL ROLE` since the role is `NOLOGIN`) and the role cannot write.

## Files

| File | Change |
|---|---|
| [init-db/022_audit_tail_pointer.sql](init-db/022_audit_tail_pointer.sql) | Comment at FORCE ROW LEVEL SECURITY explaining SECURITY DEFINER + superuser dependency |
| [init-db/024_audit_integrity_status.sql](init-db/024_audit_integrity_status.sql) | Comment at FORCE ROW LEVEL SECURITY explaining BYPASSRLS dependency for the worker UPSERT |
| [mcp-server/tests/test_audit_integrity.py](mcp-server/tests/test_audit_integrity.py) | New `TestAuditIntegrityStatusLive` class with 2 live tests (PG_INTEGRATION=1 gated) |

## Test plan
- [x] Existing unit suite passes: 1063 passed, 18 skipped, 69.69% coverage (>68% threshold)
- [x] New live tests pass against a live `pb-postgres` with migrations 022 + 024 applied
  - Verified via `docker compose up -d postgres` + targeted `PG_INTEGRATION=1` run → 2 passed
- [x] No code changes — only SQL comments + new gated tests; no risk to runtime behavior

Closes #103, closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)