### PR TITLE
feat(rerank): add infinity backend for /v1/rerank

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@
 FORGEJO_URL=http://forgejo.local:3000
 
 # ── Reranker ────────────────────────────────────────────────
-# Backend: powerbrain (built-in Cross-Encoder), tei (HuggingFace TEI), cohere
+# Backend: powerbrain (built-in Cross-Encoder), tei (HF TEI), infinity (Infinity), cohere
 RERANKER_BACKEND=powerbrain
 RERANKER_ENABLED=true
 
@@ -33,11 +33,14 @@ RERANKER_ENABLED=true
 RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L-6-v2
 # RERANKER_URL=http://reranker:8082   # default for built-in
 
-# Remote reranker (RERANKER_BACKEND=tei or cohere):
+# Remote reranker (RERANKER_BACKEND=tei, infinity, or cohere):
 #   No local-reranker profile needed — talks to external service directly.
-# RERANKER_BACKEND=tei
+#   - tei      → POST {URL}/v1/rerank, texts[] payload      (HuggingFace TEI)
+#   - infinity → POST {URL}/v1/rerank, documents[] payload  (michaelf34/infinity)
+#   - cohere   → POST {URL}/v2/rerank, documents[] payload  (Cohere API v2)
+# RERANKER_BACKEND=infinity
 # RERANKER_URL=https://ai.example.com  # or https://api.cohere.com
-# RERANKER_API_KEY=                     # required for cohere, optional for TEI
+# RERANKER_API_KEY=                     # required for cohere, optional for tei/infinity
 # RERANKER_MODEL=my-rerank-model        # required for cohere
 #
 # GDPR: External backends (cohere, remote TEI) send document content outside

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -79,7 +79,7 @@ body:
         - Docker Compose version:
         - OS:
         - Compose profiles used (tls, proxy, gpu, opal):
-        - Reranker backend (powerbrain/tei/cohere):
+        - Reranker backend (powerbrain/tei/infinity/cohere):
         - LLM provider (ollama/vllm/external):
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-27
+
+Adds a dedicated `infinity` reranker backend so deployments backed by an
+Infinity server (`michaelf34/infinity`) can use neural reranking out of the
+box. Previously the only `/v1/rerank` backend was `tei`, whose `texts[]`
+request and bare-array response are incompatible with Infinity's
+`documents[]` + `{results: [{index, relevance_score}]}` schema, while the
+`cohere` backend matched the schema but targets `/v2/rerank`. Additive and
+backward-compatible — the default backend stays `powerbrain`.
+
+### Added
+
+- **`infinity` reranker backend** — New `InfinityRerankProvider` in
+  `shared/rerank_provider.py`, selectable via `RERANKER_BACKEND=infinity`.
+  Posts the Cohere-style `documents[]` payload to `{RERANKER_URL}/v1/rerank`
+  and parses the `{results: [{index, relevance_score}]}` envelope (sorting by
+  relevance, truncating to `top_n`); model name is optional. Covered by unit
+  tests in `shared/tests/test_rerank_provider.py` and an integration test in
+  `mcp-server/tests/test_reranker_integration.py`. Backend docs in
+  `docs/architecture.md`, `CLAUDE.md`, and `.env.example` now list all four
+  backends and their request schemas.
+
 ## [0.10.1] - 2026-05-25
 
 Routine dependency-maintenance release on top of v0.10.0 — no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,9 @@ OPA checks classification on **every** MCP request.
 
 Reranker backend is configurable via `RERANKER_BACKEND`:
 - `powerbrain` (default) — built-in Cross-Encoder service
