### PR TITLE
docs(compliance): document Pro/Max chat-path bypass and edition boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,19 @@ Supports SSE streaming (`"stream": true`).
 OPA policies (`pb.proxy`) control: provider access, required tools, max iterations, MCP server access.
 Configuration: `pb-proxy/litellm_config.yaml` for aliases + `provider_keys`, `pb-proxy/mcp_servers.yaml` for MCP servers.
 
+### Edition Boundary (what Powerbrain governs and what it doesn't)
+Powerbrain enforces policy on three distinct data paths. Be explicit about which one a feature affects:
+
+1. **Ingest path** — adapters → ingestion pipeline → Qdrant/PG/Vault. Always governed (Community + Enterprise).
+2. **Tool-call path** — MCP requests (`search_knowledge`, `graph_query`, …). Always governed (OPA, vault tokens, audit).
+3. **Chat-content path** — user prompt + LLM response + multimodal attachments. **Only governed when traffic goes through `pb-proxy`** (Enterprise tier).
+
+Concrete consequence for Claude clients:
+- **Pro/Max subscription** (Claude Desktop App or Claude Code via `claude /login`): OAuth to claude.ai, `ANTHROPIC_BASE_URL` is hardcoded and cannot be redirected → chat content bypasses Powerbrain even when pb-proxy is running. Tool calls via the registered MCP endpoint still flow through Powerbrain.
+- **API-key mode** (Claude Code with `ANTHROPIC_API_KEY=sk-ant-...`, OpenAI-compatible clients, custom SDKs): `ANTHROPIC_BASE_URL=http://pb-proxy:8090` works → full chat-path protection.
+
+When answering compliance questions or recommending architecture changes, distinguish these three paths explicitly. See `docs/editions.md` and `docs/compliance-claude-desktop.md`.
+
 ## Development
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Agent / Skill
 
 🏠 **Self-Hosted & GDPR-Native** — Everything runs on your infrastructure. No external API calls for embeddings, search, or summarization. Docker Compose up and you're running.
 
