### PR TITLE
ci: validate development PRs and gate master to development-only

### DIFF
--- a/.forgejo/workflows/pr-validate.yml
+++ b/.forgejo/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [development, master]
 
 jobs:
   unit-tests:

--- a/.github/workflows/master-guard.yml
+++ b/.github/workflows/master-guard.yml
@@ -1,0 +1,28 @@
+name: Master Guard
+
+# master only accepts merges from the integration branch (development) or a
+# release/hotfix branch. GitHub cannot prevent a PR from being *opened* against
+# master, so this required check fails the PR at merge time when its source
+# branch is anything else — steering all feature work through development.
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  guard-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce allowed source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "PR head branch: $HEAD_REF"
+          case "$HEAD_REF" in
+            development|release/*|hotfix/*)
+              echo "Source branch '$HEAD_REF' may target master."
+              ;;
+            *)
+              echo "::error::PRs to master may only originate from 'development', 'release/*' or 'hotfix/*' (got '$HEAD_REF'). Open your PR against 'development' instead."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [development, master]
 
 jobs:
   unit-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,13 +485,17 @@ Feature development follows a two-branch model:
 New features and larger refactors should be developed on a separate branch and submitted as a PR against `development`. Direct pushes to `development` are allowed for small fixes. Direct pushes to `master` are blocked — only release merges from `development` land there.
 
 ### CI / PR Validation
-PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `development`:
+PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `development` **and** `master`:
 - **unit-tests** — All service tests in `python:3.12-slim` container (`-m "not integration"`), coverage threshold 80% (`--cov-fail-under=80`)
 - **opa-tests** — OPA policy tests (`opa test opa-policies/`)
 - **docker-build** — Build all 5 images (no push)
 - **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis), non-blocking
 
-All jobs must pass before merge. Branch protection requires PR for `master` — no direct pushes to `master`. Direct pushes to `development` are allowed.
+Running the full suite on `master` PRs too means the exact `development → master` merge commit is re-validated before a release lands — green-on-`development` alone is not relied upon, since direct pushes to `development` are permitted.
+
+`.github/workflows/master-guard.yml` adds a **guard-source-branch** check on `master` PRs that fails unless the PR's head branch is `development`, `release/*`, or `hotfix/*`. GitHub cannot block a PR from being *opened* against `master`; this required check blocks it at *merge* time instead, funnelling all feature work through `development`.
+
+The "Protect master" repository ruleset requires: a PR, the `unit-tests` / `opa-tests` / `docker-build` checks, and `guard-source-branch`. Direct pushes to `master` are blocked — only `development` (or a release/hotfix branch) merges there. Direct pushes to `development` are allowed for small fixes. Releases are tag-driven: pushing a `v*` tag triggers `.github/workflows/release.yml` (build + push images to GHCR + GitHub Release); no CI runs on `master` pushes.
 
 ### Load Tests
 Locust-based load tests for the MCP search pipeline (not in CI, local only):


### PR DESCRIPTION
## Summary
Reworks the CI/branch flow so feature PRs are validated on `development` and `master` only accepts merges from `development`.

- **`pr-validate.yml`** now triggers on PRs to **`development` and `master`** (was `master`-only). Feature PRs into `development` now get the full suite; the `development → master` release PR re-runs it so the exact merge commit is green before release.
- **`master-guard.yml`** (new) adds a required **`guard-source-branch`** check on `master` PRs that fails unless the head branch is `development`, `release/*`, or `hotfix/*`. GitHub can't prevent *opening* a PR against `master`, so this blocks it at *merge* time.
- Mirror the trigger change in the internal **`.forgejo`** workflow.
- **CLAUDE.md** updated to describe the actual flow (ruleset checks, tag-driven release, no CI on `master` push).

## Out-of-band change (applied separately)
The "Protect master" repository ruleset is updated to additionally require the `guard-source-branch` status check (alongside the existing `unit-tests` / `opa-tests` / `docker-build`).

## Why re-run on master PRs
Relying on "development was green" only protects master by transitivity, and that chain leaks: direct pushes to `development` are allowed, and a merge commit differs from the tested tip. Re-running on the `development→master` PR validates the exact result for ~3 min on rare release merges.

## Test plan
- [ ] This PR (base `development`) triggers `pr-validate` — unit-tests, opa-tests, docker-build, security-scan green
- [ ] After merge: a `development→master` PR shows `guard-source-branch` passing + full suite
- [ ] A feature-branch→master PR shows `guard-source-branch` failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)