### PR TITLE
fix(mcp-server): rate limiter silently disabled by NotImplementedError

### DIFF
--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -381,11 +381,19 @@ class RateLimitMiddleware:
             return await self.app(scope, receive, send)
 
         try:
-            # Extract agent info from auth state (set by AuthenticationMiddleware)
+            # Extract agent info from auth state (set by AuthenticationMiddleware).
+            # The MCP SDK's AuthenticatedUser subclasses Starlette's SimpleUser,
+            # which exposes the agent id as `username` (the OAuth client_id).
+            # It does NOT implement `identity` — that property is inherited from
+            # BaseUser and raises NotImplementedError. Touching it (even via
+            # hasattr, which only swallows AttributeError) would propagate the
+            # error into the except-block below and silently fail open on every
+            # request. Mirror the `_auth_user` helper and read `username`.
             user = scope.get("user")
-            if user and hasattr(user, "identity") and user.identity:
-                agent_id = user.identity
-                role = user.scopes[0] if user.scopes else "analyst"
+            agent_id = getattr(user, "username", None) or getattr(user, "client_id", None)
+            if user and agent_id:
+                scopes = getattr(user, "scopes", None) or []
+                role = scopes[0] if scopes else "analyst"
                 bucket = _get_bucket(agent_id, role)
                 allowed, retry_after = await bucket.consume()
 

--- a/mcp-server/tests/test_rate_limiter.py
+++ b/mcp-server/tests/test_rate_limiter.py
@@ -1,9 +1,14 @@
 """Tests for TokenBucket rate limiter."""
 
 import asyncio
+import logging
 
 import pytest
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+from starlette.authentication import UnauthenticatedUser
 
+import server
 from server import TokenBucket
 
 
@@ -48,3 +53,126 @@ class TestTokenBucket:
         allowed, retry_after = await bucket.consume()
         assert allowed is False
         assert 0.0 < retry_after <= 1.0
+
+
+def _make_user(client_id="agent-1", scopes=("analyst",)):
+    token = AccessToken(token="t", client_id=client_id, scopes=list(scopes), expires_at=None)
+    return AuthenticatedUser(token)
+
+
+class _DummyApp:
+    """Downstream ASGI app that records how often it is invoked."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def __call__(self, scope, receive, send):
+        self.calls += 1
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _drive(middleware, scope):
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg):
+        sent.append(msg)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+def _status(sent):
+    for msg in sent:
+        if msg["type"] == "http.response.start":
+            return msg["status"]
+    return None
+
+
+@pytest.fixture
+def rate_limit_env(monkeypatch):
+    """Enable rate limiting with a tiny per-role capacity for fast tests."""
+    monkeypatch.setattr(server, "RATE_LIMIT_ENABLED", True)
+    monkeypatch.setattr(server, "RATE_LIMIT_ANALYST", 2)
+    monkeypatch.setattr(
+        server, "RATE_LIMITS_BY_ROLE", {"analyst": 2, "developer": 2, "admin": 2}
+    )
+    server._rate_limit_buckets.clear()
+    yield
+    server._rate_limit_buckets.clear()
+
+
+class TestRateLimitMiddleware:
+    """Regression tests for the bug where the middleware read the SDK user's
+    `identity` property — which raises NotImplementedError — causing every
+    authenticated request to fail open and silently disable rate limiting."""
+
+    async def test_sdk_user_identity_raises(self):
+        """The MCP SDK user exposes the agent id as `username`; `identity` is
+        inherited from Starlette BaseUser and raises. This is the trap the
+        middleware must avoid."""
+        user = _make_user()
+        assert user.username == "agent-1"
+        with pytest.raises(NotImplementedError):
+            _ = user.identity
+
+    async def test_authenticated_user_enforces_limit(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": _make_user()}
+
+        for _ in range(2):  # capacity is 2
+            sent = await _drive(middleware, scope)
+            assert _status(sent) == 200
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 429
+        assert app.calls == 2  # third request never reached downstream
+
+    async def test_no_fail_open_warning_for_authenticated_user(
+        self, rate_limit_env, caplog
+    ):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": _make_user()}
+
+        with caplog.at_level(logging.WARNING, logger="pb-mcp"):
+            await _drive(middleware, scope)
+
+        assert "Rate limiter error" not in caplog.text
+
+    async def test_per_agent_isolation(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+
+        # Exhaust agent-1's bucket (capacity 2).
+        scope1 = {"type": "http", "path": "/mcp", "user": _make_user("agent-1")}
+        for _ in range(2):
+            await _drive(middleware, scope1)
+        assert _status(await _drive(middleware, scope1)) == 429
+
+        # agent-2 has its own bucket and is unaffected.
+        scope2 = {"type": "http", "path": "/mcp", "user": _make_user("agent-2")}
+        assert _status(await _drive(middleware, scope2)) == 200
+
+    async def test_unauthenticated_user_passes_through(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": UnauthenticatedUser()}
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 200
+        assert app.calls == 1
+        assert server._rate_limit_buckets == {}  # no bucket created
+
+    async def test_health_path_skipped(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/health", "user": _make_user()}
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 200
+        assert server._rate_limit_buckets == {}


### PR DESCRIPTION
## Summary
- `RateLimitMiddleware` read the agent id from `user.identity`. The MCP SDK's `AuthenticatedUser` subclasses Starlette `SimpleUser`, which never implements `identity` — the inherited `BaseUser.identity` property raises `NotImplementedError`.
- The guard `hasattr(user, "identity")` did not protect against this: `hasattr` only swallows `AttributeError`, so `NotImplementedError` propagated into the `except Exception` block, logged `Rate limiter error, request is being passed through: NotImplementedError()`, and **failed open on every authenticated request**. Rate limiting was inert in production despite `RATE_LIMIT_ENABLED=true` and the per-role limits.
- Fix: read `username` (the OAuth `client_id`), mirroring the existing `_auth_user` helper (server.py:4246). Never touch `.identity`.

## Why it went unnoticed
The failure is fail-open + a `WARNING` log only — no requests were rejected, so behaviour looked normal while limits silently never applied. Spotted incidentally during v0.11.0 reranker verification.

## Tests
Added `TestRateLimitMiddleware` in `mcp-server/tests/test_rate_limiter.py`:
- `test_sdk_user_identity_raises` — locks in *why* `identity` must not be read (it raises).
- `test_authenticated_user_enforces_limit` — 200 up to capacity, then 429; downstream not reached on 429.
- `test_no_fail_open_warning_for_authenticated_user` — asserts the fail-open warning is gone.
- `test_per_agent_isolation` — one agent's exhausted bucket doesn't affect another.
- `test_unauthenticated_user_passes_through` / `test_health_path_skipped` — no bucket created, no exception.

## Test plan
- [x] `pytest mcp-server/tests/test_rate_limiter.py -v` — 11 passed
- [ ] CI (unit-tests, opa-tests, docker-build, security-scan) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)