### PR TITLE
docs(plan): refresh audit-mirror for three-tab structure

### DIFF
--- a/docs/plans/2026-05-20-claude-chat-audit-mirror.md
+++ b/docs/plans/2026-05-20-claude-chat-audit-mirror.md
@@ -1,9 +1,10 @@
 # Claude Chat Audit-Mirror — Konzept
 
-**Date:** 2026-05-20
+**Date:** 2026-05-20 (refresh 2026-05-22 für Drei-Tab-Struktur)
 **Status:** Draft (Konzept zur Diskussion)
-**Scope:** Detektivische PII-Audits über Claude-Pro/Max-Konversationen, die am
-`pb-proxy` vorbeilaufen.
+**Scope:** Detektivische PII-Audits über Claude-Pro/Max-Konversationen (alle drei
+Tabs: Chat, Cowork, Code), die am `pb-proxy` vorbeilaufen.
+**Companion-Spec:** [Claude Desktop Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md) — dieser Plan ist Komponente **B (Audit Mirror)** in der dort formulierten Vier-Komponenten-Verteidigung.
 
 ---
 
@@ -12,43 +13,72 @@
 Claude Pro/Max (Abo) authentifiziert sich per OAuth gegen `claude.ai`.
 `ANTHROPIC_BASE_URL` ist effektiv hartkodiert — Traffic kann **nicht** durch
 `pb-proxy` umgeleitet werden (siehe [editions.md](../editions.md) +
-[compliance-claude-desktop.md](../compliance-claude-desktop.md)). Folge: der
-Chat-Kanal ist im Abo-Modus für Powerbrain unsichtbar. Eine echte Realtime-
-Prävention von PII-Leaks ist über den Proxy nicht erreichbar.
+[compliance-claude-desktop.md](../compliance-claude-desktop.md)). Folge: alle
+drei Claude-Desktop-Tabs (**Chat**, **Cowork**, **Code**) leiten Inhalte am
+Powerbrain-Proxy vorbei direkt zu Anthropic.
 
-Wirtschaftlich auf API-Tier zu wechseln ist für Solo-/Kleinteam-Setups oft
-nicht attraktiv (Pro-Abo deckt 95 % der Coding-Sessions ab). Der Pragmatismus
-heißt: **detektivisch statt präventiv**. Wir akzeptieren, dass Chat-Inhalte
-ungescannt zu Anthropic gehen, schaffen aber einen Audit-Pfad, der retroaktiv
-zeigt, *welche* personenbezogenen Daten in welcher Konversation gelandet sind.
+Anthropics 2026er Policy-Bewegungen verstärken die Notwendigkeit eines
+detektivischen Pfads zusätzlich:
+
+- **2026-02 Authentication and Credential Use Policy** — OAuth-Credentials sind
+  "intended exclusively for Claude Code and claude.ai". Drittclients mit
+  Pro/Max-Token sind explizit policy-widrig. Damit fällt jeder Wrapper-/
+  Proxy-Ansatz für Pro/Max aus.
+- **2026-04-04 Third-Party-Harness-Enforcement** — technische Sperre für
+  programmatische Pro/Max-Nutzung. Verhindert pragmatische Workarounds.
+
+Eine echte Realtime-Prävention von PII-Leaks ist im Abo-Modus mit
+Powerbrain-Mitteln **nicht erreichbar**. Wirtschaftlich auf API-Tier zu
+wechseln ist für Solo-/Kleinteam-Setups oft nicht attraktiv (Pro-Abo deckt
+95% der Coding-Sessions ab), und für Heavy-Coding-Agent-Use auf Org-Ebene
+ist API-Pricing prohibitiv (5–20× der Abo-Kosten).
+
+Der Pragmatismus heißt: **detektivisch statt präventiv**. Wir akzeptieren,
+dass Inhalte aus allen drei Tabs ungescannt zu Anthropic gehen, schaffen
+aber einen Audit-Pfad, der retroaktiv zeigt, *welche* personenbezogenen
+Daten in welcher Konversation gelandet sind — und in welcher Tab-Kategorie.
 
 ## 2. Ziel
 
-Drei messbare Ergebnisse:
+Drei messbare Ergebnisse, jeweils tab-übergreifend (Chat/Cowork/Code):
 
 1. **Vollständigkeit** — jede Conversation einer kontrollierten Anthropic-
-   Identität wird mindestens einmal gegen `pb-ingestion /scan` geprüft.
-2. **Auditierbarkeit** — Treffer (PII-Entitäten + Score + Quelle) landen
+   Identität wird mindestens einmal gegen `pb-ingestion /scan` geprüft. Code-Tab-
+   Konversationen umfassen zusätzlich File-Edit-Diffs und Terminal-Command-
+   Logs aus der Session-History.
+2. **Auditierbarkeit** — Treffer (PII-Entitäten + Score + Tab + Quelle) landen
    tamper-evident im Powerbrain Audit-Log (Art. 12, `audit_log_entries`).
 3. **Reaktion** — bei Treffern existiert ein definierter Workflow: Conversation
    in claude.ai löschen + Anthropic-Löschanforderung (Art. 17) + interne
    Incident-Notiz (`privacy_incidents`).
 
 Explizit **kein** Ziel: Live-Tampering von Outgoing-Messages. Das geht im
-Abo-Modus technisch nicht ohne TLS-MITM (siehe Abschnitt 4D).
+Abo-Modus technisch nicht ohne TLS-MITM (siehe Abschnitt 4D) und ist nach
+2026-04 Anthropic-Enforcement auch policy-widrig.
 
-## 3. Begriffsklärung — "Mirror"
+## 3. Begriffsklärung — "Mirror" und Abgrenzung zu Pre-flight
 
 Drei Interpretationen, die im Gespräch durcheinandergehen:
 
 | Begriff | Was es heißt | Wird hier behandelt? |
 |---|---|---|
