### PR TITLE
fix(ci): forgejo build pipeline publishes :<version> tags on releases

### DIFF
--- a/.forgejo/workflows/build-images.yml
+++ b/.forgejo/workflows/build-images.yml
@@ -3,15 +3,12 @@ name: Build, Push & Deploy
 on:
   push:
     branches: [master]
-    paths:
-      - 'mcp-server/**'
-      - 'ingestion/**'
-      - 'reranker/**'
-      - 'pb-proxy/**'
-      - 'worker/**'
-      - 'shared/**'
-      - 'init-db/**'
-      - 'opa-policies/**'
+    tags: ['v*']
+    # No `paths:` filter — release-tag pushes are typically on
+    # CHANGELOG-only commits and must still fire to produce
+    # :<version>-tagged images. The script (scripts/build-images.sh)
+    # does its own change detection and exits fast when nothing
+    # service-relevant changed.
   workflow_dispatch:
 
 jobs:
@@ -52,6 +49,10 @@ jobs:
           REPO: powerbrain
           FORCE_BUILD: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
           BEFORE_SHA: ${{ github.event.before }}
+          # On tag pushes (refs/tags/v*), pass the tag name so the
+          # script adds :<version> alongside :latest and :sha-<short>.
+          # Empty for branch pushes; falls back to git describe.
+          RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
       - name: Deploy — pull and restart services
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Forgejo build pipeline now publishes version tags**
+  ([build-images.sh](scripts/build-images.sh) +
+  [.forgejo/workflows/build-images.yml](.forgejo/workflows/build-images.yml)).
+  The Forgejo Actions build was tagging images only as `:latest` and
+  `:sha-<short>`, never as `:<version>` — so consumers downstream
+  (e.g. infra repos pinning the image tag) could not reference a
+  release like `0.9.0`. Two changes:
+  1. Workflow now triggers on `tags: ['v*']` in addition to `master`,
+     and drops the `paths:` filter (release commits are typically
+     CHANGELOG-only and would otherwise be skipped). The script's
+     own change detection still keeps non-release runs cheap.
+  2. `scripts/build-images.sh` reads the new `RELEASE_TAG` env
+     (passed by the workflow as `github.ref_name` on tag pushes,
+     with a `git describe --exact-match` fallback for local runs)
+     and adds a `:${VERSION}` build/push tag alongside the existing
+     two. Release-tagged runs also force `rebuild_all=true` so the
+     full image set always carries the version tag, even when only
+     CHANGELOG.md changed in the release commit.
+
 ## [0.9.0] - 2026-05-04
 
 Closes the audit-review backlog filed against v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-04
+
+A single CI hardening fix on top of v0.9.0 — no service-code changes,
+no DB migrations, no breaking changes. Cuts an explicit release so
+downstream infra repos can pin to a version tag.
+
 ### Fixed
 
 - **Forgejo build pipeline now publishes version tags**

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,7 +3,8 @@
 #  build-images.sh -- Build & push Docker images to Forgejo Registry
 #  Called by Forgejo Actions after mirror-sync from GitHub.
 #
-#  Images are tagged with :latest and :sha-<short-hash>.
+#  Images are tagged with :latest, :sha-<short-hash>, and (when HEAD
+#  is on a release tag) :<version> (e.g. :0.9.1 from tag v0.9.1).
 #  Registry: ${REGISTRY}/${ORG}/${REPO}/<service>
 # ============================================================
 set -euo pipefail
@@ -21,6 +22,21 @@ REPO_DIR="${REPO_DIR:-$(pwd)}"
 cd "$REPO_DIR"
 
 SHORT_SHA=$(git rev-parse --short HEAD)
+
+# ── Release-Tag Detection ───────────────────────────────────
+# Priority 1: RELEASE_TAG env (workflow passes github.ref_name on
+#             tag pushes — works even when HEAD is detached).
+# Priority 2: git describe --exact-match (works locally + when
+#             checkout has HEAD on the tag's commit).
+RELEASE_TAG="${RELEASE_TAG:-}"
+if [ -z "$RELEASE_TAG" ]; then
+  RELEASE_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || true)
+fi
+VERSION=""
+if [ -n "$RELEASE_TAG" ]; then
+  VERSION="${RELEASE_TAG#v}"
+  log "Release tag detected: ${RELEASE_TAG} (version: ${VERSION})"
+fi
 
 # ── Image List ──────────────────────────────────────────────
 # Each entry: "service-name:Dockerfile:build-context"
