### PR TITLE
fix(oauth): slide refresh-token expiry + fix cleanup query

### DIFF
--- a/mcp-server/oauth_provider.py
+++ b/mcp-server/oauth_provider.py
@@ -123,7 +123,11 @@ class PowerbrainOAuthProvider(
         try:
             pool = await self._get_pool()
             deleted = await pool.fetchval(
-                "DELETE FROM oauth_refresh_tokens WHERE expires_at IS NOT NULL AND expires_at < $1 RETURNING count(*)",
+                "WITH deleted AS ("
+                "    DELETE FROM oauth_refresh_tokens "
+                "    WHERE expires_at IS NOT NULL AND expires_at < $1 "
+                "    RETURNING 1"
+                ") SELECT count(*) FROM deleted",
                 int(now),
             )
             if deleted:
@@ -352,14 +356,30 @@ class PowerbrainOAuthProvider(
     ) -> OAuthToken:
         now = time.time()
         new_access_token = secrets.token_urlsafe(32)
+        granted_scopes = scopes or refresh_token.scopes
 
         # New access token: in-memory
         self._access_tokens[new_access_token] = PbAccessToken(
             token=new_access_token,
             client_id=client.client_id,
-            scopes=scopes or refresh_token.scopes,
+            scopes=granted_scopes,
             expires_at=int(now + ACCESS_TOKEN_TTL),
             api_key=refresh_token.api_key,
+        )
+
+        # Slide the refresh-token expiry on every use. Without this the
+        # refresh token keeps its original absolute expiry (now + 7d at
+        # issuance) and is never extended, so an actively used connector is
+        # force-logged-out exactly REFRESH_TOKEN_TTL after the last full
+        # authorization. _store_refresh_token upserts on the same token
+        # (ON CONFLICT (token) DO UPDATE SET expires_at), so this just bumps
+        # the expiry in place.
+        await self._store_refresh_token(
+            token=refresh_token.token,
+            client_id=client.client_id,
+            api_key=refresh_token.api_key,
+            scopes=granted_scopes,
+            expires_at=int(now + REFRESH_TOKEN_TTL),
         )
 
         return OAuthToken(
@@ -367,7 +387,7 @@ class PowerbrainOAuthProvider(
             token_type="bearer",
             expires_in=ACCESS_TOKEN_TTL,
             refresh_token=refresh_token.token,
-            scope=" ".join(scopes) if scopes else None,
+            scope=" ".join(granted_scopes) if granted_scopes else None,
         )
 
     # ── Access Token Verification (in-memory) ─────────────

--- a/mcp-server/tests/test_oauth_provider.py
+++ b/mcp-server/tests/test_oauth_provider.py
@@ -245,6 +245,44 @@ class TestExchangeAuthorizationCode:
         assert "oauth_refresh_tokens" in call_sql
 
 
+# ── Exchange Refresh Token ────────────────────────────────
+
+
+class TestExchangeRefreshToken:
+    def _rt(self, client_id="client-1", scopes=None):
+        return PbRefreshToken(
+            token="rt_keep", client_id=client_id, scopes=scopes or ["read"],
+            expires_at=int(time.time() + 100), api_key="pb_k",
+        )
+
+    async def test_issues_new_access_keeps_refresh(self):
+        prov, _, _ = _provider()
+        token = await prov.exchange_refresh_token(_make_client(), self._rt(), scopes=["read"])
+        assert token.access_token is not None
+        assert token.refresh_token == "rt_keep"  # same refresh token is reused
+        assert token.expires_in == ACCESS_TOKEN_TTL
+        assert token.access_token in prov._access_tokens
+
+    async def test_slides_refresh_expiry(self):
+        # The whole point of the fix: an active connector must never be
+        # force-logged-out. Each refresh bumps the DB expiry to now + TTL.
+        prov, pool, _ = _provider()
+        floor = int(time.time() + REFRESH_TOKEN_TTL)
+        await prov.exchange_refresh_token(_make_client(), self._rt(), scopes=["read"])
+
+        pool.execute.assert_called_once()  # the _store_refresh_token upsert
+        sql, *args = pool.execute.call_args[0]
+        assert "oauth_refresh_tokens" in sql
+        assert "ON CONFLICT" in sql
+        assert args[0] == "rt_keep"          # same token, not a new row
+        assert args[4] >= floor              # expires_at slid to ~now + TTL
+
+    async def test_falls_back_to_refresh_scopes(self):
+        prov, _, _ = _provider()
+        token = await prov.exchange_refresh_token(_make_client(), self._rt(scopes=["read"]), scopes=[])
+        assert token.scope == "read"
+
+
 # ── Refresh Token ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Root cause
Claude Desktop connects Powerbrain as a remote OAuth MCP connector. Two defects in `mcp-server/oauth_provider.py`, both surfaced from int-baumeister `pb-mcp-server` logs:

1. **Forced re-login every ~7 days (the real symptom).** Refresh tokens are issued with an absolute `expires_at = now + 7d` and `exchange_refresh_token` never extended it. An actively used connector was force-logged-out exactly `REFRESH_TOKEN_TTL` after the last full authorization (observed: full `/register` + `/authorize` re-auth on 2026-06-09). Fix: **slide** `expires_at` to `now + REFRESH_TOKEN_TTL` on every refresh (in-place upsert on the same token).

2. **Broken periodic cleanup (5-min log spam).** `DELETE FROM oauth_refresh_tokens ... RETURNING count(*)` is invalid PostgreSQL → `aggregate functions are not allowed in RETURNING`, firing every 5 minutes for days. Harmless (expiry is also checked lazily in `load_refresh_token`) but noisy and left expired rows uncollected. Fix: data-modifying CTE.

## Not the cause (ruled out via logs)
`restarts=0` (no redeploy/state loss), clock synced, no MCP 502/504 at Caddy, OAuth state persisted in Postgres (`oauth_clients`/`oauth_refresh_tokens`).

## Tests
`+3` in `test_oauth_provider.py` (sliding expiry persists, same refresh token reused, scope fallback). Full file: **36 passed**.