-| **Mirror** (Audit) | Conversations werden kopiert + nachträglich gescannt | ✅ Ja |
-| **Inline-Scrubbing** | Outgoing-Text wird *vor* Anthropic mutiert | ❌ Nein (nur via Proxy oder Browser-Extension möglich) |
-| **Realtime-Warning** | UI zeigt PII-Warnung *vor* dem Submit | Teilweise — Abschnitt 4B |
+| **Mirror** (Audit) | Conversations werden kopiert + nachträglich gescannt | ✅ Ja, das ist der Kern dieses Plans |
+| **Inline-Scrubbing** | Outgoing-Text wird *vor* Anthropic mutiert | ❌ Nein (für Claude Desktop nicht möglich; für claude.ai-Web theoretisch via Extension/Pre-flight, siehe unten) |
+| **Realtime-Warning** | UI zeigt PII-Warnung *vor* dem Submit | Teilweise — Abschnitt 4B für claude.ai-Web; via separatem Tool [Pre-flight](../specs/2026-05-22-claude-desktop-coverage-strategy.md#d-pre-flight-new-component--this-specs-only-new-build) für Desktop-Workflows |
 
-Dieser Plan adressiert primär den Audit-Pfad. Browser-Extension wird als
-nahezu kostenlose Erweiterung mitgeführt.
+Dieser Plan adressiert primär den Audit-Pfad (Komponente B in der Coverage
+Strategy). Browser-Extension (4B) und Pre-flight (separater Spec) sind die
+präventiven Pendants:
+
+- **Browser-Extension** — claude.ai-Web spezifisch, intercepted Composer-DOM,
+  zeigt Warnung vor Submit. Funktioniert nur im Browser-Tab, nicht in Claude
+  Desktop.
+- **Pre-flight (separater Spec)** — Tauri-App, hilft dem User PII zu pseudonymi-
+  sieren *bevor* er in Claude Desktop pastet. Klipboard-basiert, ToS-clean, weil
+  sie Claude Desktop nicht anfasst.
+
+Die Komponenten sind komplementär: Audit-Mirror fängt detektivisch auf, was
+Pre-flight präventiv verpasst.
 
 ## 4. Optionsraum
 
@@ -84,6 +114,9 @@ Endpoint, aber undokumentiert und sessionbasiert).
 - Heute machbar, keine Anthropic-seitige Mitwirkung nötig.
 - Funktioniert für Web + Desktop + Mobile (alle Clients schreiben in dieselbe
   serverseitige Conversation-Liste).
+- **Tab-übergreifend:** Export liefert Chat-, Cowork- und Code-Tab-Sessions im
+  selben Dump (jeweils mit `tab`-Metadatum), inklusive Code-Tab-spezifischer
+  Artefakte (File-Edit-Diffs, Terminal-Commands, Computer-Use-Events).
 - Vollständig seit Account-Start.
 
 **Nachteile:**
@@ -97,6 +130,10 @@ Endpoint, aber undokumentiert und sessionbasiert).
 **Aufwand:** ~1 Tag (Skript + Cron + Audit-Insert + Report-Mail).
 
 ### B) Browser-Extension für claude.ai
+
+*Scope-Hinweis: deckt **nur** claude.ai-Web ab (Chat-Tab im Browser). Für
+Claude Desktop nicht anwendbar — siehe Pre-flight-Spec in der Coverage
+Strategy für Desktop-Workflows.*
 
 Chrome/Firefox-Extension, die das Composer-`<div contenteditable>` von claude.ai
 beobachtet. Bei jedem Submit:
@@ -125,13 +162,22 @@ UI, Packaging).
 
 Claude Desktop (Electron) cached Conversations lokal:
 `%APPDATA%\Claude\` (Windows), `~/Library/Application Support/Claude/` (macOS).
-LevelDB/IndexedDB-Format. Ein Watcher könnte periodisch auslesen.
+LevelDB/IndexedDB-Format. Ein Watcher könnte periodisch auslesen — pro Tab
+liegen die Session-Daten in unterschiedlichen Sub-Stores (Chat / Cowork / Code).
 
-**Verworfen — Begründung:**
-- Undokumentiertes Storage-Format.
+**Verworfen für die primäre Pipeline — Begründung:**
+- Undokumentiertes Storage-Format, pro Tab unterschiedliches Schema.
 - Verschlüsselung-at-rest in neueren Versionen.
 - Schema kann sich mit jedem Desktop-Update ändern → permanenter Wartungsbedarf.
 - Liefert dieselben Daten wie Variante A (Server-Authority), nur fragiler.
+- Code-Tab speichert Datei-Inhalte teilweise als Referenz auf den User-Filesystem-
+  Pfad statt embedded — Inspektion müsste dem Pfad folgen und Datei-Inhalt
+  nachladen.
+
+**Bleibt als Fallback dokumentiert** für Cases, in denen Anthropic-Export-Endpoint
+unverfügbar oder gedrosselt ist (Stand 2026-05-22 unproblematisch, aber API-Wandel
+ist eine reale Sorge). In dem Fall braucht es einen Per-Tab-Schema-Adapter ähnlich
+dem in der Coverage Strategy (Open Question §2) skizzierten DOM-Adapter-Modell.
 
 ### D) Lokaler MITM-Proxy
 
@@ -139,44 +185,55 @@ mitmproxy + selbstsigniertes CA-Cert im OS-Trust-Store. Fängt
 `api.anthropic.com`-Traffic ab, leitet 1:1 weiter, kopiert Bodies in eine
 Audit-Queue.
 
-**Verworfen für jetzt — Begründung:**
+**Verworfen — Begründung:**
 - Eingriff ins OS-Trust-Modell (Risikoexposition für *alle* HTTPS-Apps).
 - Cert-Pinning in Claude Desktop wahrscheinlich → Connect-Fail.
 - OAuth-Tokens an Hostname + Cert gebunden → hohes Brick-Risiko.
 - Aufwand für sauberen Betrieb (CA-Rotation, Cert-Refresh, Auto-Start) erheblich.
+- **2026-02 Anthropic Authentication Policy:** OAuth-Credentials sind
+  ausschließlich für Anthropic-eigene Clients freigegeben. Ein MITM-Proxy ist
+  per Definition kein Anthropic-Client und damit policy-widrig — selbst wenn
+  technisch betriebsfähig.
 
-Wird als Fallback für Anthropic-Enterprise-Cases dokumentiert, falls A nicht
-vollständig genug ist.
+Damit ist D nicht mehr als "Enterprise-Fallback" haltbar; für Enterprise-Cases
+verweist die [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md)
+auf Endpoint-DLP (Komponente C) + API-Key-Mode-Workloads als getrennten Pfad.
 
 ## 5. Empfohlene Architektur
 
-**Stack: A (Pflicht) + B (Quick-Win)**
+**Stack: A (Pflicht, alle Tabs) + B (Quick-Win, claude.ai-Web nur)**
+**Komplementär: Pre-flight aus der [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md) für präventive Desktop-Workflows.**
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│  Claude-Konsum (Abo)                                          │
-│  ┌─────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │ claude.ai   │  │ Claude       │  │ Claude       │         │
-│  │ (Browser)   │  │ Desktop      │  │ Mobile       │         │
-│  └──────┬──────┘  └──────┬───────┘  └──────┬───────┘         │
-│         │                │                  │                │
-│         ▼ (B: live)      │                  │                │
-│  ┌─────────────┐         │                  │                │
-│  │ pb-guardian │         │                  │                │
-│  │ Extension   │         │                  │                │
-│  └──────┬──────┘         │                  │                │
-└─────────┼────────────────┼──────────────────┼────────────────┘
-          │                │                  │
-          │                ▼ (alles)          │
-          │         ┌─────────────────────────┴─┐
-          │         │  Anthropic Cloud           │
-          │         │  (Conversations gespeichert)│
-          │         └─────────────┬──────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│  Claude-Konsum (Pro/Max-Abo)                                          │
+│                                                                       │
+│  ┌─────────────┐    ┌────────────────────────────────────────────┐   │
+│  │ claude.ai   │    │ Claude Desktop                              │   │
+│  │ (Browser)   │    │ ┌──────┐ ┌────────┐ ┌────────────────────┐ │   │
+│  │             │    │ │ Chat │ │ Cowork │ │ Code               │ │   │
+│  └──────┬──────┘    │ │      │ │        │ │ (file edits,       │ │   │
+│         │           │ │      │ │        │ │  terminal, CU)     │ │   │
+│         │           │ └──────┘ └────────┘ └────────────────────┘ │   │
+│         │           └─────────────────┬───────────────────────────┘   │
+│         ▼ (B: live)                   │                               │
+│  ┌─────────────┐                      │                               │
+│  │ pb-guardian │                      │                               │
+│  │ Extension   │                      │                               │
+│  └──────┬──────┘                      │                               │
+└─────────┼─────────────────────────────┼───────────────────────────────┘
+          │                             │
+          │                ▼ (alles, alle Tabs)
+          │         ┌─────────────────────────────┐
+          │         │  Anthropic Cloud             │
+          │         │  Conversations + Code-Sessions│
+          │         │  (Server-side storage)        │
+          │         └─────────────┬────────────────┘
           │                       │
           │           ┌───────────┴──────────┐
-          │           │  A: Wöchentlicher    │
+          │           │  A: Periodischer     │
           │           │  Export-Worker       │
-          │           │  (cron, int-baumeister)│
+          │           │  (cron, pb-worker)   │
           │           └───────────┬──────────┘
           │                       │
           └───────────┬───────────┘
@@ -184,18 +241,23 @@ vollständig genug ist.
             ┌──────────────────┐
             │ pb-ingestion     │
             │  POST /scan      │
+            │  (text + diffs +  │
+            │   commands)       │
             └────────┬─────────┘
                      │
                      ▼
-            ┌──────────────────┐
-            │ pb-mcp-server    │
-            │  audit_log_entries│
-            │  privacy_incidents│
-            └──────────────────┘
+            ┌──────────────────────┐
+            │ pb-mcp-server        │
+            │  audit_log_entries   │  ← findings tagged {tab, source}
+            │  privacy_incidents   │
+            │  chat_audit_findings │
+            └──────────────────────┘
 ```
 
