### PR TITLE
release: v0.9.0 — audit-review backlog + ingestion auth fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-04
+
 Closes the audit-review backlog filed against v0.8.0
 (#101–#105) plus a follow-up security hardening for ingestion auth
 (#126).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "powerbrain"
-version = "0.8.0"
+version = "0.9.0"
 requires-python = ">=3.12"
 
 [tool.ruff]


### PR DESCRIPTION
Release v0.9.0.

## Summary

Closes the audit-review backlog filed against v0.8.0 (#101-#105) plus a follow-up security hardening for ingestion auth (#126).

### ⚠ Two breaking changes

1. **Ingestion auth fail-closed** — `AUTH_REQUIRED=true` + empty `INGESTION_AUTH_TOKEN` now refuses to start any of ingestion, mcp-server, pb-proxy, pb-worker. Mirrors the v0.7.1 OPA hardening. Opt-out via `SKIP_INGESTION_AUTH_STARTUP_CHECK=true`.
2. **`pb_audit_force_reset()` semantics** — function now writes a self-record into the chain before truncate; `archived_rows` increments by 1 and `archived_hash` points to the self-record's `entry_hash`. New optional `p_purpose` argument. Test fixtures asserting on those values must update.

### Folded-in PRs

- [#127](https://github.com/nuetzliches/powerbrain/pull/127) — fix(audit): preserve verify visibility + clean stale snapshot rendering [#102, #104]
- [#128](https://github.com/nuetzliches/powerbrain/pull/128) — docs+tests(audit): document BYPASSRLS dependency + cover worker writes [#103, #105]
- [#129](https://github.com/nuetzliches/powerbrain/pull/129) — feat(audit): record force-reset provenance in chain + archive [#101]
- [#130](https://github.com/nuetzliches/powerbrain/pull/130) — feat(security): fail-closed boot check for INGESTION_AUTH_TOKEN [#126]
- [#131](https://github.com/nuetzliches/powerbrain/pull/131) — fix(tests): reset audit_tail between TestHashChainLive cases [chip follow-up]

### What this PR does

- Promotes `[Unreleased]` to `[0.9.0] - 2026-05-04` in [CHANGELOG.md](CHANGELOG.md)
- Bumps [pyproject.toml](pyproject.toml) version to `0.9.0`

After merge, tag `v0.9.0` is created on the resulting master commit and pushed.

## Test plan
- [x] All five constituent PRs were already CI-green when merged into master
- [x] No code changes in this release commit (only CHANGELOG header + version string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)