### PR TITLE
release: v0.11.1 — rate-limiter fix + CI/branch flow

### DIFF
--- a/.forgejo/workflows/pr-validate.yml
+++ b/.forgejo/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [development, master]
 
 jobs:
   unit-tests:

--- a/.github/workflows/master-guard.yml
+++ b/.github/workflows/master-guard.yml
@@ -1,0 +1,28 @@
+name: Master Guard
+
+# master only accepts merges from the integration branch (development) or a
+# release/hotfix branch. GitHub cannot prevent a PR from being *opened* against
+# master, so this required check fails the PR at merge time when its source
+# branch is anything else — steering all feature work through development.
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  guard-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce allowed source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "PR head branch: $HEAD_REF"
+          case "$HEAD_REF" in
+            development|release/*|hotfix/*)
+              echo "Source branch '$HEAD_REF' may target master."
+              ;;
+            *)
+              echo "::error::PRs to master may only originate from 'development', 'release/*' or 'hotfix/*' (got '$HEAD_REF'). Open your PR against 'development' instead."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [development, master]
 
 jobs:
   unit-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-27
+
+Patch release fixing a silent rate-limiter outage in the MCP server. No
+database migrations, no breaking changes.
+
+### Fixed
+
+- **Rate limiter silently disabled** — `RateLimitMiddleware` read the agent
+  id from `user.identity`, but the MCP SDK's `AuthenticatedUser` (a Starlette
+  `SimpleUser`) never implements `identity` — the inherited property raises
+  `NotImplementedError`. The `hasattr(user, "identity")` guard did not help,
+  since `hasattr` only swallows `AttributeError`, so the error propagated into
+  the fail-open `except` block and every authenticated request bypassed rate
+  limiting (logging `Rate limiter error, request is being passed through`)
+  despite `RATE_LIMIT_ENABLED=true`. The middleware now reads `username` (the
+  OAuth `client_id`), matching the existing `_auth_user` helper. Regression
+  tests added in `mcp-server/tests/test_rate_limiter.py`.
+
+### Changed
+
+- **CI / branch flow** — `pr-validate` now runs on PRs to both `development`
+  and `master` (was `master`-only), so feature PRs into `development` are
+  validated and the `development → master` release merge re-runs the full
+  suite. New `master-guard` workflow adds a required `guard-source-branch`
+  check that blocks `master` PRs not originating from
+  `development`/`release/*`/`hotfix/*`.
+
 ## [0.11.0] - 2026-05-27
 
 Adds a dedicated `infinity` reranker backend so deployments backed by an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,13 +485,17 @@ Feature development follows a two-branch model:
 New features and larger refactors should be developed on a separate branch and submitted as a PR against `development`. Direct pushes to `development` are allowed for small fixes. Direct pushes to `master` are blocked — only release merges from `development` land there.
 
 ### CI / PR Validation
-PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `development`:
+PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `development` **and** `master`:
 - **unit-tests** — All service tests in `python:3.12-slim` container (`-m "not integration"`), coverage threshold 80% (`--cov-fail-under=80`)
 - **opa-tests** — OPA policy tests (`opa test opa-policies/`)
 - **docker-build** — Build all 5 images (no push)
 - **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis), non-blocking
 
-All jobs must pass before merge. Branch protection requires PR for `master` — no direct pushes to `master`. Direct pushes to `development` are allowed.
+Running the full suite on `master` PRs too means the exact `development → master` merge commit is re-validated before a release lands — green-on-`development` alone is not relied upon, since direct pushes to `development` are permitted.
+
+`.github/workflows/master-guard.yml` adds a **guard-source-branch** check on `master` PRs that fails unless the PR's head branch is `development`, `release/*`, or `hotfix/*`. GitHub cannot block a PR from being *opened* against `master`; this required check blocks it at *merge* time instead, funnelling all feature work through `development`.
+
+The "Protect master" repository ruleset requires: a PR, the `unit-tests` / `opa-tests` / `docker-build` checks, and `guard-source-branch`. Direct pushes to `master` are blocked — only `development` (or a release/hotfix branch) merges there. Direct pushes to `development` are allowed for small fixes. Releases are tag-driven: pushing a `v*` tag triggers `.github/workflows/release.yml` (build + push images to GHCR + GitHub Release); no CI runs on `master` pushes.
 
 ### Load Tests
 Locust-based load tests for the MCP search pipeline (not in CI, local only):

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -381,11 +381,19 @@ class RateLimitMiddleware:
             return await self.app(scope, receive, send)
 
         try:
-            # Extract agent info from auth state (set by AuthenticationMiddleware)
+            # Extract agent info from auth state (set by AuthenticationMiddleware).
+            # The MCP SDK's AuthenticatedUser subclasses Starlette's SimpleUser,
+            # which exposes the agent id as `username` (the OAuth client_id).
+            # It does NOT implement `identity` — that property is inherited from
+            # BaseUser and raises NotImplementedError. Touching it (even via
+            # hasattr, which only swallows AttributeError) would propagate the
+            # error into the except-block below and silently fail open on every
+            # request. Mirror the `_auth_user` helper and read `username`.
             user = scope.get("user")
-            if user and hasattr(user, "identity") and user.identity:
-                agent_id = user.identity
-                role = user.scopes[0] if user.scopes else "analyst"
+            agent_id = getattr(user, "username", None) or getattr(user, "client_id", None)
+            if user and agent_id:
+                scopes = getattr(user, "scopes", None) or []
+                role = scopes[0] if scopes else "analyst"
                 bucket = _get_bucket(agent_id, role)
                 allowed, retry_after = await bucket.consume()
 

--- a/mcp-server/tests/test_rate_limiter.py
+++ b/mcp-server/tests/test_rate_limiter.py
@@ -1,9 +1,14 @@
 """Tests for TokenBucket rate limiter."""
 
 import asyncio
+import logging
 
 import pytest
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from mcp.server.auth.provider import AccessToken
+from starlette.authentication import UnauthenticatedUser
 
+import server
 from server import TokenBucket
 
 
@@ -48,3 +53,126 @@ class TestTokenBucket:
         allowed, retry_after = await bucket.consume()
         assert allowed is False
         assert 0.0 < retry_after <= 1.0
+
+
+def _make_user(client_id="agent-1", scopes=("analyst",)):
+    token = AccessToken(token="t", client_id=client_id, scopes=list(scopes), expires_at=None)
+    return AuthenticatedUser(token)
+
+
+class _DummyApp:
+    """Downstream ASGI app that records how often it is invoked."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def __call__(self, scope, receive, send):
+        self.calls += 1
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+
+async def _drive(middleware, scope):
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg):
+        sent.append(msg)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+def _status(sent):
+    for msg in sent:
+        if msg["type"] == "http.response.start":
+            return msg["status"]
+    return None
+
+
+@pytest.fixture
+def rate_limit_env(monkeypatch):
+    """Enable rate limiting with a tiny per-role capacity for fast tests."""
+    monkeypatch.setattr(server, "RATE_LIMIT_ENABLED", True)
+    monkeypatch.setattr(server, "RATE_LIMIT_ANALYST", 2)
+    monkeypatch.setattr(
+        server, "RATE_LIMITS_BY_ROLE", {"analyst": 2, "developer": 2, "admin": 2}
+    )
+    server._rate_limit_buckets.clear()
+    yield
+    server._rate_limit_buckets.clear()
+
+
+class TestRateLimitMiddleware:
+    """Regression tests for the bug where the middleware read the SDK user's
+    `identity` property — which raises NotImplementedError — causing every
+    authenticated request to fail open and silently disable rate limiting."""
+
+    async def test_sdk_user_identity_raises(self):
+        """The MCP SDK user exposes the agent id as `username`; `identity` is
+        inherited from Starlette BaseUser and raises. This is the trap the
+        middleware must avoid."""
+        user = _make_user()
+        assert user.username == "agent-1"
+        with pytest.raises(NotImplementedError):
+            _ = user.identity
+
+    async def test_authenticated_user_enforces_limit(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": _make_user()}
+
+        for _ in range(2):  # capacity is 2
+            sent = await _drive(middleware, scope)
+            assert _status(sent) == 200
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 429
+        assert app.calls == 2  # third request never reached downstream
+
+    async def test_no_fail_open_warning_for_authenticated_user(
+        self, rate_limit_env, caplog
+    ):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": _make_user()}
+
+        with caplog.at_level(logging.WARNING, logger="pb-mcp"):
+            await _drive(middleware, scope)
+
+        assert "Rate limiter error" not in caplog.text
+
+    async def test_per_agent_isolation(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+
+        # Exhaust agent-1's bucket (capacity 2).
+        scope1 = {"type": "http", "path": "/mcp", "user": _make_user("agent-1")}
+        for _ in range(2):
+            await _drive(middleware, scope1)
+        assert _status(await _drive(middleware, scope1)) == 429
+
+        # agent-2 has its own bucket and is unaffected.
+        scope2 = {"type": "http", "path": "/mcp", "user": _make_user("agent-2")}
+        assert _status(await _drive(middleware, scope2)) == 200
+
+    async def test_unauthenticated_user_passes_through(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/mcp", "user": UnauthenticatedUser()}
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 200
+        assert app.calls == 1
+        assert server._rate_limit_buckets == {}  # no bucket created
+
+    async def test_health_path_skipped(self, rate_limit_env):
+        app = _DummyApp()
+        middleware = server.RateLimitMiddleware(app)
+        scope = {"type": "http", "path": "/health", "user": _make_user()}
+
+        sent = await _drive(middleware, scope)
+        assert _status(sent) == 200
+        assert server._rate_limit_buckets == {}


### PR DESCRIPTION
## Summary
Promotes the v0.11.1 patch from `development` to `master`.

- **fix(mcp-server):** rate limiter was silently disabled — `RateLimitMiddleware` read `user.identity` (raises `NotImplementedError` on the MCP SDK user), failing open on every authenticated request despite `RATE_LIMIT_ENABLED=true`. Now reads `username`. Regression tests added.
- **ci:** `pr-validate` runs on `development` + `master` PRs; new `master-guard` enforces development-only merges into master.
- **docs:** CHANGELOG `[0.11.1]`.

## Release
After merge, tag `v0.11.1` on `master` triggers `release.yml` (build + push images to GHCR + GitHub Release).

## Validates the new gate
This is the first `development → master` PR under the new policy: `guard-source-branch` should pass (head is `development`) and the full suite re-runs against the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)