### PR TITLE
perf(ingestion): parallelize L0+L1 layer generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Parallel L0+L1 layer generation in ingestion**
+  ([ingestion_api.py](ingestion/ingestion_api.py)). The two LLM calls
+  for the L0 abstract and L1 overview of a single document are
+  independent (same `processed_chunks`, same stateless
+  `completion_provider`, same async-safe `httpx.AsyncClient`) but were
+  awaited sequentially. Switched to `asyncio.gather` so both calls run
+  concurrently. On a 2026-05-08 re-ingest of 3782 commit-docs, layer
+  generation dominated wall time at ~10s of ~12s per document; running
+  the two completions in parallel cuts that to ~5s, a ~40% speedup on
+  long ingestion runs without changing the model or any of the
+  graceful-degradation paths. New unit test
+  ([test_layer_generation.py](ingestion/tests/test_layer_generation.py))
+  asserts the two `completion_provider.generate` calls overlap in time.
+
 ## [0.9.1] - 2026-05-04
 
 A single CI hardening fix on top of v0.9.0 — no service-code changes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-08
+
+A single performance fix on top of v0.9.1 — no service-code semantics
+change, no DB migrations, no breaking changes. Halves the LLM-wait
+portion of per-document ingestion latency on backends that support
+real concurrency (vLLM, TEI, cloud LLM providers).
+
 ### Performance
 
 - **Parallel L0+L1 layer generation in ingestion**
@@ -22,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graceful-degradation paths. New unit test
   ([test_layer_generation.py](ingestion/tests/test_layer_generation.py))
   asserts the two `completion_provider.generate` calls overlap in time.
+  Single-engine backends without batching (e.g. Ollama on a single
+  GPU/CPU) will see less benefit because inference serialises at the
+  model level — networking and prompt-prep still overlap.
 
 ## [0.9.1] - 2026-05-04
 

--- a/ingestion/ingestion_api.py
+++ b/ingestion/ingestion_api.py
@@ -1162,8 +1162,16 @@ async def ingest_text_chunks(
         processed_chunks = [p.payload["text"] for p in points]
         now_iso = datetime.now(timezone.utc).isoformat()
 
+        # L0 + L1 generation runs in parallel: both call the same stateless
+        # completion_provider over the async-safe httpx client, with no shared
+        # mutable state. Each helper has its own try/except returning None on
+        # failure, so gather() never raises here.
+        l0_text, l1_text = await asyncio.gather(
+            generate_l0(processed_chunks, source=source, classification=classification),
+            generate_l1(processed_chunks, source=source, classification=classification),
+        )
+
         # L0: Abstract
-        l0_text = await generate_l0(processed_chunks, source=source, classification=classification)
         if l0_text:
             try:
                 l0_embedding = await get_embedding(l0_text)
@@ -1193,7 +1201,6 @@ async def ingest_text_chunks(
                 l0_point_id = None
 
         # L1: Overview
-        l1_text = await generate_l1(processed_chunks, source=source, classification=classification)
         if l1_text:
             try:
                 l1_embedding = await get_embedding(l1_text)

--- a/ingestion/tests/test_layer_generation.py
+++ b/ingestion/tests/test_layer_generation.py
@@ -1,6 +1,8 @@
 """Tests for L0/L1 layer generation and ingestion pipeline integration."""
 
+import asyncio
 import json
+import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -180,3 +182,64 @@ class TestIngestLayerIntegration:
         l1_call = ingestion_api.qdrant.upsert.call_args_list[2]
         l1_points = l1_call.kwargs.get("points", l1_call[1].get("points", []))
         assert l1_points[0].payload["layer"] == "L1"
+
+    @pytest.mark.asyncio
+    async def test_l0_l1_generation_runs_in_parallel(self, monkeypatch):
+        """L0+L1 LLM calls must be issued concurrently, not sequentially.
+
+        Mocks completion_provider.generate to sleep 100ms per call. With
+        parallel execution via asyncio.gather, total layer-generation
+        latency stays around ~100ms; sequential awaits would be ~200ms.
+        """
+        async def _slow_generate(*args, **kwargs):
+            await asyncio.sleep(0.1)
+            return "generated text"
+
+        provider = AsyncMock()
+        provider.generate = AsyncMock(side_effect=_slow_generate)
+        monkeypatch.setattr(ingestion_api, "completion_provider", provider)
+
+        mock_embed = AsyncMock(return_value=[0.1] * 768)
+        monkeypatch.setattr(ingestion_api, "get_embedding", mock_embed)
+        mock_embed_batch = AsyncMock(return_value=[[0.1] * 768])
+        monkeypatch.setattr(
+            ingestion_api.embedding_provider, "embed_batch", mock_embed_batch,
+        )
+        mock_scanner = MagicMock()
+        mock_scanner.scan_text.return_value = MagicMock(
+            contains_pii=False, entity_counts={}, anonymized_text=None,
+        )
+        monkeypatch.setattr(ingestion_api, "get_scanner", lambda: mock_scanner)
+        monkeypatch.setattr(
+            ingestion_api, "check_opa_privacy",
+            AsyncMock(return_value={
+                "pii_action": "allow",
+                "dual_storage_enabled": False,
+                "retention_days": 365,
+            }),
+        )
+        monkeypatch.setattr(
+            ingestion_api, "check_opa_quality_gate",
+            AsyncMock(return_value={"allowed": True, "min_score": 0.0, "reason": ""}),
+        )
+
+        t0 = time.perf_counter()
+        await ingest_text_chunks(
+            chunks=["hello world"],
+            collection="pb_general",
+            source="test.md",
+            classification="internal",
+            project="test",
+            metadata={},
+        )
+        elapsed = time.perf_counter() - t0
+
+        # Sequential awaits would take >=200ms (2× 100ms). Parallel via
+        # asyncio.gather should stay close to 100ms. The 180ms ceiling
+        # absorbs test-runner jitter while still catching a regression
+        # to the old sequential code path.
+        assert elapsed < 0.18, (
+            f"L0+L1 generation took {elapsed:.3f}s; expected parallel "
+            f"execution (~0.1s), got near-sequential (~0.2s)"
+        )
+        assert provider.generate.call_count == 2


### PR DESCRIPTION
## Summary

- L0 abstract and L1 overview of each document are generated by two independent LLM completions; they were awaited sequentially in `ingest_text_chunks`. Switched to `asyncio.gather` so they run concurrently.
- Both helpers call the same stateless `completion_provider.generate` over the async-safe `httpx.AsyncClient`, with no shared mutable state — verified before the change. Each helper still has its own `try/except` returning `None` on failure, so `gather` cannot raise here.
- Observed in 2026-05-08 re-ingest: layer generation dominated wall time at ~10s of ~12s per document over 3782 commit-docs. Parallelization halves the LLM-wait portion, ~40% speedup on long ingestion runs. No model change, no policy change, graceful-degradation paths intact.

## Test plan

- [x] `pytest ingestion/tests/test_layer_generation.py -v` — 10/10 pass, including a new `test_l0_l1_generation_runs_in_parallel` that mocks each completion with a 100 ms delay and asserts total latency stays under 180 ms (sequential would be ≥200 ms).
- [x] `pytest ingestion/tests/ -m 'not integration'` — full ingestion unit suite (264 tests) still green.
- [ ] CI: `unit-tests`, `opa-tests`, `docker-build`, `security-scan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)