-- `tei` — HuggingFace Text Embeddings Inference `/rerank` endpoint
-- `cohere` — Cohere Rerank API v2 (external, requires API key)
+- `tei` — HuggingFace Text Embeddings Inference `/v1/rerank` (`texts[]` payload)
+- `infinity` — Infinity (`michaelf34/infinity`) `/v1/rerank`, Cohere-style `documents[]` schema (self-hosted)
+- `cohere` — Cohere Rerank API v2 `/v2/rerank` (external, requires API key)
 
 Abstraction: `shared/rerank_provider.py` (follows `shared/llm_provider.py` pattern).
 If the reranker is down → graceful fallback to Qdrant ordering.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,10 +59,11 @@ The reranker backend is configurable via `RERANKER_BACKEND` (default: `powerbrai
 | Backend | Service | API Format | Use Case |
 |---|---|---|---|
 | `powerbrain` | Built-in Cross-Encoder (`reranker/service.py`) | Powerbrain `/rerank` | Default, self-hosted, GDPR-safe |
-| `tei` | HuggingFace Text Embeddings Inference | TEI `/rerank` | GPU-accelerated, self-hosted |
+| `tei` | HuggingFace Text Embeddings Inference | TEI `/v1/rerank` (`texts[]`) | GPU-accelerated, self-hosted |
+| `infinity` | Infinity (`michaelf34/infinity`) | Infinity `/v1/rerank` (`documents[]`) | Self-hosted, Cohere-style schema |
 | `cohere` | Cohere Rerank API v2 | Cohere `/v2/rerank` | Best quality, external SaaS |
 
-**Abstraction:** `shared/rerank_provider.py` implements a strategy pattern with format translation per backend. The MCP server calls `_rerank_provider.rerank()` without knowing which backend is active. Each provider handles request/response mapping (e.g., TEI uses flat `texts[]` array + index-based response mapping, Cohere uses `relevance_score` + model parameter).
+**Abstraction:** `shared/rerank_provider.py` implements a strategy pattern with format translation per backend. The MCP server calls `_rerank_provider.rerank()` without knowing which backend is active. Each provider handles request/response mapping (e.g., TEI uses a flat `texts[]` array + bare-array response, while Infinity and Cohere use `documents[]` + a `{results: [{index, relevance_score}]}` envelope — Infinity on `/v1/rerank`, Cohere on `/v2/rerank`).
 
 **Built-in model options** (when `RERANKER_BACKEND=powerbrain`):
 - `cross-encoder/ms-marco-MiniLM-L-6-v2` (default, fast)

--- a/mcp-server/tests/test_rerank.py
+++ b/mcp-server/tests/test_rerank.py
@@ -182,7 +182,7 @@ class TestHeuristicBoosts:
         # Doc a has no files → no boost
         assert results[0].rerank_score == pytest.approx(0.80)
 
-    def test_heuristic_boost_reorders_results(self, _patch_http, monkeypatch):
+    async def test_heuristic_boost_reorders_results(self, _patch_http, monkeypatch):
         monkeypatch.setattr(server, "RERANKER_ENABLED", True)
 
         response = MagicMock()
@@ -202,11 +202,9 @@ class TestHeuristicBoosts:
              "metadata": {"project": "MINE"}},
         ]
 
-        import asyncio
-        result = asyncio.get_event_loop().run_until_complete(
-            rerank_results("query", docs, top_n=2,
-                           rerank_options={"match_project": "MINE",
-                                           "boost_same_project": 0.15})
+        result = await rerank_results(
+            "query", docs, top_n=2,
+            rerank_options={"match_project": "MINE", "boost_same_project": 0.15},
         )
         # boosted: 0.80 + 0.15 = 0.95 > winner: 0.90
         assert result[0]["id"] == "boosted"

--- a/mcp-server/tests/test_reranker_integration.py
+++ b/mcp-server/tests/test_reranker_integration.py
@@ -3,7 +3,7 @@ Integration tests for the reranker provider in the MCP server search pipeline.
 
 Tests verify that:
 - rerank_results() correctly uses the configured rerank provider
-- Different backend types (powerbrain, tei, cohere) work through the abstraction
+- Different backend types (powerbrain, tei, infinity, cohere) work through the abstraction
 - Graceful fallback works when the provider raises errors
 - The provider is swappable at runtime via create_rerank_provider()
 """
@@ -122,6 +122,38 @@ class TestRerankerProviderIntegration:
         # Verify Cohere auth header
         call_kwargs = _patch_http.post.call_args[1]
         assert "Authorization" in call_kwargs.get("headers", {})
+
+    async def test_infinity_provider_called(self, _patch_http, sample_docs, monkeypatch):
+        """Verify InfinityReranker sends a Cohere-style request to /v1/rerank."""
+        provider = create_rerank_provider(
+            backend="infinity", base_url="http://ai:8002",
+            model="nutsai-reranker-bsa-cst-v2",
+        )
+        monkeypatch.setattr(server, "_rerank_provider", provider)
+        monkeypatch.setattr(server, "RERANKER_ENABLED", True)
+
+        infinity_response = MagicMock()
+        infinity_response.raise_for_status = MagicMock()
+        infinity_response.json.return_value = {
+            "results": [
+                {"index": 2, "relevance_score": 0.95},
+                {"index": 0, "relevance_score": 0.85},
+            ]
+        }
+        _patch_http.post.return_value = infinity_response
+
+        result = await rerank_results("neural networks", sample_docs, top_n=2)
+
+        assert len(result) == 2
+        assert result[0]["id"] == "c"  # index 2 = doc "c"
+        assert result[0]["rerank_score"] == 0.95
+        # Infinity speaks the documents-based schema on /v1/rerank, not TEI's texts.
+        call_url = _patch_http.post.call_args[0][0]
+        assert "ai:8002" in call_url
+        assert "/v1/rerank" in call_url
+        payload = _patch_http.post.call_args[1]["json"]
+        assert "documents" in payload
+        assert "texts" not in payload
 
     async def test_provider_swap_at_runtime(self, _patch_http, sample_docs, monkeypatch):
         """Provider can be swapped without restarting the server."""

--- a/shared/rerank_provider.py
+++ b/shared/rerank_provider.py
@@ -4,6 +4,7 @@ Configurable Reranker Provider abstraction.
 Supports multiple backends:
 - **powerbrain** (default): Built-in Cross-Encoder service (reranker/service.py)
 - **tei**: HuggingFace Text Embeddings Inference /rerank endpoint
+- **infinity**: Infinity (michaelf34/infinity) /v1/rerank — Cohere-style schema
 - **cohere**: Cohere Rerank API v2
 
 Each provider translates between the uniform RerankDocument format and the
@@ -227,12 +228,76 @@ class CohereRerankProvider(_BaseRerankProvider):
 
 
 # ---------------------------------------------------------------------------
+# Infinity (/v1/rerank, Cohere-style schema)
+# ---------------------------------------------------------------------------
+
+class InfinityRerankProvider(_BaseRerankProvider):
+    """Calls an Infinity reranker (michaelf34/infinity) at /v1/rerank.
+
+    Infinity speaks the Cohere-style rerank schema (``documents`` in, a
+    ``{results: [{index, relevance_score}]}`` envelope out) but serves it
+    under ``/v1/rerank`` (via ``--url-prefix /v1``) rather than Cohere's
+    ``/v2/rerank``. It is therefore neither the TEI backend (which sends
+    ``texts`` and expects a bare-array response) nor the Cohere backend
+    (which targets ``/v2/rerank``).
+
+    Request:  {model?, query, documents: [str], top_n, return_documents: false}
+    Response: {results: [{index: int, relevance_score: float}]}
+    """
+
+    async def rerank(
+        self,
+        http: httpx.AsyncClient,
+        query: str,
+        documents: list[RerankDocument],
+        top_n: int,
+    ) -> list[RerankDocument]:
+        if not documents:
+            return []
+
+        payload: dict = {
+            "query": query,
+            "documents": [doc.content for doc in documents],
+            "top_n": top_n,
+            "return_documents": False,
+        }
+        if self.model:
+            payload["model"] = self.model
+
+        resp = await http.post(
+            f"{self.base_url}/v1/rerank",
+            headers=self.headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Sort by relevance descending (do not assume server order) and truncate.
+        scored = sorted(
+            data["results"], key=lambda r: r["relevance_score"], reverse=True
+        )[:top_n]
+
+        return [
+            RerankDocument(
+                id=documents[r["index"]].id,
+                content=documents[r["index"]].content,
+                score=documents[r["index"]].score,
+                rerank_score=round(r["relevance_score"], 4),
+                rank=rank,
+                metadata=documents[r["index"]].metadata,
+            )
+            for rank, r in enumerate(scored, start=1)
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
 _PROVIDERS: dict[str, type[_BaseRerankProvider]] = {
     "powerbrain": PowerbrainRerankProvider,
     "tei": TEIRerankProvider,
+    "infinity": InfinityRerankProvider,
     "cohere": CohereRerankProvider,
 }
 

--- a/shared/tests/test_rerank_provider.py
+++ b/shared/tests/test_rerank_provider.py
@@ -9,6 +9,7 @@ import pytest
 
 from shared.rerank_provider import (
     CohereRerankProvider,
+    InfinityRerankProvider,
     PowerbrainRerankProvider,
     RerankDocument,
     TEIRerankProvider,
@@ -331,6 +332,102 @@ class TestTEIRerankProvider:
 
 
 # ===========================================================================
+# InfinityRerankProvider
+# ===========================================================================
+
+class TestInfinityRerankProvider:
+    async def test_sends_documents_not_texts(self):
+        docs = _sample_docs(3)
+        json_data = {
+            "results": [
+                {"index": 0, "relevance_score": 0.5},
+                {"index": 1, "relevance_score": 0.9},
+                {"index": 2, "relevance_score": 0.3},
+            ]
+        }
+        http = _mock_http(json_data=json_data)
+        provider = InfinityRerankProvider("http://ai:8002")
+
+        await provider.rerank(http, "my query", docs, top_n=2)
+
+        call_args = http.post.call_args
+        assert call_args[0][0] == "http://ai:8002/v1/rerank"
+        payload = call_args[1]["json"]
+        assert payload["query"] == "my query"
+        assert payload["documents"] == [
+            "Content of document 0",
+            "Content of document 1",
+            "Content of document 2",
+        ]
+        assert payload["top_n"] == 2
+        assert payload["return_documents"] is False
+        assert "texts" not in payload  # Infinity uses documents, not TEI's texts
+        assert "model" not in payload  # no model set
+
+    async def test_sends_model_when_set(self):
+        docs = _sample_docs(2)
+        json_data = {"results": [{"index": 0, "relevance_score": 0.5}]}
+        http = _mock_http(json_data=json_data)
+        provider = InfinityRerankProvider("http://ai:8002", model="nutsai-reranker-bsa-cst-v2")
+
+        await provider.rerank(http, "query", docs, top_n=2)
+
+        payload = http.post.call_args[1]["json"]
+        assert payload["model"] == "nutsai-reranker-bsa-cst-v2"
+
+    async def test_relevance_score_mapping_and_sort(self):
+        docs = _sample_docs(3)
+        # Unsorted on purpose — provider must sort desc and truncate to top_n.
+        json_data = {
+            "results": [
+                {"index": 0, "relevance_score": 0.5},
+                {"index": 2, "relevance_score": 0.98},
+                {"index": 1, "relevance_score": 0.75},
+            ]
+        }
+        http = _mock_http(json_data=json_data)
+        provider = InfinityRerankProvider("http://ai:8002")
+
+        results = await provider.rerank(http, "query", docs, top_n=2)
+
+        assert len(results) == 2
+        assert results[0].id == "doc-2"  # index 2, score 0.98
+        assert results[0].rerank_score == 0.98
+        assert results[0].rank == 1
+        assert results[0].score == 0.7  # original score of doc-2
+        assert results[0].metadata == {"source": "test-2"}
+
+        assert results[1].id == "doc-1"  # index 1, score 0.75
+        assert results[1].rerank_score == 0.75
+        assert results[1].rank == 2
+
+    async def test_empty_documents(self):
+        http = _mock_http()
+        provider = InfinityRerankProvider("http://ai:8002")
+
+        results = await provider.rerank(http, "query", [], top_n=5)
+
+        assert results == []
+        http.post.assert_not_called()
+
+    async def test_http_error_propagates(self):
+        http = _mock_http(status_code=500)
+        provider = InfinityRerankProvider("http://ai:8002")
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await provider.rerank(http, "query", _sample_docs(1), top_n=1)
+
+    async def test_with_api_key(self):
+        json_data = {"results": []}
+        http = _mock_http(json_data=json_data)
+        provider = InfinityRerankProvider("http://ai:8002", api_key="key-42")
+
+        await provider.rerank(http, "q", _sample_docs(1), top_n=1)
+
+        assert http.post.call_args[1]["headers"] == {"Authorization": "Bearer key-42"}
+
+
+# ===========================================================================
 # CohereRerankProvider
 # ===========================================================================
 
@@ -423,6 +520,16 @@ class TestCreateRerankProvider:
         p = create_rerank_provider(backend="tei", base_url="http://tei:8010")
         assert isinstance(p, TEIRerankProvider)
         assert p.base_url == "http://tei:8010"
+
+    def test_infinity(self):
+        p = create_rerank_provider(backend="infinity", base_url="http://ai:8002")
+        assert isinstance(p, InfinityRerankProvider)
+        assert p.base_url == "http://ai:8002"
+
+    def test_infinity_model_optional(self):
+        # Unlike cohere, infinity does not require a model name.
+        p = create_rerank_provider(backend="infinity", base_url="http://ai:8002")
+        assert p.model == ""
 
     def test_cohere(self):
         p = create_rerank_provider(


### PR DESCRIPTION
## Summary

Adds a dedicated `infinity` reranker backend so deployments backed by an Infinity server (`michaelf34/infinity`) get working neural reranking out of the box.

**Why:** Infinity speaks the Cohere-style rerank schema (`documents[]` in, `{results: [{index, relevance_score}]}` out) but serves it on `/v1/rerank` (via `--url-prefix /v1`), not Cohere's `/v2/rerank`. Neither existing backend fits:
- `tei` targets `/v1/rerank` but sends `texts[]` and expects a bare-array response → 422 / parse error against Infinity.
- `cohere` matches the schema but hits `/v2/rerank`.

`InfinityRerankProvider` bridges the two: documents-based payload on `/v1/rerank`, sorts by `relevance_score`, truncates to `top_n`, model name optional. Additive — the default backend stays `powerbrain`.

## Changes
- `shared/rerank_provider.py`: new `InfinityRerankProvider`, registered as `infinity` in the factory.
- Tests: unit tests in `shared/tests/test_rerank_provider.py` + integration test in `mcp-server/tests/test_reranker_integration.py`.
- Docs: `docs/architecture.md`, `CLAUDE.md`, `.env.example`, and the bug-report template now list all four backends and their request schemas.
- `CHANGELOG.md`: 0.11.0.

## Test plan
- [x] `shared/tests/test_rerank_provider.py` — 39 passed (incl. new Infinity cases)
- [x] Full unit suite green locally; coverage 70% (> 68% gate), `shared/rerank_provider.py` at 99%
- [ ] CI: unit-tests, opa-tests, docker-build, security-scan