### PR TITLE
fix(ci): respect local-reranker profile in deploy step

### DIFF
--- a/.forgejo/workflows/build-images.yml
+++ b/.forgejo/workflows/build-images.yml
@@ -63,12 +63,19 @@ jobs:
           fi
 
           cd "${DEPLOY_DIR}"
-          docker compose pull mcp-server ingestion reranker pb-proxy pb-worker
-          docker compose up -d mcp-server ingestion reranker pb-proxy pb-worker
+          # NOTE: `reranker` is profile-gated (`profiles: ["local-reranker"]`)
+          # in docker-compose.yml. Naming it explicitly here would override
+          # the profile gate and force-start it, even on deployments that
+          # use a remote reranker (RERANKER_URL pointing at an external
+          # endpoint). Operators who want the local reranker should bring
+          # it up separately with `docker compose --profile local-reranker
+          # up -d reranker`.
+          docker compose pull mcp-server ingestion pb-proxy pb-worker
+          docker compose up -d mcp-server ingestion pb-proxy pb-worker
 
           echo "✅ Powerbrain services restarted"
 
-          for svc in pb-mcp-server pb-ingestion pb-reranker pb-proxy; do
+          for svc in pb-mcp-server pb-ingestion pb-proxy; do
             for i in $(seq 1 12); do
               status=$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null || echo "unknown")
               if [ "$status" = "healthy" ]; then


### PR DESCRIPTION
## Summary

The Forgejo deploy step force-starts `reranker` by naming it explicitly:

```yaml
docker compose pull ... reranker ...
docker compose up -d ... reranker ...
```

This bypasses the profile gate (`profiles: [\"local-reranker\"]`) and crash-loops the container on deployments using a remote reranker.

## Root cause

`RERANKER_MODEL` is shared by two consumers with conflicting semantics:

- **mcp-server** uses it as the model identifier sent to whatever reranker is at `RERANKER_URL` (could be remote)
- **pb-reranker (local)** uses it as a HuggingFace path passed to `AutoConfig.from_pretrained()`

When `RERANKER_URL` points at a remote service (e.g. `ai.nuetzliche.it`) and `RERANKER_MODEL=nutsai-rerank-large-v2`, the local container tries to load `cross-encoder/nutsai-rerank-large-v2` from HuggingFace and crashes:

```
OSError: cross-encoder/nutsai-rerank-large-v2 is not a local folder
and is not a valid model identifier listed on 'https://huggingface.co/models'
```

## Fix

Drop `reranker` / `pb-reranker` from the deploy step's explicit pull, up, and health-wait lists so the profile gate is honoured. The local reranker remains available via the documented opt-in:

```bash
docker compose --profile local-reranker up -d reranker
```

## Discovered

Deploying v0.9.1 to int-baumeister (remote reranker via `ai.nuetzliche.it`) — `pb-reranker` reappeared after every CI deploy with the above OSError, even after manual `docker rm`.

## Test plan

- [x] YAML lint clean (existing checks should pass)
- [ ] After merge: confirm pb-reranker no longer reappears on next master push