### PR TITLE
release: v0.10.0 — chat-path bypass transparency + incident MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-13
+
+First minor bump since v0.9.0. Two PRs shipped together: (1) the
+chat-path-bypass documentation refresh that names the structural limit
+of the Community tier when Anthropic consumer plans (Pro/Max) are in
+the picture, and (2) the privacy-incident MCP-tool layer + 72-hour
+deadline watcher on top of the long-standing `privacy_incidents`
+schema. No DB migrations, no breaking config changes — the OPA
+`pb.config.incidents` block is additive and the new MCP tools are
+gated by the same `pb_` API-key auth as every other tool.
+
 ### Added
 
 - **Privacy Incident MCP Tools (B-47, GDPR Art. 33/34)** — Five MCP tools


### PR DESCRIPTION
## Summary

Promote the `[Unreleased]` section to `[0.10.0] - 2026-05-13`. First minor bump since v0.9.0; collects two PRs that landed today:

- [PR #153](https://github.com/nuetzliches/powerbrain/pull/153) — Edition-boundary docs + `compliance-claude-desktop.md` one-pager. Honest statement of which data paths Powerbrain governs and which it cannot (consumer Anthropic plans bypass the chat channel).
- [PR #154](https://github.com/nuetzliches/powerbrain/pull/154) — Five privacy-incident MCP tools + OPA package `pb.incidents` + `incident_deadline_check` worker job + three Prometheus alert rules for the GDPR Art. 33 72-hour notification deadline.

## Test plan

- [x] Both contributing PRs landed CI-green (4/4 jobs)
- [x] OPA 154/154, MCP-tool tests 19/19, worker tests 38/38 local
- [x] CHANGELOG diff: pure section rename + version-bump preface, no other changes
- [ ] After merge: tag `v0.10.0` at the merge commit and push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)