-A liefert **Vollständigkeit** über alle Clients. B liefert **Realtime-
-Prävention** für den häufigsten Einzelfall (claude.ai Web).
+A liefert **Vollständigkeit** über alle Clients und alle Tabs (Chat/Cowork/Code).
+B liefert **Realtime-Prävention** für den häufigsten Einzelfall (claude.ai Web).
+Pre-flight (separater Spec) ergänzt B für Desktop-Workflows ohne in Claude
+Desktop einzugreifen.
 
 ## 6. Komponenten
 
@@ -221,17 +283,31 @@ CHAT_AUDIT_REPORT_WEBHOOK: str   # optional, Slack/Teams
 1. **Fetch** — Headless-Browser (Playwright) loggt sich via Cookie ein,
    triggert Export, wartet auf Download. Fallback: REST-Polling der internen
    `claude.ai/api/organizations/{org}/chat_conversations` (Pro-Account).
+   Export umfasst alle drei Tabs; pro Conversation ist das Feld `tab` (oder
+   ein äquivalenter Discriminator) auszuwerten.
 2. **Diff** — Zustand des letzten Runs (gespeichert in
    `chat_audit_state.last_conversation_ts`) bestimmt, welche Conversations neu
    oder geändert sind.
-3. **Scan** — Für jede neue/geänderte Message: `POST /scan` mit `text`,
-   `language: "de"`. Antwort enthält `pii_entities[]`.
+3. **Scan — pro Tab unterschiedliche Payload-Typen:**
+   - **Chat-Tab:** je Message → `POST /scan` mit `text`, `language: "de"`.
+     Antwort enthält `pii_entities[]`.
+   - **Cowork-Tab:** je Task-Phase + jeder Reportabschnitt → `POST /scan`. Längere
+     Texte, ggf. Chunking auf ~2KB-Stücke vor dem Scan.
+   - **Code-Tab:** zusätzlich zur Chat-History sind zu scannen:
+     - **File-Edit-Diffs** — pro Edit der Diff-Text (`+` und `-` Zeilen). PII
+       in Kommentaren / Strings / Variablennamen ist hier real.
+     - **Terminal-Commands** — Command-Line + stdout/stderr-Capture. Häufige
+       Treffer: Pfade mit User-Home, hostname, IP-Adressen, Tokens in env-Dumps.
+     - **Computer-Use-Actions** — UI-Actions (click, type) protokollieren
+       getippten Text. Falls vorhanden im Session-Log: scannen.
 4. **Persist** — Bei Treffer: Insert in `audit_log_entries`
-   (`action=chat_audit`, `metadata={conversation_id, message_id, entities,
-   max_score}`). Hash-Chain stellt Manipulation fest. Bei `score >= 0.8` oder
-   sensiblen Typen (IBAN, PASSPORT): zusätzlich `privacy_incidents`-Row mit
-   `status=detected`, `category=external_disclosure`.
-5. **Report** — Aggregierter Report (HTML oder Markdown) per Mail/Webhook.
+   (`action=chat_audit`, `metadata={conversation_id, message_id, tab,
+   artifact_type, entities, max_score}`). Hash-Chain stellt Manipulation
+   fest. Bei `score >= 0.8` oder sensiblen Typen (IBAN, PASSPORT):
+   zusätzlich `privacy_incidents`-Row mit `status=detected`,
+   `category=external_disclosure`, `data_category` abgeleitet aus `tab`.
+5. **Report** — Aggregierter Report (HTML oder Markdown) per Mail/Webhook,
+   gruppiert nach Tab und Artifact-Type.
 
 **Neue Tabellen:**
 
