### PR TITLE
feat(audit): record force-reset provenance in chain + archive (#101)

### DIFF
--- a/docs/audit-chain-migration.md
+++ b/docs/audit-chain-migration.md
@@ -71,12 +71,25 @@ SELECT * FROM pb_audit_force_reset('continuity');
 
 -- Full genesis (also wipes archive)
 SELECT * FROM pb_audit_force_reset('genesis');
+
+-- With operator-supplied purpose for forensic provenance (#101, migration 026+)
+SELECT * FROM pb_audit_force_reset('continuity', 'CI fixture cleanup');
 ```
 
 Each call returns `archived_rows`, `archived_hash`, `new_tail_hash`
 so the operator can confirm what was archived and what the next
 chain anchors to. The default mode is `continuity` — calling
 `pb_audit_force_reset()` without arguments preserves the archive.
+
+From migration 026 onward, the function also writes a self-record
+into `agent_access_log` **before** the truncate, so the forced reset
+is captured in the cryptographic chain that gets archived (continuity
+mode) or appears briefly in Postgres statement logs (genesis mode).
+`audit_archive.reset_caller` and `audit_archive.reset_purpose`
+columns capture the operator context. As a result, `archived_rows`
+includes the self-record (typically `+1` over the previous behavior),
+and `archived_hash` points to the self-record's `entry_hash` — the
+correct cryptographic snapshot of the archived chain.
 
 If your deployment is on migration 024 or earlier, fall back to the
 manual procedures below.

--- a/init-db/026_audit_force_reset_provenance.sql
+++ b/init-db/026_audit_force_reset_provenance.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- 026_audit_force_reset_provenance.sql — Forensic provenance for
+-- pb_audit_force_reset() (#101).
+-- ============================================================
+-- Migration 025 introduced pb_audit_force_reset() but left no
+-- in-chain record of who called it. The audit_archive row marker
+-- captured chain_valid=false and the previous tail hash, but neither
+-- the caller's identity nor the operator's purpose. For a function
+-- deliberately named force_reset, that gap is unhelpful: when CI
+-- flakes find a chain break, the first question is "did the test
+-- fixture reset the chain — and why?".
+--
+-- This migration applies BOTH mitigations from the issue's option
+-- list (#101 "belt and suspenders"):
+--
+--   1. Extend `audit_archive` with `reset_caller` (defaults to
+--      current_user, populated by the function) and `reset_purpose`
+--      (operator-supplied free-text). Survives in continuity mode;
+--      lost in genesis (audit_archive is truncated by design).
+--
+--   2. Write a self-record into `agent_access_log` BEFORE the
+--      TRUNCATE so the reset action is captured in the cryptographic
+--      chain that is about to be archived. The hash chain trigger
+--      links it to the previous tail, so a forensic audit can detect
+--      tampering on the historical reset record itself.
+--      In continuity mode the self-record is part of audit_archive's
+--      row_count + last_verified_hash (the chain ends at the
+--      self-record). In genesis mode the archive is then deleted, but
+--      Postgres statement logs still record the function call.
+--
+-- The function signature gains an optional `p_purpose TEXT` parameter
+-- that defaults to NULL. Existing callers (`pb_audit_force_reset()`,
+-- `pb_audit_force_reset('continuity')`, `pb_audit_force_reset('genesis')`)
+-- keep working unchanged.
+--
+-- Behavior change visible to callers: `archived_rows` now includes the
+-- self-record (typically +1 over the previous behavior), and
+-- `archived_hash` / audit_archive.last_verified_hash now point to the
+-- self-record's entry_hash instead of the pre-call tail. This is the
+-- correct cryptographic value for the archive snapshot — anyone
+-- replaying pb_verify_audit_chain over the archive will arrive at the
+-- self-record's hash. Live PG tests in
+-- mcp-server/tests/test_audit_integrity.py have been updated to match.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- 1. Extend audit_archive with provenance columns
+-- ------------------------------------------------------------
+ALTER TABLE audit_archive
+    ADD COLUMN IF NOT EXISTS reset_caller  TEXT,
+    ADD COLUMN IF NOT EXISTS reset_purpose TEXT;
+
+COMMENT ON COLUMN audit_archive.reset_caller  IS
+    'DB role that called pb_audit_force_reset(). NULL for archive rows produced by retention pruning.';
+COMMENT ON COLUMN audit_archive.reset_purpose IS
+    'Operator-supplied purpose passed to pb_audit_force_reset(p_purpose). NULL when no purpose was given.';
+
+-- ------------------------------------------------------------
+-- 2. Replace the function with the new two-arg signature
+-- ------------------------------------------------------------
+-- Drop the migration 025 single-arg version explicitly so we replace
+-- it cleanly. The new function has all-default args, so existing
+-- zero-arg and one-arg callers keep working without changes.
+DROP FUNCTION IF EXISTS pb_audit_force_reset(TEXT);
+
+CREATE OR REPLACE FUNCTION pb_audit_force_reset(
+    p_mode    TEXT DEFAULT 'continuity',  -- 'continuity' | 'genesis'
+    p_purpose TEXT DEFAULT NULL           -- operator-supplied reason
+) RETURNS TABLE(
+    archived_rows BIGINT,
+    archived_hash BYTEA,
+    new_tail_hash BYTEA
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_tail_hash BYTEA;
+    v_tail_id   BIGINT;
+    v_count     BIGINT;
+    v_caller    TEXT  := current_user;
+    v_genesis   BYTEA := '\x0000000000000000000000000000000000000000000000000000000000000000'::BYTEA;
+BEGIN
+    IF p_mode NOT IN ('continuity', 'genesis') THEN
+        RAISE EXCEPTION 'p_mode must be ''continuity'' or ''genesis'', got %', p_mode;
+    END IF;
+
+    -- 1. Insert self-record BEFORE the lock + truncate so the action
+    --    is captured in the cryptographic chain. The hash-chain trigger
+    --    will link it to the current tail, take + release the
+    --    audit_tail row lock, and advance the tail to the self-record's
+    --    entry_hash. The whole call is one transaction, so the
+    --    re-acquired lock below sees the self-record's hash.
+    INSERT INTO agent_access_log (
+        agent_id, agent_role, resource_type, resource_id,
+        action, policy_result, policy_reason,
+        purpose, request_context
+    ) VALUES (
+        v_caller,                     -- agent_id: who called force_reset
+        'admin',                      -- agent_role
+        'audit_chain',                -- resource_type
+        'force_reset',                -- resource_id
+        'force_reset',                -- action
+        'allow',                      -- policy_result
+        'pb_audit_force_reset',       -- policy_reason
+        p_purpose,                    -- purpose
+        jsonb_build_object('mode', p_mode)
+    );
+
+    -- 2. Re-acquire the row lock (no-op within the transaction, but
+    --    explicit for symmetry with migration 025).
+    SELECT last_entry_hash, last_entry_id INTO v_tail_hash, v_tail_id
+        FROM audit_tail WHERE id = 1 FOR UPDATE;
+
+    IF v_tail_hash IS NULL THEN
+        RAISE EXCEPTION 'audit_tail row missing — init-db/022 not applied';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count FROM agent_access_log;
+
+    -- 3. Archive the chain (now ending at the self-record).
+    --    chain_valid stays FALSE because this is a forced reset, not
+    --    a clean retention checkpoint. reset_caller / reset_purpose
+    --    capture the operator context.
+    INSERT INTO audit_archive(
+        archived_at, last_entry_id, last_verified_hash,
+        row_count, chain_valid, first_invalid_id, retention_cutoff,
+        reset_caller, reset_purpose
+    ) VALUES (
+        now(), v_tail_id, v_tail_hash,
+        v_count, FALSE, NULL, now(),
+        v_caller, p_purpose
+    );
+
+    -- 4. Truncate the live log (every mode).
+    --    RESTART IDENTITY also resets the BIGSERIAL sequence so the
+    --    next id starts from 1 again.
+    TRUNCATE agent_access_log RESTART IDENTITY;
+
+    IF p_mode = 'continuity' THEN
+        -- New chain continues from the self-record's hash. Anyone
+        -- walking pb_verify_audit_chain over the archive arrives at
+        -- v_tail_hash; the next live insert chains from v_tail_hash;
+        -- the migration 023 seed check passes.
+        UPDATE audit_tail
+            SET last_entry_hash = v_tail_hash,
+                last_entry_id   = 0,
+                updated_at      = now()
+            WHERE id = 1;
+        RETURN QUERY SELECT v_count, v_tail_hash, v_tail_hash;
+    ELSE
+        -- genesis: also clear the archive and reset tail to zero hash.
+        -- The reset_caller / reset_purpose columns are lost here by
+        -- design; the only forensic trace is in Postgres statement
+        -- logs (which capture every superuser-level function call).
+        DELETE FROM audit_archive;
+        UPDATE audit_tail
+            SET last_entry_hash = v_genesis,
+                last_entry_id   = 0,
+                updated_at      = now()
+            WHERE id = 1;
+        RETURN QUERY SELECT v_count, v_tail_hash, v_genesis;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION pb_audit_force_reset(TEXT, TEXT) IS
+    'TEST/STAGING ONLY. Atomically resets the audit chain. p_mode=continuity preserves audit_archive (new chain cross-links to archived hash via the migration 023 seed check). p_mode=genesis additionally truncates audit_archive and reseeds audit_tail to 32 zero bytes. p_purpose is recorded into audit_archive.reset_purpose and the in-chain self-record (#101). No production-environment guard yet — see #97 follow-up. EXECUTE granted to DB owner / superuser only.';
+
+REVOKE EXECUTE ON FUNCTION pb_audit_force_reset(TEXT, TEXT) FROM PUBLIC;

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -633,31 +633,41 @@ class TestForceReset:
 
     async def test_force_reset_continuity(self, live_pool):
         """Continuity preserves the archive and seeds the new chain
-        with the old tail hash. The next insert chains correctly,
-        verifier returns valid=true."""
-        old_tail = await self._seed_rows(live_pool, 3)
+        with the post-self-record tail hash (#101). The next insert
+        chains correctly, verifier returns valid=true."""
+        await self._seed_rows(live_pool, 3)
 
         result = await live_pool.fetchrow(
             "SELECT * FROM pb_audit_force_reset('continuity')"
         )
-        assert result["archived_rows"] == 3
-        assert result["archived_hash"] == old_tail
-        assert result["new_tail_hash"] == old_tail
+        # Self-record adds 1 to the chain before archival (#101). The
+        # archived chain therefore has 3 user rows + 1 marker = 4.
+        assert result["archived_rows"] == 4
+        # archived_hash is the post-self-record tail (the cryptographic
+        # snapshot at archive time). It is no longer equal to the
+        # pre-call tail.
+        new_tail = result["archived_hash"]
+        assert result["new_tail_hash"] == new_tail
 
         # Live log empty
         assert await live_pool.fetchval("SELECT COUNT(*) FROM agent_access_log") == 0
-        # Archive has exactly one row with chain_valid=false, row_count=3
+        # Archive has exactly one row with chain_valid=false, row_count=4
         archive_rows = await live_pool.fetch(
-            "SELECT row_count, chain_valid FROM audit_archive"
+            "SELECT row_count, chain_valid, reset_caller, reset_purpose "
+            "FROM audit_archive"
         )
         assert len(archive_rows) == 1
-        assert archive_rows[0]["row_count"] == 3
+        assert archive_rows[0]["row_count"] == 4
         assert archive_rows[0]["chain_valid"] is False
-        # Tail seeded from old hash
+        # Provenance columns populated (#101)
+        assert archive_rows[0]["reset_caller"] is not None
+        # No purpose passed to the zero/one-arg form → NULL
+        assert archive_rows[0]["reset_purpose"] is None
+        # Tail seeded from post-self-record hash
         tail = await live_pool.fetchrow(
             "SELECT last_entry_hash, last_entry_id FROM audit_tail WHERE id = 1"
         )
-        assert tail["last_entry_hash"] == old_tail
+        assert tail["last_entry_hash"] == new_tail
         assert tail["last_entry_id"] == 0
 
         # Follow-up insert chains correctly via the trigger
@@ -665,7 +675,7 @@ class TestForceReset:
         new_row = await live_pool.fetchrow(
             "SELECT prev_hash FROM agent_access_log ORDER BY id DESC LIMIT 1"
         )
-        assert new_row["prev_hash"] == old_tail
+        assert new_row["prev_hash"] == new_tail
 
         # Verifier should walk through cleanly
         v = await live_pool.fetchrow("SELECT * FROM pb_verify_audit_chain()")
@@ -673,17 +683,21 @@ class TestForceReset:
 
     async def test_force_reset_genesis(self, live_pool):
         """Genesis truncates the archive and resets the tail to 32
-        zero bytes. Next insert chains from genesis."""
-        old_tail = await self._seed_rows(live_pool, 3)
+        zero bytes. Next insert chains from genesis. The self-record
+        provenance is lost in this mode by design (#101)."""
+        await self._seed_rows(live_pool, 3)
 
         result = await live_pool.fetchrow(
-            "SELECT * FROM pb_audit_force_reset('genesis')"
+            "SELECT * FROM pb_audit_force_reset('genesis', 'pytest-genesis')"
         )
-        assert result["archived_rows"] == 3
-        assert result["archived_hash"] == old_tail
+        # Self-record bumps row_count to 4 (#101)
+        assert result["archived_rows"] == 4
+        # archived_hash is the post-self-record tail
+        assert result["archived_hash"] != b"\x00" * 32
         assert result["new_tail_hash"] == b"\x00" * 32
 
-        # Both tables empty
+        # Both tables empty — genesis discards the archive (and with it
+        # the reset_caller / reset_purpose columns; #101)
         assert await live_pool.fetchval("SELECT COUNT(*) FROM agent_access_log") == 0
         assert await live_pool.fetchval("SELECT COUNT(*) FROM audit_archive") == 0
         # Tail at genesis
@@ -719,23 +733,67 @@ class TestForceReset:
         result = await live_pool.fetchrow(
             "SELECT * FROM pb_audit_force_reset()"
         )
-        assert result["archived_rows"] == 2
+        # 2 user rows + 1 self-record (#101)
+        assert result["archived_rows"] == 3
         # Continuity preserves the archive
         assert await live_pool.fetchval(
             "SELECT COUNT(*) FROM audit_archive"
         ) == 1
 
     async def test_force_reset_on_empty_log(self, live_pool):
-        """Calling on an already-empty log is idempotent — archive entry
-        records row_count=0 with the current tail hash."""
+        """Calling on an already-empty log is no longer a true no-op
+        because the function now writes a self-record into the chain
+        before the truncate (#101). The archive marker therefore
+        records row_count=1 (the self-record alone)."""
         result = await live_pool.fetchrow(
             "SELECT * FROM pb_audit_force_reset('continuity')"
         )
-        assert result["archived_rows"] == 0
+        # Self-record alone (#101)
+        assert result["archived_rows"] == 1
         # Archive still gets a marker entry
         assert await live_pool.fetchval(
             "SELECT COUNT(*) FROM audit_archive"
         ) == 1
+
+    async def test_force_reset_records_purpose_in_archive(self, live_pool):
+        """The new p_purpose argument is stored in audit_archive
+        alongside the caller (#101). Continuity mode preserves both."""
+        await self._seed_rows(live_pool, 2)
+        await live_pool.fetchrow(
+            "SELECT * FROM pb_audit_force_reset("
+            "'continuity', 'CI fixture cleanup')"
+        )
+        archive = await live_pool.fetchrow(
+            "SELECT reset_caller, reset_purpose FROM audit_archive"
+        )
+        # current_user is whatever the test connects as (typically
+        # pb_admin); we just assert it was captured.
+        assert archive["reset_caller"] is not None
+        assert len(archive["reset_caller"]) > 0
+        assert archive["reset_purpose"] == "CI fixture cleanup"
+
+    async def test_force_reset_self_record_in_archived_chain(self, live_pool):
+        """The self-record written before the truncate is part of the
+        cryptographic chain that gets archived (#101). row_count
+        confirms it; the archive's last_verified_hash is the
+        self-record's entry_hash."""
+        # Empty log start, so any rows in the archived chain come from
+        # the function itself.
+        result = await live_pool.fetchrow(
+            "SELECT * FROM pb_audit_force_reset("
+            "'continuity', 'pytest-self-record-check')"
+        )
+        archive = await live_pool.fetchrow(
+            "SELECT row_count, last_verified_hash, reset_purpose "
+            "FROM audit_archive"
+        )
+        assert archive["row_count"] == 1
+        # last_verified_hash matches the function's reported
+        # archived_hash (the self-record's hash)
+        assert archive["last_verified_hash"] == result["archived_hash"]
+        # And it's not the genesis hash
+        assert archive["last_verified_hash"] != b"\x00" * 32
+        assert archive["reset_purpose"] == "pytest-self-record-check"
 
 
 @pytest.mark.skipif(not _PG_INTEGRATION,


### PR DESCRIPTION
## Summary

`pb_audit_force_reset()` previously left no in-chain record of who called it. The `audit_archive` marker captured `chain_valid=false` and the previous tail hash, but neither caller identity nor operator purpose. This PR applies **both** mitigations from the issue's option list (\"belt and suspenders\"):

1. **`audit_archive` gains `reset_caller` + `reset_purpose` columns** (populated from `current_user` and a new `p_purpose` argument). Survives in continuity mode; lost in genesis by design.
2. **A self-record is written to `agent_access_log` before the TRUNCATE**, so the reset action is captured in the cryptographic chain that's about to be archived. In continuity mode the self-record is part of `audit_archive.last_verified_hash` + `row_count`. In genesis mode the chain is then truncated, but Postgres statement logs still record the function call.

Function signature gains an optional `p_purpose TEXT` parameter that defaults to NULL. Existing callers keep working unchanged.

## Behavior change visible to callers

| Field | Before | After |
|---|---|---|
| `archived_rows` | user-row count | user-row count + 1 (self-record) |
| `archived_hash` | pre-call tail | post-self-record tail (cryptographic snapshot at archive time) |
| `audit_archive.last_verified_hash` | pre-call tail | post-self-record tail |
| `audit_archive.reset_caller` | (column missing) | `current_user` |
| `audit_archive.reset_purpose` | (column missing) | passed-in `p_purpose` |

## Files

| File | Change |
|---|---|
| [init-db/026_audit_force_reset_provenance.sql](init-db/026_audit_force_reset_provenance.sql) | New migration: ALTER audit_archive + replace function with new signature + self-record insert |
| [mcp-server/tests/test_audit_integrity.py](mcp-server/tests/test_audit_integrity.py) | Updated `TestForceReset` tests for new behavior; 2 new tests covering provenance columns + in-chain self-record |
| [docs/audit-chain-migration.md](docs/audit-chain-migration.md) | Document new signature, p_purpose argument, in-chain self-record |

## Test plan
- [x] Existing unit suite passes: 1063 passed, 18 skipped, 69.69% coverage (>68% threshold)
- [x] Live tests pass against fresh pb-postgres with all migrations applied (incl. 026):
  - 7 / 7 in `TestForceReset` (5 updated + 2 new)
- [x] No production code uses `pb_audit_force_reset()` — only tests and docs (verified via grep)

## Migration impact

Function signature evolves from `pb_audit_force_reset(p_mode TEXT DEFAULT 'continuity')` to `pb_audit_force_reset(p_mode TEXT DEFAULT 'continuity', p_purpose TEXT DEFAULT NULL)`. The migration explicitly drops the old single-arg version before creating the new two-arg version. Zero-arg and single-arg callers keep working via the default `p_purpose=NULL`.

## Notes for reviewers

- During verification, the pre-existing `TestHashChainLive` fixture was found to have a state-pollution bug (audit_tail not reset between tests). It's gated behind `PG_INTEGRATION=1` and unrelated to this change — flagged separately in [\`docs/spawn-task-pending\`].
- The self-record uses `'force_reset'` as both `action` and `resource_id`, with `request_context = jsonb_build_object('mode', p_mode)`. This is enough to identify the event in any future export.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)