-🔀 **AI Provider Proxy** — Optional gateway between your AI consumers and their LLM providers. Transparently injects Powerbrain tools into every LLM request and executes tool calls automatically. Your teams use any LLM they prefer (100+ providers via LiteLLM); Powerbrain ensures they always query policy-checked enterprise context. Activate with `docker compose --profile proxy up`.
+🔀 **AI Provider Proxy** — Optional gateway between your AI consumers and their LLM providers. Transparently injects Powerbrain tools into every LLM request and executes tool calls automatically. Pseudonymises the chat content on the wire (PII scan via the ingestion pipeline) before it reaches the LLM. Your teams use any LLM they prefer (100+ providers via LiteLLM); Powerbrain ensures they always query policy-checked enterprise context. Without the proxy, direct chat from subscription clients (Claude Desktop / Claude Code Pro/Max) bypasses the chat-path PII scan — see the [edition boundary](docs/editions.md#edition-boundary-what-runs-through-powerbrain--and-what-doesnt). Activate with `docker compose --profile proxy up`.
 
 ## ⚖️ EU AI Act Compliance Toolkit
 
@@ -191,6 +191,8 @@ curl http://localhost:8090/v1/chat/completions \
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Step-by-step tutorial: ingest data, search, understand policies |
+| [Editions (Community vs Enterprise)](docs/editions.md) | Capability matrix, edition boundary, which tier governs which data path |
+| [Compliance with Claude Desktop / Code subscriptions](docs/compliance-claude-desktop.md) | Honest answer on Pro/Max bypass, three-tier mitigation, DPA vs AI Act |
 | [MCP Tool Reference](docs/mcp-tools.md) | All 23 MCP tools with parameters and access roles |
 | [What is Powerbrain?](docs/what-is-powerbrain.md) | Detailed overview and positioning |
 | [Architecture](docs/architecture.md) | Technical deep-dive |

--- a/docs/compliance-claude-desktop.md
+++ b/docs/compliance-claude-desktop.md
@@ -1,0 +1,213 @@
+# Compliance with Claude Desktop / Claude Code subscriptions
+
+This document is for compliance officers, data protection officers, and
+architects who need a precise answer to one question: *"If our staff
+uses Claude Desktop or Claude Code on a Pro / Max subscription, does
+Powerbrain still keep us GDPR- and EU-AI-Act-compliant?"*
+
+The honest answer has nuance. This page lays it out without marketing.
+
+## TL;DR
+
+- Powerbrain **fully governs** what flows through its ingest adapters
+  and its MCP tool calls — in both Community and Enterprise editions.
+- Powerbrain **only governs the free chat content** when the client
+  speaks the proxy on port 8090. Subscription-based Anthropic clients
+  (Pro/Max, both Desktop App and `claude /login` in Claude Code)
+  **cannot** be redirected to the proxy; their chat channel bypasses
+  Powerbrain by design.
+- Therefore: if regulated personal data may appear in free chat
+  prompts, you need *either* commercial Anthropic plans + Powerbrain
+  proxy on the wire, *or* organisational/DLP controls that prevent
+  regulated data from reaching subscription chats, *or* a defence-in-
+  depth chat-history ingest workflow (see Tier 2 below).
+- A Team/Enterprise DPA does **not** automatically discharge EU AI Act
+  Articles 12–15 — those remain deployer obligations regardless of the
+  Anthropic plan.
+
+## The bypass, precisely
+
+Claude Pro and Claude Max are **consumer plans**. They authenticate via
+OAuth against `claude.ai`. Anthropic deliberately does not allow these
+plans to redirect the backend endpoint:
+
+| Client | Auth | `ANTHROPIC_BASE_URL` honoured? | Chat content visible to Powerbrain? |
+|---|---|---|---|
+| Claude Desktop App (Pro/Max) | OAuth | ❌ | ❌ |
+| Claude Code (Pro/Max via `claude /login`) | OAuth | ❌ | ❌ (but `UserPromptSubmit` hooks can intercept locally) |
+| Claude Code (API key `sk-ant-...`) | API key | ✅ | ✅ via pb-proxy |
+| OpenAI-compatible clients (Cursor, OpenCode, …) | API key | ✅ (their own equivalent) | ✅ via pb-proxy |
+| Anthropic SDK / API direct | API key | ✅ | ✅ via pb-proxy |
+
+The bypass is not a Powerbrain limitation — it is structural in how
+Anthropic packages subscriptions.
+
+## What runs through Powerbrain regardless of the client
+
+These do **not** depend on which client the user runs:
+
+- **Ingest:** GitHub/Office 365/Git adapters authenticate against
+  source systems with their own tokens. No Anthropic involvement.
+  Pipeline always runs: chunking → Presidio → quality gate → vault
+  mapping → embedding.
+- **Tool calls:** When the agent calls `search_knowledge`,
+  `query_data`, `graph_query`, etc. via the MCP endpoint, OPA checks
+  every request. The audit hash chain records every access. Vault
+  tokens are still required for PII reveal.
+
+So even a Claude Desktop Pro user, configured with Powerbrain as an
+MCP server, gets policy-checked retrieval. What that user *types in
+the chat box*, and what Anthropic streams back, remain outside our
+perimeter.
+
+## The three-tier mitigation model
+
+Pick the strongest tier you can enforce — they stack.
+
+### Tier 1 — Real-time chat-path protection (preventive, gold standard)
+
+Enforce that any client touching regulated data speaks the proxy:
+
+- Claude Code CLI with `ANTHROPIC_API_KEY` and
+  `ANTHROPIC_BASE_URL=http://pb-proxy:8090`.
+- OpenAI-compatible clients pointed at `pb-proxy/v1/chat/completions`.
+- For Anthropic-format clients: `pb-proxy/v1/messages` (works with
+  Claude Code, custom Anthropic-SDK applications, etc.).
+
+Result: PII pseudonymisation happens **before** the LLM sees the
+prompt; vault resolution happens **after** the tool call, gated by
+OPA `pb.proxy.pii_resolve_tool_results` and the `X-Purpose` header.
+GDPR Art. 5, 32 and EU AI Act Art. 12, 13 are addressed for the chat
+path itself.
+
+This tier requires an Anthropic **commercial** plan (API, Team or
+Enterprise) for the LLM key, because consumer subscriptions cannot
+provide an `sk-ant-…` key usable in API mode. Alternatively: a local
+LLM (Ollama, vLLM on-prem) routed through the same proxy — no
+Anthropic involvement at all.
+
+### Tier 2 — Defence-in-depth chat-history ingest (detective)
+
+For users you genuinely cannot move off Pro/Max (e.g. legacy
+workflows, external collaborators with their own subscriptions), pull
+their conversation history into Powerbrain on a regular schedule:
+
+- **Option A — Anthropic conversation export** (ToS-clean, official):
+  users export their conversations from claude.ai → upload to a
+  Powerbrain endpoint (planned: `claude_export_adapter`). Ingestion
+  pipeline runs Presidio + quality gate + vault mapping retroactively.
+- **Option B — Claude Code local session logs** (ToS-clean): Claude
+  Code stores conversation logs locally in
+  `~/.claude/projects/<hash>/*.jsonl`. A scheduled adapter parses and
+  ingests these. Available regardless of subscription type.
+- **Option C — Claude Desktop App local storage** (ToS grey area, brittle
+  across app updates): app stores conversations in OS-local IndexedDB
+  / SQLite. Not recommended unless the other options are unavailable.
+
+This tier delivers:
+- ✅ Audit trail (EU AI Act Art. 12) — retroactive, T+24h
+- ✅ Transparency (Art. 13) — user can see what they sent
+- ✅ DLP retrospective — flag conversations that contained PII
+- ❌ Art. 32 (pseudonymisation *before* processing) — not solvable
+  this way; Anthropic still received the cleartext
+- ❌ Art. 5 (data minimisation) — same
+- ❌ Right-to-erasure end-to-end — Powerbrain can delete its vault
+  mapping, but Anthropic's copy is on a separate retention clock
+
+Tier 2 turns *uncontrolled* into *detective with latency*. That is
+substantively better than nothing for GDPR Art. 5(2) accountability
+("we knew, we logged, we acted") but not equivalent to Tier 1.
+
+### Tier 3 — Endpoint DLP (preventive, organisation-wide)
+
+Tools like Microsoft Purview, Symantec DLP, Netskope, Zscaler can
+block or scan HTTPS traffic to `claude.ai` and `*.anthropic.com`
+based on classification labels and content patterns.
+
+- ✅ Covers app *and* web
+- ✅ Real-time block-before-send
+- ❌ Not Powerbrain-native — separate tool, separate procurement
+- ❌ Usually block-only or warn-only, not pseudonymise-then-forward
+  (DLP cannot reconstruct a valid Anthropic conversation)
+
+Use Tier 3 as the safety net under Tier 1: "regulated data may only
+leave the device via the Powerbrain proxy; everything else is
+blocked."
+
+## Anthropic plan vs DPA vs EU AI Act
+
+A frequent confusion: *"We have a Claude Team subscription, so we have
+a DPA, so we're compliant."* Not quite.
+
+| Plan | DPA inclusion | Training default | Notes |
+|---|---|---|---|
+| Free / Pro / Max | ❌ No DPA — consumer terms only | Opt-in per user, model trained on accepted chats | No commercial AVV; per-user privacy setting decides training use |
+| Team / Enterprise / API / Claude Code commercial | ✅ DPA + SCCs auto-incorporated in Commercial ToS | Not used for training without active opt-in | Signed copy on request via Anthropic Sales |
+| Via AWS Bedrock / GCP Vertex | DPA of the hyperscaler | Per hyperscaler | EU residency available via these paths |
+
+**DPA solves GDPR Art. 28** (Auftragsverarbeitung). It does **not**
+solve EU AI Act obligations:
+
+- Anthropic has announced intent to sign the **EU GPAI Code of
+  Practice**, publishes Model Cards and a Transparency Hub. They cover
+  the GPAI-provider duties for Art. 53 GPAI.
+- Anthropic does **not** publish a public article-by-article mapping
+  to AI Act Art. 12 (logging), Art. 13 (transparency to deployers in
+  detail), Art. 14 (human oversight), Art. 15 (accuracy/robustness
+  monitoring in the deployment context). The deployer obligations
+  remain with **you**, regardless of which Anthropic plan you hold.
+
+Powerbrain provides the deployer-side building blocks for those
+articles: audit hash chain (Art. 12), `get_system_info` and
+`generate_compliance_doc` (Art. 13, Annex IV), `pending_reviews` and
+circuit breaker (Art. 14), drift detection (Art. 15). These are
+useful regardless of the Anthropic plan — and necessary regardless of
+the Anthropic plan.
+
+## Realistic recommendations by scenario
+
+| Scenario | Recommendation |
+|---|---|
+| Regulated data (HR, health, finance, customer PII) appears in chat | Tier 1 mandatory. Tier 3 as enforcement. Pro/Max subscriptions disallowed for regulated workflows by policy. |
+| Internal R&D, no customer data, no employee data | Pro/Max subscriptions acceptable. Register Powerbrain MCP for retrieval. Document the chat-channel boundary in your DPIA. |
+| External collaborators with their own subscriptions | Tier 2 ingest of their exported conversations + AVV clause that requires retroactive export to your Powerbrain. |
+| Air-gapped or strict-residency requirement | Tier 1 with local LLM (Ollama/vLLM) via pb-proxy. No Anthropic involvement. |
+
+## What Powerbrain does **not** claim
+
+To be explicit (this matters for an audit):
+
+- Powerbrain does **not** intercept Pro/Max OAuth sessions, does
+  **not** proxy claude.ai, and does **not** sign on behalf of
+  Anthropic. The Pro/Max bypass is a structural Anthropic decision,
+  not a Powerbrain limitation we plan to remove.
+- Powerbrain does **not** make a deployer GDPR- or AI-Act-compliant by
+  installation. It provides building blocks; the deployer must apply
+  them to the actual data flows.
+- Powerbrain does **not** replace organisational measures (training,
+  AVV with sub-processors, DPIA, breach response). It augments them.
+
+## What to ask Anthropic / your DPO
+
+When the conversation moves beyond what Powerbrain can answer:
+
+1. *"For our seat plan, is the DPA already in effect or do we need
+   to sign a separate copy?"* — usually no separate signature on
+   commercial plans, but ask for the executed copy in writing.
+2. *"What is the default retention on our plan, and can we negotiate
+   Zero Data Retention (ZDR)?"* — ZDR is Enterprise/API only, via
+   Sales, not self-service. Enterprise default retention is
+   unlimited; configurable down to 30 days minimum.
+3. *"Where is our data processed? Is EU residency available
+   contractually?"* — direct Anthropic does not advertise EU
+   residency; AWS Bedrock and GCP Vertex provide EU regions.
+4. *"What is your sub-processor list and how is it updated?"* —
+   available via Trust Center (login required).
+
+## See also
+
+- [editions.md](editions.md#edition-boundary-what-runs-through-powerbrain--and-what-doesnt) — the Community vs Enterprise data-path matrix
+- [gdpr-external-ai-services.md](gdpr-external-ai-services.md) — the underlying GDPR analysis (Art. 28, 32, 44–49, Schrems II)
+- [risk-management.md](risk-management.md) — EU AI Act Art. 9 risk register
+- [architecture.md](architecture.md) — system-level overview
+- [init-db/006_privacy_incidents.sql](../init-db/006_privacy_incidents.sql) — incident-tracking schema (the Powerbrain side of Art. 33/34 readiness)

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -49,6 +49,69 @@ running only the base profiles is community.
 | Per-provider key management + `X-Provider-Key` header | — | ✅ |
 | Chat document attachments (PDF/DOCX/XLSX extraction via OPA) | — | ✅ |
 
+## Edition boundary: what runs through Powerbrain — and what doesn't
+
+Powerbrain enforces policies on data **that passes through Powerbrain**.
+That sounds obvious, but with chat-native AI tools there is a non-obvious
+trap: the user's free-form prompt and the LLM's response form a channel
+that *only* the enterprise tier proxies. Direct-to-MCP setups leave that
+channel bypassed.
+
+### The three data paths
+
+| Path | Community (direct-to-MCP) | Enterprise (via pb-proxy) |
+|---|---|---|
+| **Ingest** — adapters pulling from GitHub, Office 365, Git, manual upload | ✅ Full pipeline: chunking → Presidio → quality gate → vault → embedding | ✅ Identical — adapters are independent of the chat tier |
+| **Tool calls** — `search_knowledge`, `query_data`, `graph_query`, … | ✅ OPA per request, vault tokens, audit chain | ✅ Same, plus optional purpose-bound `/vault/resolve` |
+| **Chat content** — user prompt, system instructions, LLM response, multimodal attachments | ❌ **Bypass** — goes directly from client to LLM provider, Powerbrain never sees it | ✅ Pseudonymised on the wire (`/pseudonymize`), policy-checked, audited |
+
+**Ingest and tool calls are protected in both editions.** The bypass
+only applies to the free-form chat channel.
+
+### Why this matters specifically for Claude Desktop / Claude Pro/Max
+
+Anthropic's consumer plans (Claude Free, Pro, Max) authenticate users
+via OAuth against the claude.ai backend. There is no `ANTHROPIC_BASE_URL`
+override in this mode — the endpoint is hardcoded. Consequently:
+
+- **Claude Desktop App** on Pro/Max: chat content goes straight to
+  Anthropic. You can register `pb-mcp-server` as an MCP endpoint to
+  protect tool calls, but the prompt/response channel itself is
+  bypassed.
+- **Claude Code CLI** on Pro/Max (via `claude /login`): identical
+  situation — OAuth to claude.ai, `ANTHROPIC_BASE_URL` ignored.
+  Hooks (`UserPromptSubmit` etc.) can however intercept the prompt
+  *locally* before it leaves the machine, which gives Claude Code a
+  mitigation lever that Claude Desktop App does not have.
+- **Claude Code CLI** in API-key mode (`ANTHROPIC_API_KEY=sk-ant-...`):
+  `ANTHROPIC_BASE_URL=http://pb-proxy:8090` works as expected. This is
+  the only Anthropic-native setup that gives you full chat-path
+  protection out of the box.
+- **OpenAI-compatible clients** (Cursor, OpenCode, custom SDKs)
+  pointed at `/v1/chat/completions` are unaffected — they go through
+  the proxy normally.
+
+### Implications for your compliance argument
+
+- If your argument depends on Powerbrain pseudonymising the chat
+  content itself (most GDPR Art. 32, Art. 5 scenarios), you must enforce
+  one of: (a) enterprise tier + clients that speak the proxy
+  (API-key Claude Code, OpenAI-compatible, or HTTP API), (b)
+  commercial Anthropic plan (Team/Enterprise/API) with DPA *plus*
+  Powerbrain proxy for the wire, or (c) endpoint DLP that blocks
+  consumer plans for regulated classifications.
+- If your argument only needs **policy-checked retrieval and audit
+  on the tool layer** — for example an internal assistant where the
+  chat is just UX over a deterministic tool flow — direct-to-MCP
+  community is sufficient.
+- The honest one-liner for customers: *"Powerbrain governs every
+  byte of retrieved enterprise data. It governs free chat content
+  only when clients speak our proxy."*
+
+See [compliance-claude-desktop.md](compliance-claude-desktop.md) for the
+three-tier mitigation model (real-time proxy, defence-in-depth chat-history
+ingest, endpoint DLP) and the GDPR/AI-Act mapping per tier.
+
 ## Which should I run?
 
 **Community fits when:**

--- a/docs/gdpr-external-ai-services.md
+++ b/docs/gdpr-external-ai-services.md
@@ -22,13 +22,24 @@ Anyone who passes personal data to a third party for processing
 **must** conclude a DPA. Without a DPA, the transfer is a violation —
 regardless of the recipient.
 
-| Service | DPA available? |
-|--------|----------------|
-| Anthropic API (Enterprise/Team) | Yes, can be concluded via the console |
-| claude.ai (Consumer) | **No** — Anthropic acts as its own controller there, not as a data processor |
+| Plan / Service | DPA available? | Activation |
+|---|---|---|
+| Claude Free / Pro / Max (Consumer) | **No** — Anthropic acts as its own controller, not as a data processor | — |
+| Claude Team / Enterprise / API / Claude Code commercial | Yes — DPA + SCCs are **automatically incorporated into the Commercial ToS** (no separate signature required); signed copy on request | Implicit on accepting Commercial ToS |
+| Via AWS Bedrock / GCP Vertex | DPA of the **hyperscaler**, not Anthropic | Per hyperscaler |
 
-For **claude.ai** there is structurally no DPA path. This alone
-rules out compliant use for data involving personal references.
+For **Consumer plans (Free/Pro/Max)** there is structurally no DPA
+path — Anthropic acts as its own controller. This alone rules out
+compliant use for data with personal references. Pro/Max being a
+"paid plan" does **not** make it a commercial plan in the DPA sense.
+
+⚠️ **Subscription bypass with Powerbrain in the picture:** Even when
+Powerbrain is deployed, a developer or knowledge worker who pastes
+personal data into a Claude Desktop window backed by a Pro/Max
+subscription transmits that data **outside** the Powerbrain perimeter
+— see [Edition boundary in editions.md](editions.md#edition-boundary-what-runs-through-powerbrain--and-what-doesnt)
+and [compliance-claude-desktop.md](compliance-claude-desktop.md) for the
+realistic mitigation tiers.
 
 ### 2. Third-Country Transfer USA (Art. 44–49 GDPR)
 
@@ -65,11 +76,17 @@ for the original data.
 
 | Scenario | Assessment |
 |----------|-----------|
-| claude.ai (Browser/Consumer) with personal data | **Clear violation** — no DPA possible, training data risk |
-| Anthropic API without DPA + SCCs | **Violation** — missing contractual basis |
+| claude.ai (Browser/Consumer) with personal data | **Clear violation** — no DPA possible, training-data risk |
+| Claude Desktop / Claude Code on Pro/Max subscription with personal data | **Clear violation** — same Consumer relation as claude.ai; no DPA, hardcoded endpoint, no proxy override |
+| Anthropic API (Team/Enterprise) without DPA acceptance + SCCs | **Violation** — missing contractual basis |
 | Anthropic API with DPA + SCCs, without TIA | **Likely violation** |
-| Anthropic API with DPA + SCCs + TIA + no training | Legally arguable, residual risk from CLOUD Act |
-| This project (Ollama local) | ✅ No transfer, no problem |
+| Anthropic API with DPA + SCCs + TIA + commercial-plan no-training default | Legally arguable, residual risk from CLOUD Act |
+| Powerbrain Community (direct-to-MCP) — chat against Anthropic, retrieval via Powerbrain | **Tool calls protected, chat content not** — apply the same DPA/SCC/TIA tests to the chat channel separately |
+| Powerbrain Enterprise (pb-proxy) → Anthropic commercial API with DPA | Wire pseudonymised by Powerbrain *before* Anthropic sees it, residual risk reduced — still TIA-dependent |
+| Powerbrain (any edition) → local LLM (Ollama / vLLM on-prem) | ✅ No transfer, no problem |
+
+→ The split into Powerbrain-protected and unprotected channels is
+detailed in [Edition boundary](editions.md#edition-boundary-what-runs-through-powerbrain--and-what-doesnt).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,15 @@ Add Powerbrain to your MCP client configuration:
 
 This works with Claude Desktop, Claude Code, OpenCode, or any MCP-compatible client. Replace the dev key with your production key when deploying.
 
+> **Note on the chat channel.** This configuration protects every
+> *tool call* the agent makes against Powerbrain, but the free-form
+> chat content (the user's prompt and the LLM's response) still goes
+> directly between the client and its LLM provider. For setups where
+> Powerbrain must also pseudonymise the chat content itself (e.g.
+> Claude Desktop or Claude Code in a Pro/Max subscription), see
+> [Edition boundary](editions.md#edition-boundary-what-runs-through-powerbrain--and-what-doesnt)
+> and [compliance-claude-desktop.md](compliance-claude-desktop.md).
+
 ## 4. Ingest Data
 
 Use the `ingest_data` tool to add content to the knowledge base:


### PR DESCRIPTION
## Summary

Make the structural limit of the Community tier explicit so customers and operators do not assume Powerbrain governs data paths that bypass it. No code changes — documentation only.

The recurring gap: Claude Desktop App and Claude Code on a Pro/Max subscription use OAuth against `claude.ai` and **cannot** be redirected via `ANTHROPIC_BASE_URL` — the chat content goes straight to Anthropic, regardless of whether `pb-proxy` is deployed. Powerbrain's Community tier protects ingest and MCP tool calls, but the free chat channel is bypassed for subscription clients. Until now this was only implicit in `docs/editions.md`; this PR makes it explicit at every touchpoint where a reader could mistakenly assume full coverage.

## What changed

- **`docs/editions.md`** — new "Edition boundary" section with the three-paths matrix (ingest / tool calls / chat content) and Pro-Max-specific notes for Claude Desktop App and Claude Code (OAuth vs API-key mode)
- **`docs/compliance-claude-desktop.md` (new)** — standalone compliance one-pager: TL;DR, bypass mechanics, three-tier mitigation model (real-time proxy / detective chat-history ingest / endpoint DLP), DPA vs EU AI Act distinction, per-scenario recommendations, "what Powerbrain does not claim", DPO/Anthropic question list
- **`docs/gdpr-external-ai-services.md`** — DPA availability table broken down by plan (Free/Pro/Max have none; Team/Enterprise/API have auto-incorporated DPA+SCCs), assessment matrix extended with Powerbrain configurations (Community vs Enterprise vs local-LLM)
- **`README.md`** — AI Provider Proxy bullet notes the chat-path bypass for subscription clients; doc index extended with editions and compliance pages
- **`docs/getting-started.md`** — client-connect section flags that tool calls are protected but free chat content is not, with link to the edition boundary
- **`CLAUDE.md`** — new "Edition Boundary" subsection under Key Concepts so agent-facing context is consistent with the customer docs

## Test plan

- [ ] Verify the new and edited links resolve in GitHub's Markdown preview (especially the internal anchors `#edition-boundary-what-runs-through-powerbrain--and-what-doesnt`)
- [ ] Read `docs/compliance-claude-desktop.md` end-to-end and sanity-check that every claim is conservative (no overreach beyond cited Anthropic sources)
- [ ] Spot-check that the tone is consistently neutral-honest in `editions.md` / `getting-started.md` / `README.md` and explicitly warning (⚠️) only in `gdpr-external-ai-services.md`
- [ ] Confirm `CLAUDE.md` Edition Boundary section is short enough to be useful as agent context (does not duplicate the customer doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)