### PR TITLE
feat(security): fail-closed boot check for INGESTION_AUTH_TOKEN (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠ BREAKING CHANGES
+
+- **Ingestion auth fail-closed**
+  ([#126](https://github.com/nuetzliches/powerbrain/issues/126)).
+  `INGESTION_AUTH_TOKEN` no longer falls back to allow-all when empty.
+  With the default `AUTH_REQUIRED=true`, **mcp-server, pb-proxy,
+  ingestion, and pb-worker now refuse to start** if the token is
+  missing — surfacing the silent-degradation mode introduced in
+  v0.8.0 (B-50, [PR #89](https://github.com/nuetzliches/powerbrain/pull/89))
+  as a hard boot failure instead. Mirrors the OPA hardening from
+  v0.7.1 ([PR #62](https://github.com/nuetzliches/powerbrain/pull/62))
+  and the same `SKIP_*_STARTUP_CHECK` opt-out pattern.
+
+  **Migration:** existing deployments that already provisioned
+  `secrets/ingestion_auth_token.txt` (or set the env var) need no
+  changes. Deployments mid-rollout with an empty token must either
+  set the token, or explicitly set `AUTH_REQUIRED=false` (test/dev
+  only — disables ALL auth layers, not only ingestion). Unit-test
+  rigs can set `SKIP_INGESTION_AUTH_STARTUP_CHECK=true`; the standard
+  `conftest.py` fixtures already do.
+
+  New observability: `pb_ingestion_auth_enabled{service=...}` Prometheus
+  gauge reports the boot-time decision per service so dashboards can
+  alert on degraded mode regardless of how the service started.
+
 ## [0.8.0] - 2026-04-30
 
 Audit-chain hardening on top of the 0.7.x summarization-pool +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Closes the audit-review backlog filed against v0.8.0
+(#101–#105) plus a follow-up security hardening for ingestion auth
+(#126).
+
 ### ⚠ BREAKING CHANGES
 
 - **Ingestion auth fail-closed**
@@ -28,9 +32,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rigs can set `SKIP_INGESTION_AUTH_STARTUP_CHECK=true`; the standard
   `conftest.py` fixtures already do.
 
-  New observability: `pb_ingestion_auth_enabled{service=...}` Prometheus
-  gauge reports the boot-time decision per service so dashboards can
-  alert on degraded mode regardless of how the service started.
+- **`pb_audit_force_reset()` signature gains an optional `p_purpose`
+  argument and behavior changes**
+  ([#101](https://github.com/nuetzliches/powerbrain/issues/101)).
+  The function now writes a self-record into `agent_access_log`
+  before the truncate so the reset action is captured in the
+  cryptographic chain that's about to be archived. As a result,
+  `archived_rows` includes the self-record (typically `+1` over the
+  previous behavior), and `archived_hash` /
+  `audit_archive.last_verified_hash` point to the self-record's
+  `entry_hash` (the correct cryptographic snapshot of the archived
+  chain) instead of the pre-call tail. Existing zero-arg and
+  one-arg callers continue to work via the new default
+  `p_purpose=NULL`. Test/staging tooling that asserted on
+  `archived_rows` / `archived_hash` literals must update; the
+  bundled live tests show the pattern.
+
+### Added
+
+- **`audit_archive.reset_caller` + `reset_purpose` columns**
+  ([#101](https://github.com/nuetzliches/powerbrain/issues/101),
+  migration `026_audit_force_reset_provenance.sql`). Captures the DB
+  role that issued `pb_audit_force_reset()` and the operator-supplied
+  reason. Survives in continuity mode; lost in genesis (audit_archive
+  is truncated by design, but Postgres statement logs still record the
+  function call).
+- **`pb_ingestion_auth_enabled{service=...}` Prometheus gauge**
+  ([#126](https://github.com/nuetzliches/powerbrain/issues/126)).
+  Reports the boot-time decision per service (`1`=token configured,
+  `0`=disabled or skipped) so dashboards can alert on degraded mode
+  regardless of how the service started.
+- **Live PG coverage for the audit_integrity_status worker writes**
+  ([#105](https://github.com/nuetzliches/powerbrain/issues/105)).
+  New `TestAuditIntegrityStatusLive` class in
+  `mcp-server/tests/test_audit_integrity.py` (`PG_INTEGRATION=1`
+  gated). Catches future regressions if the worker role loses the
+  BYPASSRLS that today makes the UPSERT through `FORCE ROW LEVEL
+  SECURITY` work.
+
+### Fixed
+
+- **Audit-worker logs verify result before the cache UPSERT**
+  ([#102](https://github.com/nuetzliches/powerbrain/issues/102)).
+  When migration 024 hadn't been applied yet (mid-rollback or partial
+  setup), the verify result was silently lost: the primary
+  `pb_verify_audit_chain_tail()` call succeeded, but the UPSERT into
+  the missing `audit_integrity_status` table raised, and the
+  exception handler tried the same UPSERT and also failed. Operators
+  now see `audit chain verified: {…}` at INFO level (or
+  `audit chain invalid: {…}` at ERROR) before the persistence attempt.
+- **Transparency snapshot returns `total_checked: null` when the
+  cache is stale** ([#104](https://github.com/nuetzliches/powerbrain/issues/104)).
+  Previously returned `0`, which the Annex IV renderer dutifully
+  formatted as `verified at last check: '0'` — misleading because no
+  check had run at all. The snapshot's `stale` flag is the primary
+  signal; `total_checked: null` is the JSON-idiomatic
+  "value unknown" so consumers can't accidentally read it as zero.
+  The compliance-doc renderer now displays `unknown` instead of
+  `None`/`0`.
+- **Test state pollution in `TestHashChainLive`**
+  ([PR #131](https://github.com/nuetzliches/powerbrain/pull/131)).
+  The `live_pool` fixture cleaned `agent_access_log` and
+  `audit_archive` between tests but not `audit_tail`, so a later
+  test's inserts chained from a stale tail and `pb_verify_audit_chain`
+  walked them as broken. Fixture now resets `audit_tail` to genesis
+  in both setup and teardown, mirroring `TestForceReset.live_pool`.
+  Latent bug; only visible under `PG_INTEGRATION=1`.
+
+### Documentation
+
+- **BYPASSRLS dependency on audit-chain writes**
+  ([#103](https://github.com/nuetzliches/powerbrain/issues/103)).
+  Inline comments in migrations 022 (`audit_tail`) and 024
+  (`audit_integrity_status`) explaining that writes succeed only via
+  BYPASSRLS — `pb_admin` is `SUPERUSER` by default in the
+  `pb-postgres` image. Deployments running the worker as a
+  non-superuser role need an explicit INSERT/UPDATE policy or the
+  `audit_integrity_status_refresh` job will silently fail and the
+  transparency snapshot will degrade to stale.
+- **`pb_audit_force_reset()` self-record + `p_purpose`**
+  in `docs/audit-chain-migration.md`. Documents the new optional
+  `p_purpose` argument and the implications of the in-chain
+  self-record on the function's return values.
 
 ## [0.8.0] - 2026-04-30
 

--- a/ingestion/ingestion_api.py
+++ b/ingestion/ingestion_api.py
@@ -80,6 +80,7 @@ from shared.opa_client import (
     opa_query,
     verify_required_policies,
 )
+from shared.ingestion_auth import verify_ingestion_auth_configured
 
 POSTGRES_URL = build_postgres_url()
 
@@ -226,6 +227,17 @@ app = FastAPI(title="Powerbrain Ingestion API", version="1.0.0")
 
 # ── Service-token auth (B-50, defense-in-depth on top of pb-net) ──
 INGESTION_AUTH_TOKEN = read_secret("INGESTION_AUTH_TOKEN", "")
+AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "true").lower() == "true"
+SKIP_INGESTION_AUTH_STARTUP_CHECK = (
+    os.getenv("SKIP_INGESTION_AUTH_STARTUP_CHECK", "false").lower() == "true"
+)
+# Fail-closed: refuse to start with empty token + AUTH_REQUIRED=true (#126).
+verify_ingestion_auth_configured(
+    INGESTION_AUTH_TOKEN,
+    auth_required=AUTH_REQUIRED,
+    skip_check=SKIP_INGESTION_AUTH_STARTUP_CHECK,
+    service_name="ingestion",
+)
 from auth_middleware import IngestionAuthMiddleware  # noqa: E402
 app.add_middleware(IngestionAuthMiddleware, expected_token=INGESTION_AUTH_TOKEN)
 

--- a/ingestion/tests/conftest.py
+++ b/ingestion/tests/conftest.py
@@ -14,6 +14,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 # otherwise fail during the lifespan event. Set the opt-out before the
 # app is imported anywhere in the test session.
 os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")
+# The ingestion-auth boot check (#126) refuses to import the app with
+# AUTH_REQUIRED=true (the default) and an empty INGESTION_AUTH_TOKEN.
+# Tests don't run a real ingestion service, so opt out at import time.
+os.environ.setdefault("SKIP_INGESTION_AUTH_STARTUP_CHECK", "true")
 
 
 @pytest.fixture

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -57,6 +57,7 @@ from shared.opa_client import (
     opa_query,
     verify_required_policies,
 )
+from shared.ingestion_auth import verify_ingestion_auth_configured
 from shared.telemetry import (
     init_telemetry, setup_auto_instrumentation, trace_operation,
     request_telemetry_context, get_current_telemetry,
@@ -82,6 +83,18 @@ INGESTION_URL = os.getenv("INGESTION_URL", "http://ingestion:8081")
 # B-50: defense-in-depth bearer for the ingestion service. Read once
 # at startup (Docker Secret /run/secrets/ingestion_auth_token).
 INGESTION_AUTH_TOKEN = read_secret("INGESTION_AUTH_TOKEN", "")
+AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "true").lower() == "true"
+SKIP_INGESTION_AUTH_STARTUP_CHECK = (
+    os.getenv("SKIP_INGESTION_AUTH_STARTUP_CHECK", "false").lower() == "true"
+)
+# Fail-closed: refuse to start with empty token + AUTH_REQUIRED=true (#126).
+verify_ingestion_auth_configured(
+    INGESTION_AUTH_TOKEN,
+    auth_required=AUTH_REQUIRED,
+    skip_check=SKIP_INGESTION_AUTH_STARTUP_CHECK,
+    service_name="mcp-server",
+)
+
 
 def _ingestion_headers() -> dict[str, str]:
     """Auth headers for internal ingestion calls; empty when token unset."""
@@ -139,7 +152,8 @@ MCP_PORT       = int(os.getenv("MCP_PORT", "8080"))
 MCP_PATH       = os.getenv("MCP_PATH", "/mcp")
 MCP_PUBLIC_URL = os.getenv("MCP_PUBLIC_URL", f"http://localhost:{MCP_PORT}")
 METRICS_PORT   = int(os.getenv("METRICS_PORT", "9091"))
-AUTH_REQUIRED  = os.getenv("AUTH_REQUIRED", "true").lower() == "true"
+# AUTH_REQUIRED is already read above (next to INGESTION_AUTH_TOKEN) so the
+# fail-closed boot check (#126) sees the same value.
 
 RATE_LIMIT_ENABLED    = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
 RATE_LIMIT_ANALYST    = int(os.getenv("RATE_LIMIT_ANALYST", "60"))

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -15,6 +15,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 # TestClient would otherwise fail at startup. Set the opt-out before
 # any test imports the module under test.
 os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")
+# The ingestion-auth boot check (#126) refuses to import the module with
+# AUTH_REQUIRED=true (the default) and an empty INGESTION_AUTH_TOKEN.
+os.environ.setdefault("SKIP_INGESTION_AUTH_STARTUP_CHECK", "true")
 
 
 @pytest.fixture

--- a/pb-proxy/config.py
+++ b/pb-proxy/config.py
@@ -9,6 +9,7 @@ import logging
 import yaml
 
 from shared.config import read_secret as _read_secret
+from shared.ingestion_auth import verify_ingestion_auth_configured
 
 log = logging.getLogger("pb-proxy")
 
@@ -75,6 +76,16 @@ PG_POOL_MAX = int(os.getenv("PG_POOL_MAX", "5"))
 
 # ── Authentication ───────────────────────────────────────────
 AUTH_REQUIRED = os.getenv("AUTH_REQUIRED", "true").lower() == "true"
+SKIP_INGESTION_AUTH_STARTUP_CHECK = (
+    os.getenv("SKIP_INGESTION_AUTH_STARTUP_CHECK", "false").lower() == "true"
+)
+# Fail-closed: refuse to start with empty token + AUTH_REQUIRED=true (#126).
+verify_ingestion_auth_configured(
+    INGESTION_AUTH_TOKEN,
+    auth_required=AUTH_REQUIRED,
+    skip_check=SKIP_INGESTION_AUTH_STARTUP_CHECK,
+    service_name="pb-proxy",
+)
 PG_HOST = os.getenv("PG_HOST", "postgres")
 PG_PORT = int(os.getenv("PG_PORT", "5432"))
 PG_DATABASE = os.getenv("PG_DATABASE", "powerbrain")

--- a/pb-proxy/tests/conftest.py
+++ b/pb-proxy/tests/conftest.py
@@ -12,3 +12,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 # tests — TestClient would otherwise fail to start because no OPA is
 # running in the CI container.
 os.environ.setdefault("SKIP_OPA_STARTUP_CHECK", "true")
+# The ingestion-auth boot check (#126) refuses to import config.py with
+# AUTH_REQUIRED=true (the default) and an empty INGESTION_AUTH_TOKEN.
+os.environ.setdefault("SKIP_INGESTION_AUTH_STARTUP_CHECK", "true")

--- a/shared/ingestion_auth.py
+++ b/shared/ingestion_auth.py
@@ -1,0 +1,121 @@
+"""Boot-time check for INGESTION_AUTH_TOKEN configuration (issue #126).
+
+Mirrors the OPA boot-check pattern (`shared/opa_client.verify_required_policies`).
+A misconfigured `INGESTION_AUTH_TOKEN` would silently disable the ingestion
+service's defense-in-depth auth layer (the middleware logs a warning and
+allows everything). For a feature explicitly described as "defense-in-depth",
+silent failure defeats the purpose.
+
+This module surfaces the misconfiguration as a hard boot-time error when
+`AUTH_REQUIRED=true` (the default) and the token is empty, so a typo in the
+secret name or a forgotten rollout becomes immediately visible instead of
+shipping a degraded-mode service that healthchecks happily report as green.
+
+Operators have three escape hatches:
+  - `AUTH_REQUIRED=false` — opts out of the auth layer entirely (test/dev).
+  - `SKIP_INGESTION_AUTH_STARTUP_CHECK=true` — bypasses just this check
+    (mirrors `SKIP_OPA_STARTUP_CHECK`; intended for unit tests).
+  - Set the token. The fix.
+
+The Prometheus gauge `pb_ingestion_auth_enabled{service=...}` exposes the
+runtime state so operators can alert on degraded mode regardless of the
+boot path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from prometheus_client import Gauge, REGISTRY
+
+
+log = logging.getLogger("pb.ingestion_auth")
+
+
+def _get_or_create_gauge() -> Gauge:
+    """Idempotent Gauge registration so re-imports during tests don't
+    raise ``Duplicated timeseries`` against the global registry."""
+    name = "pb_ingestion_auth_enabled"
+    try:
+        return Gauge(
+            name,
+            "1 if INGESTION_AUTH_TOKEN is configured, 0 otherwise. "
+            "Reports the boot-time decision per service.",
+            ["service"],
+        )
+    except ValueError as exc:
+        if "Duplicated timeseries" not in str(exc):
+            raise
+        for collector in list(REGISTRY._collector_to_names.keys()):
+            if getattr(collector, "_name", None) == name:
+                return collector  # type: ignore[return-value]
+        raise
+
+
+pb_ingestion_auth_enabled = _get_or_create_gauge()
+
+
+class IngestionAuthMisconfiguredError(RuntimeError):
+    """Raised when AUTH_REQUIRED=true but INGESTION_AUTH_TOKEN is empty.
+
+    Surfaced at module import time so the service refuses to start
+    instead of running in a silently-degraded mode (#126).
+    """
+
+
+def verify_ingestion_auth_configured(
+    token: str,
+    *,
+    auth_required: bool,
+    skip_check: bool,
+    service_name: str,
+) -> None:
+    """Boot-time guard for INGESTION_AUTH_TOKEN. See module docstring.
+
+    Args:
+        token: The INGESTION_AUTH_TOKEN value (possibly empty).
+        auth_required: The service's AUTH_REQUIRED flag.
+        skip_check: Operator opt-out (`SKIP_INGESTION_AUTH_STARTUP_CHECK`),
+            mirroring `SKIP_OPA_STARTUP_CHECK`.
+        service_name: Service identifier for logging + metrics labels
+            (e.g. "ingestion", "mcp-server").
+
+    Raises:
+        IngestionAuthMisconfiguredError: when ``auth_required`` is True,
+            ``token`` is empty, and ``skip_check`` is False.
+    """
+    label = pb_ingestion_auth_enabled.labels(service=service_name)
+
+    if not auth_required:
+        log.warning(
+            "[%s] AUTH_REQUIRED=false — INGESTION_AUTH_TOKEN check skipped. "
+            "Run with AUTH_REQUIRED=true in production deployments.",
+            service_name,
+        )
+        label.set(0)
+        return
+
+    if token:
+        label.set(1)
+        return
+
+    if skip_check:
+        log.warning(
+            "[%s] SKIP_INGESTION_AUTH_STARTUP_CHECK=true — booting without "
+            "INGESTION_AUTH_TOKEN despite AUTH_REQUIRED=true. Intended for "
+            "unit tests only; do not set this in production.",
+            service_name,
+        )
+        label.set(0)
+        return
+
+    label.set(0)
+    raise IngestionAuthMisconfiguredError(
+        f"[{service_name}] AUTH_REQUIRED=true but INGESTION_AUTH_TOKEN is "
+        f"empty. The ingestion service auth layer would be silently "
+        f"disabled. Provide the token (Docker Secret "
+        f"/run/secrets/ingestion_auth_token, or env INGESTION_AUTH_TOKEN), "
+        f"or set AUTH_REQUIRED=false to skip auth in test/dev. To bypass "
+        f"this check (e.g. unit tests), set "
+        f"SKIP_INGESTION_AUTH_STARTUP_CHECK=true."
+    )

--- a/shared/tests/test_ingestion_auth.py
+++ b/shared/tests/test_ingestion_auth.py
@@ -1,0 +1,118 @@
+"""Tests for the INGESTION_AUTH_TOKEN boot-time check (#126)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.ingestion_auth import (
+    IngestionAuthMisconfiguredError,
+    pb_ingestion_auth_enabled,
+    verify_ingestion_auth_configured,
+)
+
+
+def _gauge_value(service: str) -> float:
+    return pb_ingestion_auth_enabled.labels(service=service)._value.get()
+
+
+class TestVerifyIngestionAuthConfigured:
+    def test_token_set_passes_and_marks_enabled(self):
+        verify_ingestion_auth_configured(
+            "secret-token",
+            auth_required=True,
+            skip_check=False,
+            service_name="test-token-set",
+        )
+        assert _gauge_value("test-token-set") == 1
+
+    def test_empty_token_with_auth_required_raises(self):
+        with pytest.raises(IngestionAuthMisconfiguredError) as exc:
+            verify_ingestion_auth_configured(
+                "",
+                auth_required=True,
+                skip_check=False,
+                service_name="test-empty-token",
+            )
+        # Helpful diagnostic content in the error message
+        assert "INGESTION_AUTH_TOKEN" in str(exc.value)
+        assert "AUTH_REQUIRED" in str(exc.value)
+        assert "SKIP_INGESTION_AUTH_STARTUP_CHECK" in str(exc.value)
+        # Gauge marks it as disabled
+        assert _gauge_value("test-empty-token") == 0
+
+    def test_auth_not_required_passes_with_empty_token(self):
+        verify_ingestion_auth_configured(
+            "",
+            auth_required=False,
+            skip_check=False,
+            service_name="test-auth-not-required",
+        )
+        # Gauge marks the disabled state so dashboards can alert on it
+        assert _gauge_value("test-auth-not-required") == 0
+
+    def test_skip_check_bypasses_with_empty_token(self):
+        # Should not raise even though auth_required=True + token is empty
+        verify_ingestion_auth_configured(
+            "",
+            auth_required=True,
+            skip_check=True,
+            service_name="test-skip-check",
+        )
+        assert _gauge_value("test-skip-check") == 0
+
+    def test_skip_check_logs_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pb.ingestion_auth"):
+            verify_ingestion_auth_configured(
+                "",
+                auth_required=True,
+                skip_check=True,
+                service_name="test-skip-warns",
+            )
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "SKIP_INGESTION_AUTH_STARTUP_CHECK" in msgs
+
+    def test_auth_not_required_logs_warning(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pb.ingestion_auth"):
+            verify_ingestion_auth_configured(
+                "any-token",
+                auth_required=False,
+                skip_check=False,
+                service_name="test-not-required-warns",
+            )
+        msgs = " ".join(r.message for r in caplog.records)
+        assert "AUTH_REQUIRED=false" in msgs
+
+    def test_token_set_does_not_warn(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="pb.ingestion_auth"):
+            verify_ingestion_auth_configured(
+                "real-token",
+                auth_required=True,
+                skip_check=False,
+                service_name="test-no-warn",
+            )
+        # Happy path emits no log records
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_each_service_gets_its_own_gauge_label(self):
+        verify_ingestion_auth_configured(
+            "tok",
+            auth_required=True,
+            skip_check=False,
+            service_name="svc-a",
+        )
+        verify_ingestion_auth_configured(
+            "",
+            auth_required=False,
+            skip_check=False,
+            service_name="svc-b",
+        )
+        assert _gauge_value("svc-a") == 1
+        assert _gauge_value("svc-b") == 0
+
+    def test_misconfigured_error_is_runtime_error(self):
+        # Subclass relationship lets callers catch RuntimeError generically
+        # if they prefer a broader except clause.
+        assert issubclass(IngestionAuthMisconfiguredError, RuntimeError)

--- a/worker/scheduler.py
+++ b/worker/scheduler.py
@@ -25,6 +25,11 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from prometheus_client import start_http_server
 
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from shared.config import read_secret as _read_secret
+from shared.ingestion_auth import verify_ingestion_auth_configured
+
 from worker.context import WorkerContext
 from worker.jobs import (
     accuracy_metrics,
@@ -114,6 +119,19 @@ def register_jobs(scheduler: AsyncIOScheduler, ctx: WorkerContext) -> None:
 
 async def main() -> None:
     log.info("pb-worker starting")
+
+    # Fail-closed: refuse to start when AUTH_REQUIRED=true and the
+    # ingestion service token is missing — repo_sync would 401 on every
+    # tick and the misconfig would only surface in worker logs (#126).
+    verify_ingestion_auth_configured(
+        _read_secret("INGESTION_AUTH_TOKEN", ""),
+        auth_required=os.getenv("AUTH_REQUIRED", "true").lower() == "true",
+        skip_check=os.getenv(
+            "SKIP_INGESTION_AUTH_STARTUP_CHECK", "false"
+        ).lower() == "true",
+        service_name="pb-worker",
+    )
+
     ctx = await WorkerContext.create()
     log.info("postgres connected (%s)", os.getenv("POSTGRES_HOST", "postgres"))
 


### PR DESCRIPTION
## Summary

[PR #89](https://github.com/nuetzliches/powerbrain/pull/89) (B-50, v0.8.0) introduced \`IngestionAuthMiddleware\` as defense-in-depth on the internal ingestion endpoints. To keep rolling upgrades non-breaking, an empty \`INGESTION_AUTH_TOKEN\` was treated as **fail-open**: a loud warning at startup, then every request allowed through.

The fail-open default lets a misconfigured deployment **silently lose its auth layer** without any signal beyond a startup log line — typo in the secret name, forgotten rollout, accidentally empty rotation. For a feature explicitly described as \"defense-in-depth\", silent failure defeats the purpose.

This PR mirrors the v0.7.1 OPA hardening ([PR #62](https://github.com/nuetzliches/powerbrain/pull/62)): with the default \`AUTH_REQUIRED=true\`, services refuse to start when the token is empty.

## Affected services

| Service | Why it needs the boot check |
|---|---|
| **ingestion** | Hosts the auth middleware; empty token = silent allow-all |
| **mcp-server** | Calls ingestion for log_access, scan, ingest |
| **pb-proxy** | Calls ingestion for chat-path PII scanning |
| **pb-worker** | Calls ingestion for repo_sync job |

## Three escape hatches

- \`AUTH_REQUIRED=false\` — opts out of the auth layer entirely (test/dev only — disables ALL auth layers, not just ingestion).
- \`SKIP_INGESTION_AUTH_STARTUP_CHECK=true\` — bypasses just this check (mirrors \`SKIP_OPA_STARTUP_CHECK\`; the standard \`conftest.py\` fixtures already set this).
- **Set the token.** The fix.

## New observability

\`pb_ingestion_auth_enabled{service=\"...\"}\` Prometheus gauge reports the boot-time decision per service so dashboards can alert on degraded mode regardless of how the service started.

## Files

| File | Change |
|---|---|
| [shared/ingestion_auth.py](shared/ingestion_auth.py) | NEW — \`verify_ingestion_auth_configured()\`, \`IngestionAuthMisconfiguredError\`, gauge |
| [shared/tests/test_ingestion_auth.py](shared/tests/test_ingestion_auth.py) | NEW — 9 unit tests covering all branches |
| [ingestion/ingestion_api.py](ingestion/ingestion_api.py) | Boot-check call before middleware setup |
| [mcp-server/server.py](mcp-server/server.py) | Boot-check call; deduped local AUTH_REQUIRED definition |
| [pb-proxy/config.py](pb-proxy/config.py) | Boot-check call at module load |
| [worker/scheduler.py](worker/scheduler.py) | Boot-check call at the start of \`main()\` |
| \`*/tests/conftest.py\` | Add \`SKIP_INGESTION_AUTH_STARTUP_CHECK=true\` so unit tests can import the apps without setting the token |
| [CHANGELOG.md](CHANGELOG.md) | Breaking-change note in Unreleased |

## Test plan

- [x] 9 new unit tests pass (\`shared/tests/test_ingestion_auth.py\`)
- [x] Full unit suite: 1072 passed, 16 skipped, 69.77% coverage (>68% threshold)
- [x] All existing tests for the four affected services still pass after their conftest gets the new env var

## Migration impact (for the next release notes)

Existing deployments that already provisioned \`secrets/ingestion_auth_token.txt\` (or set the env var) need no changes. Deployments mid-rollout with an empty token must either:
- Set the token, **or**
- Explicitly set \`AUTH_REQUIRED=false\` (test/dev only)

This is the recommended close-out for #126 and likely the headline of the next release (0.8.1 as a security patch, or roll into 0.9.0).

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)