@@ -248,9 +324,11 @@ CREATE TABLE chat_audit_findings (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     detected_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
     source          TEXT NOT NULL,       -- 'anthropic'
+    tab             TEXT NOT NULL,       -- 'chat' | 'cowork' | 'code'
+    artifact_type   TEXT NOT NULL,       -- 'message' | 'file_diff' | 'terminal_command' | 'cu_action' | 'cowork_phase'
     conversation_id TEXT NOT NULL,
-    message_id      TEXT NOT NULL,
-    role            TEXT NOT NULL,       -- 'user' | 'assistant'
+    message_id      TEXT NOT NULL,       -- für Code-Tab: edit-id / command-id
+    role            TEXT NOT NULL,       -- 'user' | 'assistant' | 'tool'
     entities        JSONB NOT NULL,      -- [{type, score, start, end}]
     max_score       REAL NOT NULL,
     audit_log_id    UUID REFERENCES audit_log_entries(id),
@@ -258,6 +336,7 @@ CREATE TABLE chat_audit_findings (
 );
 CREATE INDEX idx_chat_audit_findings_conversation ON chat_audit_findings(conversation_id);
 CREATE INDEX idx_chat_audit_findings_detected_at ON chat_audit_findings(detected_at DESC);
+CREATE INDEX idx_chat_audit_findings_tab ON chat_audit_findings(tab, detected_at DESC);
 ```
 
 ### 6.2 Browser-Extension (Variante B)
@@ -326,15 +405,22 @@ Admin kann Schwellwerte und Auto-Incident-Trigger ohne Restart über
 
 ## 7. Rollout
 
-| Phase | Inhalt | Aufwand | Wert |
-|---|---|---|---|
-| **0** | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
-| **1** | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report | 1.5 d | ✅ Vollständige Auditierung |
-| **2** | B — pb-guardian Extension, Chrome-Store-Submit | 2 d | ⚠️ Live-Prävention claude.ai Web |
-| **3** | Dashboard in Grafana: "Chat PII Findings per Week" + Auto-Incident-Tile | 0.5 d | Sichtbarkeit |
-| **4** | OPA-Policy-Tuning auf Basis erster Treffer (false-positive-Rate) | iterativ | Qualität |
+Aligned mit der [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md#roll-out)
+Phasen-Nummerierung:
 
-Phasen 1 und 2 können parallel laufen (verschiedene Skill-Sets).
+| Phase | Coverage-Strategy-Mapping | Inhalt | Aufwand | Wert |
+|---|---|---|---|---|
+| **A.0** | (Voraussetzung) | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
+| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
+| **A.2** | Phase 2 Erweiterung | A erweitert auf **Cowork**-Tab (Task-Phase-Chunking) | 0.5 d | ✅ Tab-`cowork` auditiert |
+| **A.3** | Phase 2 Erweiterung | A erweitert auf **Code**-Tab (File-Diffs, Terminal-Commands, Computer-Use-Actions) | 2 d | ✅ Tab-`code` auditiert — der größte Coverage-Sprung |
+| **B.1** | Phase 2 Defence-in-Depth | B — pb-guardian Extension, Chrome-Store-Submit (claude.ai-Web nur, Chat-Composer) | 2 d | ⚠️ Live-Prävention für den Browser-Use-Case |
+| **C.1** | Phase 1 "Document + position" | Dashboard in Grafana: "Chat PII Findings per Tab per Week" + Auto-Incident-Tile | 0.5 d | Sichtbarkeit |
+| **C.2** | (laufend) | OPA-Policy-Tuning auf Basis erster Treffer (false-positive-Rate, per Tab) | iterativ | Qualität |
+
+Phasen A.1 / B.1 / C.1 können parallel laufen (verschiedene Skill-Sets).
+A.3 ist der höchste Aufwand, hat aber auch den höchsten Compliance-Wert —
+Code-Tab ist im Kunden-Use-Case der Hauptkanal.
 
 ## 8. Compliance-Wirkung
 
@@ -373,6 +459,21 @@ haben — und schnell reagieren können.
    Conversations lesen — das ist gewollt, aber sollte in der internen Policy
    transparent gemacht werden (Mitarbeiterinformation falls jemals
    Mehr-User-Setup).
+7. **Code-Tab — File-Inhalte vs. Diffs.** Der Server-Export liefert die
+   Diffs (Edit-Operationen), nicht zwingend den vollständigen File-Inhalt
+   nach jeder Edit. Wenn PII nur in unveränderten File-Teilen existiert,
+   die der Coding-Agent gelesen aber nicht geändert hat, ist die im Diff
+   nicht sichtbar. Mitigation: Pre-flight (separater Spec) `resolve file`-
+   Mode kann ergänzend ganze Files gegen den Vault scannen.
+8. **Code-Tab — Computer-Use-Captures.** Ob Anthropic-Export die Computer-
+   Use-Actions (incl. getippter Text in andere Apps) lückenlos protokolliert,
+   ist nicht vollständig dokumentiert. Falls nicht: Audit-Lücke für diesen
+   Modus. Endpoint-DLP (Coverage Strategy Komponente C) ist hier die
+   ergänzende Antwort.
+9. **Cowork-Tab — Long-Context-Chunking.** Cowork-Tasks können sehr lange
+   Texte enthalten. Naïves `/scan` läuft in Presidio-Timeouts. Chunking auf
+   ~2KB ist nötig, mit Aufmerksamkeit auf Entity-Splits über Chunk-Grenzen
+   (Mitigation: 200-Byte-Overlap zwischen Chunks).
 
 ## 10. Offene Fragen
 
@@ -391,22 +492,32 @@ haben — und schnell reagieren können.
 
 ## 11. Nächste Schritte
 
-Wenn das Konzept grundsätzlich abgenommen ist:
+Wenn das Konzept (und die übergeordnete [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md))
+grundsätzlich abgenommen sind:
 
-1. Spec für Phase 0 (`/provider/scan`-Endpoint) schreiben → `docs/specs/`.
-2. Spec für Phase 1 (Export-Worker) schreiben → `docs/specs/`.
-3. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`).
-4. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
+1. Spec für Phase A.0 (`/provider/scan`-Endpoint im pb-proxy) schreiben → `docs/specs/`.
+2. Spec für Phase A.1 (Export-Worker, Chat-Tab) schreiben → `docs/specs/`.
+3. Tab-Adapter-Spezifikation für A.2 (Cowork) + A.3 (Code) als
+   Folge-Spec — die Adapter folgen demselben Selector-Adapter-Muster, das in
+   der Coverage Strategy für Pre-flight skizziert ist.
+4. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`) — Scope explizit
+   auf claude.ai-Web halten, Desktop-Workflows decken durch Pre-flight ab.
+5. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
    `nuts/powerbrain` einreichen.
 
 ---
 
 **Cross-References:**
 
-- [editions.md](../editions.md) — Edition-Boundary, drei Datenpfade
+- [editions.md](../editions.md) — Edition-Boundary, drei Datenpfade (ingest /
+  tool-calls / chat-content)
 - [compliance-claude-desktop.md](../compliance-claude-desktop.md) — Drei-Tier-
   Mitigation-Modell, hier ist Tier 2 (detective chat-history ingest)
   spezifiziert
+- [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md)
+  — übergeordneter Spec, in dem dieser Plan als Komponente B verankert ist;
+  enthält das Vier-Komponenten-Modell (MCP Connector / Audit Mirror /
+  Endpoint DLP / Pre-flight) und das Decision-Record gegen Wrapper-Ansätze
 - [gdpr-external-ai-services.md](../gdpr-external-ai-services.md) — DPA-
   Matrix, AVV-Status pro Anthropic-Plan
 - [risk-management.md](../risk-management.md) — Risikoregister-Eintrag für

--- a/docs/plans/2026-05-20-claude-chat-audit-mirror.md
+++ b/docs/plans/2026-05-20-claude-chat-audit-mirror.md
@@ -312,7 +312,7 @@ CHAT_AUDIT_REPORT_WEBHOOK: str   # optional, Slack/Teams
 **Neue Tabellen:**
 
 ```sql