@@ -56,7 +72,7 @@ for svc in mcp-server ingestion reranker pb-proxy worker shared init-db opa-poli
   fi
 done
 
-if [ "$changed" = "ALL" ] || [ "$has_service_change" = false ]; then
+if [ "$changed" = "ALL" ] || [ "$has_service_change" = false ] || [ -n "$VERSION" ]; then
   rebuild_all=true
   log "Rebuilding all images."
 fi
@@ -84,17 +100,20 @@ for entry in "${IMAGES[@]}"; do
   context="${rest#*:}"
   log "Building ${image} (context: ${context})..."
 
-  docker build \
-    -f "$dockerfile" \
-    -t "${image}:latest" \
-    -t "${image}:sha-${SHORT_SHA}" \
-    "$context"
+  build_tags=("-t" "${image}:latest" "-t" "${image}:sha-${SHORT_SHA}")
+  [ -n "$VERSION" ] && build_tags+=("-t" "${image}:${VERSION}")
+
+  docker build -f "$dockerfile" "${build_tags[@]}" "$context"
 
   log "Pushing ${image}..."
   docker push "${image}:latest"
   docker push "${image}:sha-${SHORT_SHA}"
-
-  ok "${service} -> ${image}:sha-${SHORT_SHA}"
+  if [ -n "$VERSION" ]; then
+    docker push "${image}:${VERSION}"
+    ok "${service} -> ${image}:${VERSION} (also :latest, :sha-${SHORT_SHA})"
+  else
+    ok "${service} -> ${image}:sha-${SHORT_SHA} (also :latest)"
+  fi
   built=$((built + 1))
 done
 


### PR DESCRIPTION
## Summary

The Forgejo Actions build (`scripts/build-images.sh` + `.forgejo/workflows/build-images.yml`) was tagging images only as `:latest` and `:sha-<short>`, never `:<version>`. Downstream consumers (e.g. infra repos pinning the image tag) cannot reference a release like `0.9.0` and have to fall back to `:latest` or SHA-pin.

Discovered while pinning Powerbrain in [nuts-infra#4](https://github.com/nuetzliches/nuts-infra/pull/4) — `docker pull git.nuetzliche.it/nuts/powerbrain/mcp-server:0.9.0` returns 404.

## Changes

### `.forgejo/workflows/build-images.yml`

- Add `tags: ['v*']` trigger so release-tag pushes fire the workflow.
- Drop the `paths:` filter — the v0.9.0 release commit was a CHANGELOG-only bump (`76a6850`) and would otherwise be skipped, leaving `:0.9.0` images unpublished. The script's own change-detection keeps non-release runs cheap.
- Pass `RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}` to the build script.

### `scripts/build-images.sh`

- Read `RELEASE_TAG` env first; fall back to `git describe --exact-match --tags HEAD` for local invocations or detached-HEAD CI runs.
- Add `:${VERSION}` as a build/push tag alongside `:latest` and `:sha-${SHORT_SHA}` when a tag is detected.
- Force `rebuild_all=true` on release-tagged runs so every service image carries the version tag even when only CHANGELOG.md was touched in the release commit.

### `CHANGELOG.md`

- New entry under `[Unreleased]` — ready for a v0.9.1 cut.

## Tag mapping after merge + tag

After this lands and `v0.9.1` is tagged, the registry will carry:

```
git.nuetzliche.it/nuts/powerbrain/mcp-server:latest
git.nuetzliche.it/nuts/powerbrain/mcp-server:sha-<short>
git.nuetzliche.it/nuts/powerbrain/mcp-server:0.9.1
```

(and the same for `ingestion`, `reranker`, `pb-proxy`, `worker`).

## Test plan

- [x] `bash -n scripts/build-images.sh` — syntax clean
- [x] Local dry: `RELEASE_TAG=v0.9.1 SHORT_SHA=$(git rev-parse --short HEAD) bash -x scripts/build-images.sh` (with REGISTRY/ORG/REPO mocked) prints the three `-t` flags as expected
- [ ] After merge: tag `v0.9.1` on master, verify `git.nuetzliche.it/nuts/powerbrain/mcp-server:0.9.1` resolves
- [ ] Smoke test on int-baumeister: pin `TAG=0.9.1` in nuts-infra Powerbrain `.env.example` (already prepared in [nuts-infra#4](https://github.com/nuetzliches/nuts-infra/pull/4)) and re-deploy

## Related

- Discovered in [nuts-infra#4](https://github.com/nuetzliches/nuts-infra/pull/4) (Powerbrain v0.9.0 deploy + Forgejo secrets migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)