### PR TITLE
fix(tests): reset audit_tail between TestHashChainLive cases

### DIFF
--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -416,12 +416,24 @@ class TestHashChainLive:
         pool = await asyncpg.create_pool(url, min_size=1, max_size=2)
         # Clean state — test class assumes an empty agent_access_log AND
         # an empty audit_archive (otherwise the trigger would use a stale
-        # checkpoint as the genesis prev_hash anchor).
+        # checkpoint as the genesis prev_hash anchor). audit_tail must
+        # also be reset so the trigger seeds the chain from genesis rather
+        # than a stale hash left over from prior test runs.
         await pool.execute("DELETE FROM agent_access_log")
         await pool.execute("DELETE FROM audit_archive")
+        await pool.execute(
+            "UPDATE audit_tail SET last_entry_hash = $1, last_entry_id = 0 "
+            "WHERE id = 1",
+            b"\x00" * 32,
+        )
         yield pool
         await pool.execute("DELETE FROM agent_access_log")
         await pool.execute("DELETE FROM audit_archive")
+        await pool.execute(
+            "UPDATE audit_tail SET last_entry_hash = $1, last_entry_id = 0 "
+            "WHERE id = 1",
+            b"\x00" * 32,
+        )
         await pool.close()
 
     async def _insert(self, pool, n: int, action: str = "search",


### PR DESCRIPTION
## Summary

`TestHashChainLive.live_pool` (`mcp-server/tests/test_audit_integrity.py:410`) cleans `agent_access_log` and `audit_archive` between tests but did **not** reset `audit_tail`. After earlier tests insert rows, `audit_tail.last_entry_hash` and `last_entry_id` retain values that point to deleted rows. The next test's inserts then chain from a stale tail, so `pb_verify_audit_chain()` walks with the wrong seed and returns `valid=false`.

`TestForceReset.live_pool` already does the right thing — mirror that pattern in both setup (before `yield`) and teardown (after `yield`).

Latent on master because the failing tests are gated behind `PG_INTEGRATION=1`, which CI does not exercise.

## Reproduction (master, before this PR)

```bash
docker compose up -d postgres
docker exec pb-postgres psql -U pb_admin -d powerbrain \
  -c "ALTER ROLE pb_admin WITH PASSWORD 'pbtest';"

docker run --rm --network powerbrain_pb-net \
  -v "$(pwd):/app" -w /app \
  -e PG_INTEGRATION=1 \
  -e POSTGRES_URL="postgresql://pb_admin:pbtest@pb-postgres:5432/powerbrain" \
  python:3.12-slim bash -c "
    pip install --no-cache-dir -q -r mcp-server/requirements.txt asyncpg pytest pytest-asyncio &&
    PYTHONPATH=.:mcp-server python -m pytest mcp-server/tests/test_audit_integrity.py::TestHashChainLive -v
  "
```

Failures on master:
- `test_verify_full_chain_after_inserts` — `assert v["valid"] is True` returns False
- `test_checkpoint_and_rechain` — `assert cp["chain_valid"] is True` returns False

## Test plan

- [x] `TestHashChainLive::test_verify_full_chain_after_inserts` passes
- [x] `TestHashChainLive::test_checkpoint_and_rechain` passes
- [x] Full `TestHashChainLive` class (9 tests) — all pass, no regressions
- [x] Full `TestForceReset` class (5 tests) — all pass, no regressions

## Scope

- Single file: `mcp-server/tests/test_audit_integrity.py`
- No production code changes
- No schema changes
- No CI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)