--- init-db/021_chat_audit.sql
+-- init-db/027_chat_audit.sql
 CREATE TABLE chat_audit_state (
     source         TEXT PRIMARY KEY,    -- 'anthropic'
     last_export_at TIMESTAMPTZ,
@@ -411,7 +411,7 @@ Phasen-Nummerierung:
 | Phase | Coverage-Strategy-Mapping | Inhalt | Aufwand | Wert |
 |---|---|---|---|---|
 | **A.0** | (Voraussetzung) | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
-| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
+| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 027, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
 | **A.2** | Phase 2 Erweiterung | A erweitert auf **Cowork**-Tab (Task-Phase-Chunking) | 0.5 d | ✅ Tab-`cowork` auditiert |
 | **A.3** | Phase 2 Erweiterung | A erweitert auf **Code**-Tab (File-Diffs, Terminal-Commands, Computer-Use-Actions) | 2 d | ✅ Tab-`code` auditiert — der größte Coverage-Sprung |
 | **B.1** | Phase 2 Defence-in-Depth | B — pb-guardian Extension, Chrome-Store-Submit (claude.ai-Web nur, Chat-Composer) | 2 d | ⚠️ Live-Prävention für den Browser-Use-Case |
@@ -502,7 +502,7 @@ grundsätzlich abgenommen sind:
    der Coverage Strategy für Pre-flight skizziert ist.
 4. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`) — Scope explizit
    auf claude.ai-Web halten, Desktop-Workflows decken durch Pre-flight ab.
-5. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
+5. OPA-Policy-Section + Migration 027 als kleinen Vorlauf-PR auf
    `nuts/powerbrain` einreichen.
 
 ---

--- a/docs/specs/2026-05-22-claude-desktop-coverage-strategy.md
+++ b/docs/specs/2026-05-22-claude-desktop-coverage-strategy.md
@@ -1,0 +1,250 @@
+# Claude Desktop Coverage Strategy — Spec
+
+**Status:** Draft 2026-05-22, not yet approved
+**Owner:** Powerbrain core team
+**Supersedes:** [PR #174 — Pseudonym Bridge spec, closed 2026-05-22](https://github.com/nuetzliches/powerbrain/pull/174)
+**Related:** [docs/editions.md](../editions.md), [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md), [docs/plans/2026-05-20-claude-chat-audit-mirror.md](../plans/2026-05-20-claude-chat-audit-mirror.md)
+
+## Motivation
+
+Enterprise customers want to keep using **Claude Desktop on Pro/Max subscriptions** with Powerbrain mediating as much of the data flow as possible for GDPR / EU AI Act compliance. Three constraints are non-negotiable from the customer side:
+
+1. **Pro/Max stays.** Per-developer Pro/Max is the cost model that fits org budgets. API-priced usage at scale (heavy coding-agent workloads, hundreds of devs) is prohibitively expensive — often 5–20× the subscription cost.
+2. **Claude Desktop stays.** Especially the Code tab — the integrated coding-agent UX with sessions, Git isolation, terminal, computer use, and visual diff review is what the org has standardized on. Replacing it with a CLI or a different tool is organisationally not feasible.
+3. **"Just ban it" is not viable.** Without an officially supported path, employees use Claude Desktop anyway via shadow IT. Compliance then has zero visibility — worse than a partial-coverage sanctioned solution.
+
+The customer ask is therefore: *what is the maximum honest coverage Powerbrain can deliver for Claude Desktop on Pro/Max, given Anthropic's 2026 policy posture, and what can compliance teams credibly tell their DPO and DPA based on that coverage?*
+
+This spec is the honest answer. It supersedes the Pseudonym Bridge spec, which targeted the wrong abstraction (claude.ai chat webview) and the wrong threat model.
+
+## What changed in 2026 that closes the obvious paths
+
+Three Anthropic policy / enforcement moves reshape the design space:
+
+1. **2026-02 — "Authentication and Credential Use" policy.** OAuth credentials (Free / Pro / Max) are *"intended exclusively for Claude Code and claude.ai"*. Third-party clients using Pro/Max OAuth are now explicitly policy-violating.
+2. **2026-04-04 — Third-party harness enforcement.** Anthropic technically blocked third-party harnesses from using Max subscription limits. Projects in the [CLIProxyAPI](https://rogs.me/2026/02/use-your-claude-max-subscription-as-an-api-with-cliproxyapi/) / [Claw Code](https://claw-code.codes/) class were the direct target.
+3. **2025-10-08 Consumer Terms Section 3** remains: prohibits reverse-engineering, decompilation, and access to the Service through "automated or non-human means" except via Anthropic API key.
+
+What these close, definitively:
+
+- Wrapping or modifying the Claude Desktop binary
+- Forking Claude Code and using Pro/Max OAuth in the fork
+- Building a proxy that relays Pro/Max OAuth credentials to api.claude.ai
+- DOM-injecting into Anthropic's proprietary client UI
+
+What they do **not** close:
+
+- Powerbrain components running alongside Claude Desktop, used voluntarily by the user
+- Powerbrain MCP servers registered through Claude Desktop's official Connectors mechanism
+- Network-level controls applied by the customer's IT department to their own endpoints
+- Detective audit of conversations after the fact, from data the user already has access to
+
+This spec lives entirely in the "do not close" half.
+
+## Claude Desktop in May 2026 — three tabs, three flow profiles
+
+Claude Desktop (macOS + Windows; Linux still uses the CLI) has three tabs:
+
+| Tab | Purpose | Primary data flow | Tool calls | File access | Computer use |
+|---|---|---|---|---|---|
+| **Chat** | Free-form conversation | Prompt → LLM → Response | Limited (search etc.) | None | No |
+| **Cowork** | Dispatched / longer agentic work | Task → background agent → report | Moderate | Workspace-scoped | No |
+| **Code** | Software development (coding agent) | Prompt → agent loop → file edits, terminal, computer use | Extensive | Full project access | Yes (research preview) |
+
+All three authenticate via OAuth against Anthropic. All three send chat content directly to Anthropic's edge. Powerbrain currently sits in two places:
+
+- As a **Connector** (MCP server) registered in Claude Desktop's settings — touches the tool-call layer
+- As an **ingestion sink** for content the user explicitly imports via Powerbrain adapters (GitHub, Office 365, etc.) — touches the knowledge-base layer
+
+Everything else flows past Powerbrain.
+
+## Coverage matrix
+
+What each Powerbrain mechanism covers, per Claude Desktop data path:
+
+| Data path | MCP Connector (existing) | Audit Mirror (planned) | Endpoint DLP (customer IT) | Pre-flight (new, this spec) |
+|---|---|---|---|---|
+| **User prompt** (text typed by user) | ❌ Bypass | ✅ Post-hoc record | ⚠️ Allow/block only, no content inspection | ✅ Pre-submit pseudonymisation, user-driven |
+| **LLM response** | ❌ Bypass | ✅ Post-hoc record | ❌ | ✅ Post-receive resolution, user-driven |
+| **File attachments** uploaded into Claude | ❌ Bypass | ✅ Mirrored as ref | ⚠️ Block by MIME possible | ✅ Pre-upload scan + pseudonymise |
+| **Tool calls** to Powerbrain MCP | ✅ Full OPA + audit | ✅ Identical | n/a | n/a |
+| **Tool calls** to other connectors | depends on connector | ✅ Mirrored as event | ⚠️ Network-level | n/a |
+| **File edits** by Code tab on user filesystem | n/a (local) | ✅ Diff mirrored | ⚠️ Filesystem ACL | n/a |
+| **Terminal commands** in Code tab | n/a (local) | ✅ Command + output mirrored | ⚠️ Process ACL | n/a |
+| **Computer use** (mouse/keyboard control) | n/a (local) | ✅ Action log mirrored | ⚠️ Accessibility-API gating | n/a |
+
+The matrix shows the honest picture: **no single Powerbrain mechanism covers everything; the combination of MCP + audit-mirror + endpoint-DLP + pre-flight closes most of the gap most of the time, without ever requiring us to intercept Claude Desktop itself.**
+
+## Components
+
+### A. MCP Connector (existing — formalise as part of strategy)
+
+Powerbrain's `mcp-server` registered as a Connector in Claude Desktop's settings. Provides 28 tools to the agent in any tab. Already covers:
+
+- OPA policy enforcement per tool call
+- Vault-token-based PII resolution for tool results
+- Audit chain on `agent_access_log`
+- Knowledge graph, search, document retrieval, incident reporting
+
+**Status:** Production today. Documented in [docs/mcp-tools.md](../mcp-tools.md) and the Connectors capability row in [docs/editions.md](../editions.md).
+
+**What changes in this spec:** None to the component itself; the spec formalises that the MCP Connector is the **primary coverage layer** and frames the other components as defence-in-depth around it.
+
+### B. Audit Mirror (planned — see [chat-audit-mirror plan](../plans/2026-05-20-claude-chat-audit-mirror.md))
+
+Reads Claude Desktop's local conversation storage (SQLite under `~/Library/Application Support/Claude/...` on macOS, `%AppData%\Claude\...` on Windows), mirrors conversations into Powerbrain's audit chain after the fact.
+
+Coverage:
+
+- Every prompt and response across all three tabs
+- File-edit diffs and terminal-command events from the Code tab (Claude Desktop's session log captures these)
+- Tool-call invocations (visible in session log even when the connector wasn't Powerbrain)
+
+What it provides:
+
+- GDPR Art. 5 (lawfulness, accountability) — record of every PII-touching interaction
+- GDPR Art. 30 (records of processing) — auditable per-user log
+- EU AI Act Art. 12 (record keeping) — interactions with high-risk AI system
+- Incident response (Art. 33/34) — forensic trace when something leaks
+
+What it does **not** provide:
+
+- Prevention — PII has already reached Anthropic by the time we see it
+- Real-time blocking
+- Cross-device visibility (mirror runs per host; centralised aggregation is a separate concern)
+
+**Status:** Plan exists, implementation not started. This spec promotes it to the "coverage strategy backbone."
+
+### C. Endpoint DLP (customer-IT deployment pattern)
+
+Network-level controls on the user's endpoint. Customer IT can:
+
+- Allow `api.claude.ai` only for specific roles / classified workstations
+- Block uploads above N bytes via egress filtering (limits attachment exfiltration risk)
+- Require VPN-tunnelled connection so traffic is at least visible at the boundary (though TLS hides content)
+- Block `api.claude.ai` entirely on workstations handling restricted data, falling back to API-keyed Powerbrain proxy
+
+This is **not a Powerbrain component**; Powerbrain documents the pattern and provides recommended firewall / proxy rules.
+
+**Status:** Pattern only. Spec adds a recommendations section in [docs/deployment.md](../deployment.md) with concrete configs for common DLP suites.
+
+### D. Pre-flight (new component — this spec's only new build)
+
+A small client-side application that helps users **pseudonymise text before they paste it into Claude Desktop** and **resolve pseudonyms in Claude's responses after they paste them back**. Critically: Pre-flight does **not** interact with Claude Desktop itself in any way — no DOM injection, no clipboard hooks into Claude's window, no automation. It is a separate tool the user voluntarily invokes.
+
+#### UX
+
+Three invocation patterns, all opt-in:
+
+1. **Global hotkey + popup** (default) — `Ctrl/Cmd+Shift+P` opens a small Pre-flight window. User pastes text → sees pseudonymised version → copies it → switches to Claude Desktop → pastes it. Same flow in reverse for responses.
+2. **Clipboard offer** (opt-in) — when Pre-flight is running and the user copies text, a notification offers "Pseudonymise before paste?" Click accept → clipboard is replaced. User pastes into Claude. Skip → clipboard unchanged.
+3. **Browser-extension hand-off** — for the rare user that also wants chat-content-side governance on `claude.ai` (the website, not the desktop app), Pre-flight provides hooks the extension uses. Out of scope as a deliverable here; covered in [docs/editions.md](../editions.md) chat-content path.
+
+Pre-flight UI shows:
+
+- Original text (input)
+- Pseudonymised text (output, copyable)
+- Detected PII categories and counts ("3 person names, 1 email, 1 IBAN")
+- Resolution mode for responses: paste a Claude response containing `[TYPE:hash]` tokens → see resolved text alongside
+
+#### Architecture
+
+| Aspect | Choice | Rationale |
+|---|---|---|
+| Framework | Tauri (Rust backend + system webview UI) | Small footprint (~5MB), no Chromium bundling, OS-keychain integration via `tauri-plugin-keychain` |
+| Backend integration | Existing `/pseudonymize` (ingestion) + `/vault/resolve` (mcp-server) | Zero new backend services |
+| Auth | Local `pb_` key in OS keychain | Same key model as the rest of Powerbrain; rotatable |
+| Offline | No — Pre-flight requires Powerbrain reachable | Acceptable: corporate deploy, Powerbrain on intranet |
+| Distribution | Signed installers (macOS notarised, Windows code-signed), org-wide MDM-deployable | Compliance customers run MDM; this is friction-free |
+| Branding | "Powerbrain Pre-flight" — explicit, not pretending to be anything else | ToS clarity; user knows they're using a Powerbrain tool |
+
+#### Why this is ToS-clean
+
+- Does not interact with Claude Desktop's process, binary, DOM, or network traffic
+- Does not use Anthropic API or Anthropic OAuth credentials
+- Is just a clipboard / text utility that calls Powerbrain endpoints
+- User explicitly invokes it; nothing automated against Anthropic
+
+The pre-flight pattern is the same as a desktop password manager that helps you generate strong passwords before pasting them into a website. The website never knows the password manager exists.
+
+#### Limitations
+
+- **User must remember to use it.** Pure UX problem. Mitigated by hotkey + clipboard-offer ergonomics + training.
+- **Doesn't catch in-app file uploads.** When the user drags a file into Claude Desktop directly, Pre-flight isn't involved. Mitigation: Pre-flight has a "scan file" mode that pseudonymises a file's text content to a clipboard-ready blob; user pastes that instead of dragging the file. Awkward but defensible.
+- **Responses stay pseudonymised in Claude's session.** Anthropic stores Claude's response text containing `[PERSON:abc]` tokens. The audit-mirror picks this up correctly. If the user wants resolved text, they paste-back through Pre-flight.
+- **Code-tab file edits.** When Claude edits a file in the user's project, the file content is whatever Claude produces. If the user pseudonymised the original prompt with PII tokens, Claude may write code that references `[PERSON:abc]` literally. Pre-flight provides a "resolve file" command that walks a file (or a project directory) and replaces pseudonyms.
+
+These limitations exist; the spec is honest about them.
+
+## What customers can claim, honestly
+
+Combining the four components, a compliance customer can defensibly assert:
+
+| Claim | Substantiated by |
+|---|---|
+| "Tool-call layer is fully governed by Powerbrain policy and audit" | MCP Connector (A) |
+| "Every interaction with Claude Desktop is recorded for GDPR Art. 30 record-keeping" | Audit Mirror (B) |
+| "Restricted-classified workstations have technical egress controls preventing direct Claude Desktop access" | Endpoint DLP (C) |
+| "Users have a sanctioned mechanism to remove PII from prompts before submission" | Pre-flight (D) |
+| "We can demonstrate evidence of prompt-side PII protection per incident" | A + B + D combined |
+
+What they cannot claim:
+
+| ❌ Inflated claim | Actual reality |
+|---|---|
+| "Every Claude Desktop prompt is pseudonymised at the wire" | Only prompts the user runs through Pre-flight are |
+| "Claude never sees raw PII from our employees" | Depends on user discipline + Pre-flight adoption |
+| "Powerbrain intercepts and rewrites all Claude Desktop traffic" | It does not — that path is closed by Anthropic policy |
+
+This honest framing is what DPOs need. Inflated claims fail under scrutiny; honest claims with documented evidence chains pass.
+
+## Decision record — what we deliberately do not build
+
+Captured here so the question doesn't keep coming back:
+
+| Considered approach | Decision | Reason |
+|---|---|---|
+| DOM-inject into claude.ai webview | **Rejected.** | Claude Desktop's Code tab is not a webview of claude.ai. Pseudonym Bridge spec (PR #174) targeted the wrong abstraction. |
+| Modify Claude Desktop's `app.asar` | **Rejected.** | Consumer Terms Section 3 (reverse-engineering / modification). Also: Anthropic's auto-updater overwrites the patch. Compliance product cannot stand on a ToS violation. |
+| Fork Claude Code / build OAuth proxy / third-party harness on Pro/Max | **Rejected.** | Feb 2026 Authentication policy + April 2026 enforcement explicitly target this class. |
+| Repackage like aaddrick/claude-desktop-debian for our purposes | **Rejected.** | aaddrick relies on Anthropic's continued tolerance of a hobby Linux port. Powerbrain as commercial compliance product would not enjoy the same tolerance. |
+| Use Claude Code CLI hooks on Pro/Max OAuth | **Deferred — not recommended for Code tab coverage.** | CLI hooks exist (`UserPromptSubmit`) but using them with Pro/Max OAuth in a commercial Powerbrain workflow conflicts with the spirit of the Feb 2026 policy. We do not actively recommend this to customers. |
+| Run our own LLM gateway and ask users to point Claude Desktop at it | **Not possible.** | Claude Desktop's endpoint is hardcoded; `ANTHROPIC_BASE_URL` has no effect in the GUI. |
+
+## Roll-out
+
+| Phase | Deliverables | Customer-facing outcome |
+|---|---|---|
+| **1. Document + position** | This spec landed, [docs/editions.md](../editions.md) coverage-matrix updated, [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md) refreshed with the 2026 policy moves, DLP recommendations in [docs/deployment.md](../deployment.md) | Sales / compliance teams have an honest pitch deck |
+| **2. Audit Mirror MVP** | Implement [chat-audit-mirror plan](../plans/2026-05-20-claude-chat-audit-mirror.md) for macOS first, then Windows | Customers get the Art. 30 record-keeping claim immediately |
+| **3. Pre-flight v1** | Tauri app, macOS + Windows, hotkey + popup UI, OS-keychain `pb_` key, signed installers | Customers can train users on a sanctioned pseudonymisation workflow |
+| **4. Pre-flight v2** | Clipboard-offer mode, file-scan mode, project-resolve mode | Higher adoption via lower friction; addresses file-upload limitation |
+| **5. Cross-device aggregation** | Audit Mirror reports per-user logs centrally to Powerbrain | Org-level compliance dashboards |
+
+Each phase is independent — customers can buy / deploy in any order.
+
+## Open questions
+
+1. **Audit-mirror legality per jurisdiction.** Some employee-monitoring regulations require explicit consent before logging chat. Customer-side concern, but Powerbrain should provide a recommended consent flow (banner on Pre-flight first run, etc.).
+2. **Storage format of Claude Desktop session logs.** Need to reverse-engineer (lawfully — accessing data the user already owns) the SQLite schema; assume it changes across versions. Adapter strategy similar to the DOM-adapter idea in the closed Pseudonym Bridge spec.
+3. **MDM deployment story.** Compliance customers run MDM (Jamf, Intune). Pre-flight needs a silent-install / preconfigured-`pb_`-key story. Spec out as part of Phase 3.
+4. **Pricing.** Pre-flight is an enterprise-tier feature. Is it bundled with `pb-proxy` license or separately licensed? Out of spec scope; product decision.
+5. **Linux story.** Pre-flight on Linux is feasible (Tauri supports it). Claude Desktop is not available on Linux — those users use Claude Code CLI which already has API-key + `ANTHROPIC_BASE_URL=pb-proxy` as the supported path. So Pre-flight on Linux is value-additive for users of other AI tools, not for Claude Desktop coverage.
+
+## Test plan
+
+Doc + minor-component spec only. The single new buildable component (Pre-flight) gets its own implementation plan once approved.
+
+- [ ] Spec reviewed against [docs/editions.md](../editions.md) three-paths matrix — does the coverage matrix here align?
+- [ ] Spec reviewed against [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md) — does the decision-record cite the right Anthropic policy timestamps?
+- [ ] Compliance team confirms the "what customers can claim" table is defensibly accurate for German GDPR / EU AI Act framing
+- [ ] Sales team confirms the strategy addresses the actual customer ask ("Pro/Max stays, Powerbrain dazwischen")
+- [ ] Decision on Pre-flight tech stack (Tauri vs Electron vs native) before Phase 3 plan
+
+## Out of scope (deliberately)
+
+- Anything that intercepts, modifies, or proxies Claude Desktop's network traffic, process, binary, or UI
+- Any product feature that relies on continued Anthropic tolerance of policy-violating patterns
+- API-key-mode Claude Code coverage — already addressed by `pb-proxy` + `ANTHROPIC_BASE_URL`, not a Pro/Max scenario
+- Replacing Claude Desktop with a Powerbrain-built coding agent
+- Bridging non-Anthropic AI tools (ChatGPT, Gemini, Copilot). Pre-flight architecturally works for them too, but per-tool integration is a separate product question.


### PR DESCRIPTION
## Summary

Refresh of the Claude chat audit-mirror plan to align with the new [Coverage Strategy spec (PR #175)](https://github.com/nuetzliches/powerbrain/pull/175). The original plan was written assuming Claude Desktop was primarily a chat app — but the real product surface is three tabs (Chat / Cowork / Code), and the Code tab is where compliance customers' coverage gap actually lives.

Doc-only change.

## What changed

- **Three-tab awareness** woven through Sections 1, 2, 4A, 5, 6, 9
- **Policy context** added — Feb 2026 Authentication and Credential Use policy + April 2026 third-party-harness enforcement are now cited as part of why the *detective* approach is needed (the *preventive* paths got closed)
- **Schema** (migration 021) gains \`tab\` and \`artifact_type\` columns so findings can be filtered/grouped per tab and per source artifact (message vs file diff vs terminal command vs computer-use action vs cowork phase)
- **Scan workflow** per tab:
  - Chat — plain text messages (unchanged from before)
  - Cowork — task phases + report sections, chunked with 200-byte overlap
  - Code — additionally: file-edit diffs, terminal commands + stdout, computer-use actions
- **Rollout phases** renamed to match Coverage Strategy phase numbering (A.1 Chat, A.2 Cowork, A.3 Code) — A.3 is the highest-effort, highest-value sub-phase
- **MITM proxy (Option D)** demoted from "Enterprise fallback" to outright rejected — the Feb 2026 policy explicitly closes this even if technically buildable
- **Local cache inspection (Option C)** demoted from rejected to "documented fallback for when server-export breaks"
- **Cross-link** to the Coverage Strategy spec added in the header and bottom cross-references; Pre-flight (separate component in that spec) explicitly positioned as the *preventive complement* to this *detective* plan

## Companion to

- [PR #175 — Coverage Strategy spec](https://github.com/nuetzliches/powerbrain/pull/175) (this plan is Component B in that spec)
- Supersedes the framing of [PR #174 — closed Pseudonym Bridge spec](https://github.com/nuetzliches/powerbrain/pull/174)

## Test plan

Doc-only.

- [ ] Plan and Coverage Strategy spec align on what Component B covers vs what's deferred to other components
- [ ] Schema design (tab + artifact_type) reviewed before migration 021 lands
- [ ] Rollout phase mapping confirmed with sales / compliance positioning

## Checklist

- [x] Cross-links to companion spec + related plans
- [x] Schema changes documented (migration 021)
- [x] Per-tab artifact types explicitly enumerated
- [x] Known limitations updated for Code/Cowork specifics