### PR TITLE
release: 0.11.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,33 @@ updates:
     labels: ["dependencies"]
     open-pull-requests-limit: 5
 
+  # Requirements are pinned exactly (see CLAUDE.md "Dependency Pinning"), so a
+  # directory that Dependabot does not watch never receives security patches.
+  # The three entries below close that gap.
+  - package-ecosystem: "pip"
+    directory: "/" # requirements-dev.txt — test + security tooling
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/ingestion/adapters/office365"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/demo"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "docker"
     directory: "/mcp-server"
     target-branch: "development"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Exact dependency pins** — every `requirements*.txt` now pins exact versions
+  (`==`) instead of open `>=` ranges. An open range means each `pip install` —
+  in CI, in a Docker build, on a laptop — silently takes whatever is newest on
+  PyPI at that moment. On 2026-03-24 the malicious LiteLLM releases `1.82.7`
+  and `1.82.8` were live for roughly 40 minutes; the pin at the time was
+  `litellm>=1.60`, so any build inside that window would have installed the
+  backdoor. No build ran then — the first CI workflow landed on 2026-03-26,
+  `pb-proxy` sits behind an opt-in compose profile that the E2E stack does not
+  activate, and no local artefacts of those versions exist. Upper bounds at the
+  next major would not have helped either: `1.82.8` sits inside `>=1.60,<2.0`.
+  Rationale and the remaining gap — transitive dependencies are still unpinned —
+  are documented in CLAUDE.md under "Dependency Pinning".
+- **Dependabot coverage completed** — added pip entries for `/`
+  (`requirements-dev.txt`), `/ingestion/adapters/office365` and `/demo`. With
+  exact pins, a directory Dependabot does not watch never receives security
+  patches, which is strictly worse than an open range.
+- **Reranker image no longer bypasses its pins** — `reranker/Dockerfile`
+  installed an unpinned inline package list and ignored
+  `reranker/requirements.txt` entirely. It now installs from that file, still
+  via the PyTorch CPU index.
+
+### Fixed
+
+- **CI red since late July** — `mcp[server]>=1.27.1` resolved to `mcp 2.0.0`,
+  whose API drops the `Server.list_tools()` decorator used in
+  `mcp-server/server.py` and `streamablehttp_client` used in
+  `pb-proxy/tool_injection.py`. Test collection failed on both; the cascading
+  `DuplicateTimeseries` errors were a symptom of the half-executed imports, not
+  an independent fault. `mcp` is now held at `1.29.0`, the last 1.x release, and
+  the suite passes again (1115 passed, 20 skipped, 70.45% coverage). Porting to
+  the 2.x API remains a separate task.
+- **Reranker tracing was silently disabled** — the image never installed the
+  OpenTelemetry packages its `requirements.txt` declares, so
+  `shared/telemetry.py` degraded to disabled even though `docker-compose.yml`
+  configures the service with `OTEL_ENABLED=true` and an OTLP endpoint.
+  Installing from `requirements.txt` now also brings in `pydantic` and the OTel
+  packages, so the reranker traces as documented.
+- **Dead `[server]` extra** — `mcp[server]` requested an extra that no `mcp`
+  release provides (pip: "does not provide the extra 'server'"), so it had
+  always installed nothing. Dropped.
+
 ## [0.11.1] - 2026-05-27
 
 Patch release fixing a silent rate-limiter outage in the MCP server. No

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,6 +596,32 @@ Details on all features: see `docs/architecture.md`
 - Environment variables for all configuration (no hardcoded values)
 - Graceful degradation: every service must work without the reranker
 - Docker Secrets supported via `_read_secret()` with env var fallback
+- Python dependencies pinned exactly (`==`), never open ranges — see below
+
+### Dependency Pinning
+
+All `requirements*.txt` files pin exact versions (`==`), never open ranges (`>=`).
+
+**Why:** an open range means the next `pip install` — in CI, in a Docker build,
+on a laptop — silently pulls whatever is newest on PyPI at that moment. On
+2026-03-24 the LiteLLM releases `1.82.7`/`1.82.8` were malicious and live for
+about 40 minutes; the pin at the time was `litellm>=1.60`, so any build in that
+window would have installed the backdoor. Exact pins turn a new release into a
+reviewed event instead of an automatic one. Upper bounds at the next major
+(`<2.0`) do **not** help against this: `1.82.8` sits inside `>=1.60,<2.0`.
+
+**Consequences to keep in mind:**
+
+- Every directory holding a requirements file must be listed in
+  `.github/dependabot.yml` — an unwatched directory freezes and stops receiving
+  security patches, which is strictly worse than an open range.
+- Transitive dependencies stay unpinned. Closing that gap needs a lockfile with
+  hashes (`pip-compile --generate-hashes` plus `pip install --require-hashes`)
+  and a rewrite of the Dockerfile and CI install steps — not done yet.
+- When changing a version, resolve the whole set at once
+  (`pip install --dry-run --report`) so shared packages (httpx, pydantic,
+  OpenTelemetry, …) stay identical across services: CI installs every
+  requirements file into a single environment, so a mismatch breaks the build.
 
 ### Naming Prefix Convention (`pb`)
 

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,4 +1,6 @@
-streamlit>=1.32
-streamlit-agraph>=0.0.45
-requests>=2.32
-pydantic>=2.5
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+streamlit==1.61.1
+streamlit-agraph==0.0.45
+requests==2.34.2
+pydantic==2.13.4

--- a/ingestion/adapters/office365/requirements.txt
+++ b/ingestion/adapters/office365/requirements.txt
@@ -3,9 +3,11 @@
 # Content extraction libs (markitdown, python-docx, openpyxl, python-pptx,
 # beautifulsoup4) have moved into ingestion/requirements.txt because they are
 # now shared across adapters and the /extract endpoint.
+#
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 
 # Microsoft Graph authentication (Entra ID protocol fixes)
-msal>=1.32
+msal==1.37.0
 
 # HTTP client (shared with core)
-httpx>=0.28
+httpx==0.28.1

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -1,30 +1,31 @@
-fastapi>=0.136.3
-uvicorn[standard]>=0.34
-httpx>=0.28.1
-asyncpg>=0.31.0
-qdrant-client>=1.12
-presidio-analyzer>=2.2.359
-presidio-anonymizer>=2.2
-spacy>=3.8.14
-pydantic>=2.13.4
-pyyaml>=6.0.3
-pyjwt[crypto]>=2.12.1
-cachetools>=7.1.1
-prometheus-client>=0.25.0
-opentelemetry-api>=1.41.1
-opentelemetry-sdk>=1.42.1
-opentelemetry-exporter-otlp-proto-grpc>=1.42.1
-opentelemetry-instrumentation-fastapi>=0.62b1
-opentelemetry-instrumentation-httpx>=0.63b1
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+fastapi==0.141.1
+uvicorn[standard]==0.52.2
+httpx==0.28.1
+asyncpg==0.31.0
+qdrant-client==1.19.0
+presidio-analyzer==2.2.364
+presidio-anonymizer==2.2.364
+spacy==3.8.15
+pydantic==2.13.4
+pyyaml==6.0.3
+pyjwt[crypto]==2.13.0
+cachetools==7.1.7
+prometheus-client==0.26.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+opentelemetry-instrumentation-fastapi==0.65b0
+opentelemetry-instrumentation-httpx==0.65b0
 
 # ── Content extraction (used by Office 365 adapter, GitHub adapter (opt-in),
 #    and the /extract endpoint called by pb-proxy for chat attachments) ──
-# Upper bounds cap at the next major to block unreviewed breaking changes.
-markitdown>=0.1.5,<0.2
-python-docx>=1.2.0,<2.0
-openpyxl>=3.1.0,<4.0
-python-pptx>=1.0.2,<2.0
-beautifulsoup4>=4.14.3,<5.0
+markitdown==0.1.7
+python-docx==1.2.0
+openpyxl==3.1.5
+python-pptx==1.0.2
+beautifulsoup4==4.15.0
 
 # ── Optional OCR fallback for scanned PDFs (default off) ──
 # Activated at build time via `--build-arg WITH_OCR=true` in the Dockerfile.
@@ -32,5 +33,5 @@ beautifulsoup4>=4.14.3,<5.0
 # Also requires system packages `tesseract-ocr` and `poppler-utils`.
 # pytesseract and pdf2image are installed unconditionally (pure Python, tiny);
 # Tesseract itself is opt-in at the image level.
-pytesseract>=0.3.13,<0.4
-pdf2image>=1.17.0,<2.0
+pytesseract==0.3.13
+pdf2image==1.17.0

--- a/init-db/001_schema.sql
+++ b/init-db/001_schema.sql
@@ -3,7 +3,7 @@
 -- ============================================================
 
 -- Classification levels
-CREATE TABLE classifications (
+CREATE TABLE IF NOT EXISTS classifications (
     id          SERIAL PRIMARY KEY,
     name        VARCHAR(50) UNIQUE NOT NULL,
     level       INTEGER NOT NULL,           -- 0=public, 1=internal, 2=confidential, 3=restricted
@@ -15,10 +15,11 @@ INSERT INTO classifications (name, level, description, access_policy) VALUES
 ('public',       0, 'Freely accessible to all agents',  'pb.access.public'),
 ('internal',     1, 'Internal agents only',             'pb.access.internal'),
 ('confidential', 2, 'Restricted access',                'pb.access.confidential'),
-('restricted',   3, 'Strictly controlled',              'pb.access.restricted');
+('restricted',   3, 'Strictly controlled',              'pb.access.restricted')
+ON CONFLICT (name) DO NOTHING;
 
 -- Datasets (imported CSV, JSON etc.)
-CREATE TABLE datasets (
+CREATE TABLE IF NOT EXISTS datasets (
     id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name             VARCHAR(255) NOT NULL,
     description      TEXT,
@@ -31,22 +32,22 @@ CREATE TABLE datasets (
     updated_at       TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_datasets_project ON datasets(project);
-CREATE INDEX idx_datasets_classification ON datasets(classification);
+CREATE INDEX IF NOT EXISTS idx_datasets_project ON datasets(project);
+CREATE INDEX IF NOT EXISTS idx_datasets_classification ON datasets(classification);
 
 -- Individual rows of a dataset
-CREATE TABLE dataset_rows (
+CREATE TABLE IF NOT EXISTS dataset_rows (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     dataset_id  UUID REFERENCES datasets(id) ON DELETE CASCADE,
     data        JSONB NOT NULL,
     created_at  TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_dataset_rows_dataset ON dataset_rows(dataset_id);
-CREATE INDEX idx_dataset_rows_data ON dataset_rows USING GIN(data);
+CREATE INDEX IF NOT EXISTS idx_dataset_rows_dataset ON dataset_rows(dataset_id);
+CREATE INDEX IF NOT EXISTS idx_dataset_rows_data ON dataset_rows USING GIN(data);
 
 -- Document metadata (reference to Qdrant vectors)
-CREATE TABLE documents_meta (
+CREATE TABLE IF NOT EXISTS documents_meta (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     title               VARCHAR(500) NOT NULL,
     source              VARCHAR(500),
@@ -60,11 +61,11 @@ CREATE TABLE documents_meta (
     updated_at          TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_documents_meta_project ON documents_meta(project);
-CREATE INDEX idx_documents_meta_classification ON documents_meta(classification);
+CREATE INDEX IF NOT EXISTS idx_documents_meta_project ON documents_meta(project);
+CREATE INDEX IF NOT EXISTS idx_documents_meta_classification ON documents_meta(classification);
 
 -- Audit log for agent access
-CREATE TABLE agent_access_log (
+CREATE TABLE IF NOT EXISTS agent_access_log (
     id              BIGSERIAL PRIMARY KEY,
     agent_id        VARCHAR(100) NOT NULL,
     agent_role      VARCHAR(50),
@@ -77,12 +78,12 @@ CREATE TABLE agent_access_log (
     created_at      TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_audit_agent ON agent_access_log(agent_id);
-CREATE INDEX idx_audit_time ON agent_access_log(created_at);
-CREATE INDEX idx_audit_result ON agent_access_log(policy_result);
+CREATE INDEX IF NOT EXISTS idx_audit_agent ON agent_access_log(agent_id);
+CREATE INDEX IF NOT EXISTS idx_audit_time ON agent_access_log(created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_result ON agent_access_log(policy_result);
 
 -- Project management
-CREATE TABLE projects (
+CREATE TABLE IF NOT EXISTS projects (
     id          VARCHAR(100) PRIMARY KEY,
     name        VARCHAR(255) NOT NULL,
     description TEXT,

--- a/init-db/002_privacy.sql
+++ b/init-db/002_privacy.sql
@@ -4,7 +4,7 @@
 -- ============================================================
 
 -- Data categories for GDPR purpose binding
-CREATE TABLE data_categories (
+CREATE TABLE IF NOT EXISTS data_categories (
     id              VARCHAR(50) PRIMARY KEY,
     description     TEXT NOT NULL,
     contains_pii    BOOLEAN DEFAULT false,
@@ -20,34 +20,35 @@ INSERT INTO data_categories (id, description, contains_pii, legal_basis, allowed
 ('marketing_data',  'Marketing contacts',           true,  'Art. 6 para. 1 lit. a (consent)',             ARRAY['campaign_management','consent_based_contact'], 365),
 ('contract_data',   'Contract documents',           true,  'Art. 6 para. 1 lit. b (contract performance)', ARRAY['contract_fulfillment','legal'], 1095),
 ('accounting_data', 'Accounting data',              true,  'Art. 6 para. 1 lit. c (legal obligation)',    ARRAY['accounting','audit'], 3650),
-('technical_data',  'Technical documentation',      false, NULL, ARRAY['development','operations'], 365);
+('technical_data',  'Technical documentation',      false, NULL, ARRAY['development','operations'], 365)
+ON CONFLICT (id) DO NOTHING;
 
 -- Add privacy fields to datasets
 ALTER TABLE datasets
-    ADD COLUMN data_category     VARCHAR(50) REFERENCES data_categories(id),
-    ADD COLUMN contains_pii      BOOLEAN DEFAULT false,
-    ADD COLUMN legal_basis        VARCHAR(100),
-    ADD COLUMN retention_expires_at TIMESTAMPTZ,
-    ADD COLUMN pii_fields         TEXT[],           -- Which fields contain PII
-    ADD COLUMN pseudonymized      BOOLEAN DEFAULT false;
+    ADD COLUMN IF NOT EXISTS data_category     VARCHAR(50) REFERENCES data_categories(id),
+    ADD COLUMN IF NOT EXISTS contains_pii      BOOLEAN DEFAULT false,
+    ADD COLUMN IF NOT EXISTS legal_basis        VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS pii_fields         TEXT[],           -- Which fields contain PII
+    ADD COLUMN IF NOT EXISTS pseudonymized      BOOLEAN DEFAULT false;
 
-CREATE INDEX idx_datasets_retention ON datasets(retention_expires_at)
+CREATE INDEX IF NOT EXISTS idx_datasets_retention ON datasets(retention_expires_at)
     WHERE retention_expires_at IS NOT NULL;
-CREATE INDEX idx_datasets_pii ON datasets(contains_pii)
+CREATE INDEX IF NOT EXISTS idx_datasets_pii ON datasets(contains_pii)
     WHERE contains_pii = true;
 
 -- Add privacy fields to documents_meta
 ALTER TABLE documents_meta
-    ADD COLUMN data_category     VARCHAR(50) REFERENCES data_categories(id),
-    ADD COLUMN contains_pii      BOOLEAN DEFAULT false,
-    ADD COLUMN retention_expires_at TIMESTAMPTZ,
-    ADD COLUMN data_subject_refs TEXT[];    -- References to data subjects
+    ADD COLUMN IF NOT EXISTS data_category     VARCHAR(50) REFERENCES data_categories(id),
+    ADD COLUMN IF NOT EXISTS contains_pii      BOOLEAN DEFAULT false,
+    ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS data_subject_refs TEXT[];    -- References to data subjects
 
-CREATE INDEX idx_docs_retention ON documents_meta(retention_expires_at)
+CREATE INDEX IF NOT EXISTS idx_docs_retention ON documents_meta(retention_expires_at)
     WHERE retention_expires_at IS NOT NULL;
 
 -- Data subjects (for access and deletion requests)
-CREATE TABLE data_subjects (
+CREATE TABLE IF NOT EXISTS data_subjects (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     external_ref    VARCHAR(255) UNIQUE NOT NULL,  -- External ID (customer no., etc.)
     pseudonym       VARCHAR(100) UNIQUE,           -- Pseudonymized identifier
@@ -56,11 +57,11 @@ CREATE TABLE data_subjects (
     created_at      TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_data_subjects_ref ON data_subjects(external_ref);
-CREATE INDEX idx_data_subjects_pseudonym ON data_subjects(pseudonym);
+CREATE INDEX IF NOT EXISTS idx_data_subjects_ref ON data_subjects(external_ref);
+CREATE INDEX IF NOT EXISTS idx_data_subjects_pseudonym ON data_subjects(pseudonym);
 
 -- Deletion request tracking (Art. 17 GDPR)
-CREATE TABLE deletion_requests (
+CREATE TABLE IF NOT EXISTS deletion_requests (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     data_subject_id UUID REFERENCES data_subjects(id),
     request_date    TIMESTAMPTZ DEFAULT now(),
@@ -73,14 +74,14 @@ CREATE TABLE deletion_requests (
 
 -- Extend audit log with privacy fields
 ALTER TABLE agent_access_log
-    ADD COLUMN contains_pii      BOOLEAN DEFAULT false,
-    ADD COLUMN purpose            VARCHAR(100),
-    ADD COLUMN legal_basis        VARCHAR(100),
-    ADD COLUMN data_category      VARCHAR(50),
-    ADD COLUMN fields_redacted    TEXT[];
+    ADD COLUMN IF NOT EXISTS contains_pii      BOOLEAN DEFAULT false,
+    ADD COLUMN IF NOT EXISTS purpose            VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS legal_basis        VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS data_category      VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS fields_redacted    TEXT[];
 
 -- PII scan results (detection log)
-CREATE TABLE pii_scan_log (
+CREATE TABLE IF NOT EXISTS pii_scan_log (
     id              BIGSERIAL PRIMARY KEY,
     source          VARCHAR(500),
     scan_date       TIMESTAMPTZ DEFAULT now(),
@@ -91,7 +92,7 @@ CREATE TABLE pii_scan_log (
 );
 
 -- View: all datasets with an expiring retention period
-CREATE VIEW v_expiring_data AS
+CREATE OR REPLACE VIEW v_expiring_data AS
 SELECT
     'dataset' AS source_type,
     id,

--- a/init-db/003_knowledge_graph.sql
+++ b/init-db/003_knowledge_graph.sql
@@ -16,82 +16,71 @@ CREATE EXTENSION IF NOT EXISTS age;
 LOAD 'age';
 SET search_path = ag_catalog, "$user", public;
 
--- Create graph
-SELECT create_graph('knowledge');
+-- ── Graph + labels ─────────────────────────────────────────
+--
+-- AGE has no IF NOT EXISTS for create_graph/create_vlabel/create_elabel,
+-- so guard against its catalog (ag_graph.name, ag_label.name+graph).
 
--- ── Vertex labels (node types) ─────────────────────────────
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM ag_catalog.ag_graph WHERE name = 'knowledge') THEN
+        PERFORM ag_catalog.create_graph('knowledge');
+    END IF;
+END
+$$;
 
-SELECT create_vlabel('knowledge', 'Project');
-SELECT create_vlabel('knowledge', 'Technology');
-SELECT create_vlabel('knowledge', 'Actor');
-SELECT create_vlabel('knowledge', 'Document');
-SELECT create_vlabel('knowledge', 'Rule');
-SELECT create_vlabel('knowledge', 'Concept');
+-- The ::cstring casts are required, not cosmetic: create_vlabel/create_elabel
+-- take cstring parameters. Bare string literals work because "unknown"
+-- coerces to cstring, but a TEXT loop variable does not -- without the cast
+-- this fails with "function ag_catalog.create_vlabel(unknown, text) does not
+-- exist".
+DO $$
+DECLARE
+    graph_oid OID;
+    lbl       TEXT;
+BEGIN
+    SELECT graphid INTO graph_oid FROM ag_catalog.ag_graph WHERE name = 'knowledge';
 
--- ── Edge labels (relationship types) ───────────────────────
+    -- Vertex labels (node types)
+    FOREACH lbl IN ARRAY ARRAY[
+        'Project', 'Technology', 'Actor', 'Document', 'Rule', 'Concept'
+    ] LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM ag_catalog.ag_label
+            WHERE name = lbl AND graph = graph_oid
+        ) THEN
+            PERFORM ag_catalog.create_vlabel('knowledge'::cstring, lbl::cstring);
+        END IF;
+    END LOOP;
 
-SELECT create_elabel('knowledge', 'USES');
-SELECT create_elabel('knowledge', 'WORKS_ON');
-SELECT create_elabel('knowledge', 'HAS_ROLE');
-SELECT create_elabel('knowledge', 'BELONGS_TO');
-SELECT create_elabel('knowledge', 'DESCRIBES');
-SELECT create_elabel('knowledge', 'APPLIES_TO');
-SELECT create_elabel('knowledge', 'RELATED_TO');
-SELECT create_elabel('knowledge', 'DEPENDS_ON');
+    -- Edge labels (relationship types)
+    FOREACH lbl IN ARRAY ARRAY[
+        'USES', 'WORKS_ON', 'HAS_ROLE', 'BELONGS_TO',
+        'DESCRIBES', 'APPLIES_TO', 'RELATED_TO', 'DEPENDS_ON'
+    ] LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM ag_catalog.ag_label
+            WHERE name = lbl AND graph = graph_oid
+        ) THEN
+            PERFORM ag_catalog.create_elabel('knowledge'::cstring, lbl::cstring);
+        END IF;
+    END LOOP;
+END
+$$;
 
--- ── Example data ───────────────────────────────────────────
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Project {name: 'knowledge base', phase: 'setup', classification: 'internal'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Project {name: 'API-Gateway', phase: 'production', classification: 'confidential'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Technology {name: 'Qdrant', category: 'database', version: '1.12'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Technology {name: 'PostgreSQL', category: 'database', version: '16'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Technology {name: 'OPA', category: 'policy_engine'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Technology {name: 'FastAPI', category: 'framework'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  MATCH (p:Project {name: 'knowledge base'}), (t:Technology {name: 'Qdrant'})
-  CREATE (p)-[:USES {since: '2026-03', purpose: 'vector search'}]->(t)
-$$) AS (e agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  MATCH (p:Project {name: 'knowledge base'}), (t:Technology {name: 'PostgreSQL'})
-  CREATE (p)-[:USES {since: '2026-03', purpose: 'structured data'}]->(t)
-$$) AS (e agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  MATCH (p:Project {name: 'knowledge base'}), (t:Technology {name: 'OPA'})
-  CREATE (p)-[:USES {since: '2026-03', purpose: 'policy set'}]->(t)
-$$) AS (e agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Concept {name: 'GDPR', domain: 'compliance'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  CREATE (:Concept {name: 'PII detection', domain: 'privacy'})
-$$) AS (v agtype);
-
-SELECT * FROM cypher('knowledge', $$
-  MATCH (c1:Concept {name: 'PII detection'}), (c2:Concept {name: 'GDPR'})
-  CREATE (c1)-[:RELATED_TO {relation: 'implements_requirement_of'}]->(c2)
-$$) AS (e agtype);
+-- ── No example data ────────────────────────────────────────
+--
+-- This file used to seed demo nodes here (Projects 'knowledge base' and
+-- 'API-Gateway', Technologies Qdrant/PostgreSQL/OPA/FastAPI, Concepts
+-- GDPR/'PII detection') via plain cypher CREATE. Because db-migrate re-runs
+-- every init-db file on each deploy and CREATE has no uniqueness check,
+-- those statements never errored -- they silently inserted another copy
+-- every time. The MATCH ... CREATE edge statements made it worse than
+-- linear: on run N they match N copies on each side and create N^2 edges.
+-- Live this had reached 25 copies per node and 16575 USES edges instead of 3.
+--
+-- Keep this section empty. The graph is populated by ingestion, and demo
+-- content does not belong in a migration that re-runs on every deploy.
 
 -- ── Views for fast access ──────────────────────────────────
 

--- a/init-db/004_evaluation.sql
+++ b/init-db/004_evaluation.sql
@@ -4,7 +4,7 @@
 -- ============================================================
 
 -- Agent feedback on search results
-CREATE TABLE search_feedback (
+CREATE TABLE IF NOT EXISTS search_feedback (
     id              BIGSERIAL PRIMARY KEY,
     query           TEXT NOT NULL,
     result_ids      TEXT[] NOT NULL,
@@ -18,13 +18,13 @@ CREATE TABLE search_feedback (
     created_at      TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_feedback_query   ON search_feedback(query);
-CREATE INDEX idx_feedback_rating  ON search_feedback(rating);
-CREATE INDEX idx_feedback_agent   ON search_feedback(agent_id);
-CREATE INDEX idx_feedback_time    ON search_feedback(created_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_query   ON search_feedback(query);
+CREATE INDEX IF NOT EXISTS idx_feedback_rating  ON search_feedback(rating);
+CREATE INDEX IF NOT EXISTS idx_feedback_agent   ON search_feedback(agent_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_time    ON search_feedback(created_at);
 
 -- Test set for offline evaluation
-CREATE TABLE eval_test_set (
+CREATE TABLE IF NOT EXISTS eval_test_set (
     id                SERIAL PRIMARY KEY,
     query             TEXT NOT NULL,
     expected_ids      TEXT[],           -- Known relevant document IDs
@@ -35,7 +35,7 @@ CREATE TABLE eval_test_set (
 );
 
 -- Evaluation runs (stored results from run_eval.py)
-CREATE TABLE eval_runs (
+CREATE TABLE IF NOT EXISTS eval_runs (
     id              SERIAL PRIMARY KEY,
     run_date        TIMESTAMPTZ DEFAULT now(),
     test_count      INTEGER,

--- a/init-db/005_versioning.sql
+++ b/init-db/005_versioning.sql
@@ -4,7 +4,7 @@
 -- ============================================================
 
 -- Snapshot metadata (Qdrant + PG + OPA policy commit)
-CREATE TABLE knowledge_snapshots (
+CREATE TABLE IF NOT EXISTS knowledge_snapshots (
     id              SERIAL PRIMARY KEY,
     snapshot_name   VARCHAR(255) NOT NULL,
     created_at      TIMESTAMPTZ DEFAULT now(),
@@ -20,11 +20,11 @@ CREATE TABLE knowledge_snapshots (
     size_bytes      BIGINT
 );
 
-CREATE INDEX idx_snapshots_name ON knowledge_snapshots(snapshot_name);
-CREATE INDEX idx_snapshots_time ON knowledge_snapshots(created_at);
+CREATE INDEX IF NOT EXISTS idx_snapshots_name ON knowledge_snapshots(snapshot_name);
+CREATE INDEX IF NOT EXISTS idx_snapshots_time ON knowledge_snapshots(created_at);
 
 -- Temporal history for datasets (SCD Type 2)
-CREATE TABLE datasets_history (
+CREATE TABLE IF NOT EXISTS datasets_history (
     history_id      BIGSERIAL PRIMARY KEY,
     dataset_id      UUID NOT NULL,
     valid_from      TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -34,8 +34,8 @@ CREATE TABLE datasets_history (
     changed_by      VARCHAR(100)
 );
 
-CREATE INDEX idx_datasets_hist_id   ON datasets_history(dataset_id);
-CREATE INDEX idx_datasets_hist_time ON datasets_history(valid_from, valid_to);
+CREATE INDEX IF NOT EXISTS idx_datasets_hist_id   ON datasets_history(dataset_id);
+CREATE INDEX IF NOT EXISTS idx_datasets_hist_time ON datasets_history(valid_from, valid_to);
 
 -- Trigger: automatically write history on changes to datasets
 CREATE OR REPLACE FUNCTION track_dataset_changes()
@@ -58,6 +58,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_datasets_history ON datasets;
 CREATE TRIGGER trg_datasets_history
     AFTER INSERT OR UPDATE OR DELETE ON datasets
     FOR EACH ROW EXECUTE FUNCTION track_dataset_changes();

--- a/init-db/006_privacy_incidents.sql
+++ b/init-db/006_privacy_incidents.sql
@@ -11,25 +11,37 @@
 --  Even "closed" incidents remain as evidence.
 -- ============================================================
 
-CREATE TYPE incident_status AS ENUM (
-    'detected',          -- Detected automatically or manually, not yet assessed
-    'under_review',      -- Data protection officer / admin is reviewing
-    'contained',         -- Data access locked, further dissemination stopped
-    'notified_authority',-- Notification to supervisory authority sent (Art. 33)
-    'notified_subject',  -- Data subject informed (Art. 34)
-    'resolved',          -- Closed, no notification required or already reported
-    'false_positive'     -- Review found no actual breach
-);
+-- ENUM types have no CREATE ... IF NOT EXISTS, so guard on pg_type.
+-- Note: adding a value to an existing enum needs its own
+-- ALTER TYPE ... ADD VALUE IF NOT EXISTS in a later migration; this
+-- guard only covers first creation.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'incident_status') THEN
+        CREATE TYPE incident_status AS ENUM (
+            'detected',          -- Detected automatically or manually, not yet assessed
+            'under_review',      -- Data protection officer / admin is reviewing
+            'contained',         -- Data access locked, further dissemination stopped
+            'notified_authority',-- Notification to supervisory authority sent (Art. 33)
+            'notified_subject',  -- Data subject informed (Art. 34)
+            'resolved',          -- Closed, no notification required or already reported
+            'false_positive'     -- Review found no actual breach
+        );
+    END IF;
 
-CREATE TYPE incident_source AS ENUM (
-    'llm_detection',     -- LLM detected unanonymized PII in the context
-    'pii_scanner',       -- Presidio scan during re-indexing
-    'agent_report',      -- Agent reported via submit_feedback or explicit report
-    'manual_audit',      -- Human review
-    'retention_check'    -- Retention cleanup discovered orphaned PII data
-);
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'incident_source') THEN
+        CREATE TYPE incident_source AS ENUM (
+            'llm_detection',     -- LLM detected unanonymized PII in the context
+            'pii_scanner',       -- Presidio scan during re-indexing
+            'agent_report',      -- Agent reported via submit_feedback or explicit report
+            'manual_audit',      -- Human review
+            'retention_check'    -- Retention cleanup discovered orphaned PII data
+        );
+    END IF;
+END
+$$;
 
-CREATE TABLE privacy_incidents (
+CREATE TABLE IF NOT EXISTS privacy_incidents (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
     -- Detection
@@ -82,11 +94,11 @@ CREATE TABLE privacy_incidents (
     deletion_request_id UUID REFERENCES deletion_requests(id)
 );
 
-CREATE INDEX idx_incidents_status    ON privacy_incidents(status);
-CREATE INDEX idx_incidents_detected  ON privacy_incidents(detected_at);
-CREATE INDEX idx_incidents_source    ON privacy_incidents(source);
-CREATE INDEX idx_incidents_pii_types ON privacy_incidents USING gin(pii_types_found);
-CREATE INDEX idx_incidents_notifiable ON privacy_incidents(notifiable_risk)
+CREATE INDEX IF NOT EXISTS idx_incidents_status    ON privacy_incidents(status);
+CREATE INDEX IF NOT EXISTS idx_incidents_detected  ON privacy_incidents(detected_at);
+CREATE INDEX IF NOT EXISTS idx_incidents_source    ON privacy_incidents(source);
+CREATE INDEX IF NOT EXISTS idx_incidents_pii_types ON privacy_incidents USING gin(pii_types_found);
+CREATE INDEX IF NOT EXISTS idx_incidents_notifiable ON privacy_incidents(notifiable_risk)
     WHERE notifiable_risk = true AND authority_notified_at IS NULL;
 
 -- Trigger: automatically record status changes in history
@@ -105,13 +117,14 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS trg_incident_status_history ON privacy_incidents;
 CREATE TRIGGER trg_incident_status_history
     BEFORE UPDATE ON privacy_incidents
     FOR EACH ROW EXECUTE FUNCTION track_incident_status();
 
 -- View: open incidents that might endanger the 72-hour notification deadline
 -- (Art. 33: notification within 72 hours of becoming aware)
-CREATE VIEW v_incidents_requiring_attention AS
+CREATE OR REPLACE VIEW v_incidents_requiring_attention AS
 SELECT
     id,
     detected_at,

--- a/init-db/007_pii_vault.sql
+++ b/init-db/007_pii_vault.sql
@@ -20,7 +20,7 @@ GRANT USAGE ON SCHEMA pii_vault TO mcp_vault_reader;
 -- ── Tables ─────────────────────────────────────────────────
 
 -- Original content (plaintext + detected PII entities)
-CREATE TABLE pii_vault.original_content (
+CREATE TABLE IF NOT EXISTS pii_vault.original_content (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     document_id     UUID NOT NULL REFERENCES documents_meta(id) ON DELETE CASCADE,
     chunk_index     INT NOT NULL,
@@ -32,13 +32,13 @@ CREATE TABLE pii_vault.original_content (
     UNIQUE (document_id, chunk_index)
 );
 
-CREATE INDEX idx_vault_content_retention
+CREATE INDEX IF NOT EXISTS idx_vault_content_retention
     ON pii_vault.original_content(retention_expires_at);
-CREATE INDEX idx_vault_content_document
+CREATE INDEX IF NOT EXISTS idx_vault_content_document
     ON pii_vault.original_content(document_id);
 
 -- Pseudonym mapping (for traceability + Art. 17 deletion)
-CREATE TABLE pii_vault.pseudonym_mapping (
+CREATE TABLE IF NOT EXISTS pii_vault.pseudonym_mapping (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     document_id     UUID NOT NULL REFERENCES documents_meta(id) ON DELETE CASCADE,
     chunk_index     INT NOT NULL,
@@ -48,13 +48,13 @@ CREATE TABLE pii_vault.pseudonym_mapping (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_vault_mapping_document
+CREATE INDEX IF NOT EXISTS idx_vault_mapping_document
     ON pii_vault.pseudonym_mapping(document_id);
-CREATE INDEX idx_vault_mapping_pseudonym
+CREATE INDEX IF NOT EXISTS idx_vault_mapping_pseudonym
     ON pii_vault.pseudonym_mapping(pseudonym);
 
 -- Separate audit log only for vault access
-CREATE TABLE pii_vault.vault_access_log (
+CREATE TABLE IF NOT EXISTS pii_vault.vault_access_log (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     agent_id        VARCHAR(200) NOT NULL,
     document_id     UUID NOT NULL,
@@ -64,13 +64,13 @@ CREATE TABLE pii_vault.vault_access_log (
     accessed_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_vault_access_agent
+CREATE INDEX IF NOT EXISTS idx_vault_access_agent
     ON pii_vault.vault_access_log(agent_id, accessed_at);
-CREATE INDEX idx_vault_access_document
+CREATE INDEX IF NOT EXISTS idx_vault_access_document
     ON pii_vault.vault_access_log(document_id);
 
 -- Project salts (deterministic per project)
-CREATE TABLE pii_vault.project_salts (
+CREATE TABLE IF NOT EXISTS pii_vault.project_salts (
     project_id      VARCHAR(100) PRIMARY KEY REFERENCES projects(id),
     salt            VARCHAR(200) NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -87,37 +87,50 @@ ALTER TABLE pii_vault.project_salts     ENABLE ROW LEVEL SECURITY;
 -- Audit log: even the table owner may not delete
 ALTER TABLE pii_vault.vault_access_log FORCE ROW LEVEL SECURITY;
 
--- Policy: only mcp_vault_reader and the DB owner (pb_admin) may access
-CREATE POLICY vault_content_read ON pii_vault.original_content
-    FOR SELECT TO mcp_vault_reader USING (true);
-
-CREATE POLICY vault_content_insert ON pii_vault.original_content
-    FOR INSERT TO mcp_vault_reader WITH CHECK (true);
-
-CREATE POLICY vault_content_delete ON pii_vault.original_content
-    FOR DELETE TO mcp_vault_reader USING (true);
-
-CREATE POLICY vault_mapping_read ON pii_vault.pseudonym_mapping
-    FOR SELECT TO mcp_vault_reader USING (true);
-
-CREATE POLICY vault_mapping_insert ON pii_vault.pseudonym_mapping
-    FOR INSERT TO mcp_vault_reader WITH CHECK (true);
-
-CREATE POLICY vault_mapping_delete ON pii_vault.pseudonym_mapping
-    FOR DELETE TO mcp_vault_reader USING (true);
-
-CREATE POLICY vault_access_log_insert ON pii_vault.vault_access_log
-    FOR INSERT TO mcp_vault_reader WITH CHECK (true);
-
-CREATE POLICY vault_access_log_read ON pii_vault.vault_access_log
-    FOR SELECT TO mcp_vault_reader USING (true);
-
--- Salts are append-only: no UPDATE/DELETE to preserve pseudonym integrity
-CREATE POLICY vault_salts_read ON pii_vault.project_salts
-    FOR SELECT TO mcp_vault_reader USING (true);
-
-CREATE POLICY vault_salts_insert ON pii_vault.project_salts
-    FOR INSERT TO mcp_vault_reader WITH CHECK (true);
+-- Policy: only mcp_vault_reader and the DB owner (pb_admin) may access.
+--
+-- Postgres has no CREATE POLICY IF NOT EXISTS, so each policy is guarded
+-- against pg_policies the same way 014/022/024 do it. Driven off a VALUES
+-- list rather than ten near-identical DO blocks.
+--
+-- Salts and the access log are append-only: no UPDATE/DELETE policy, so
+-- pseudonym integrity and the audit trail survive a compromised reader.
+--
+-- Caveat, same as the hand-written guards elsewhere: this only creates a
+-- missing policy, it never updates one that already exists. Changing a
+-- definition below needs an explicit DROP POLICY in a later migration.
+DO $$
+DECLARE
+    pol RECORD;
+BEGIN
+    FOR pol IN
+        SELECT * FROM (VALUES
+            ('original_content',  'vault_content_read',      'SELECT', 'USING (true)'),
+            ('original_content',  'vault_content_insert',    'INSERT', 'WITH CHECK (true)'),
+            ('original_content',  'vault_content_delete',    'DELETE', 'USING (true)'),
+            ('pseudonym_mapping', 'vault_mapping_read',      'SELECT', 'USING (true)'),
+            ('pseudonym_mapping', 'vault_mapping_insert',    'INSERT', 'WITH CHECK (true)'),
+            ('pseudonym_mapping', 'vault_mapping_delete',    'DELETE', 'USING (true)'),
+            ('vault_access_log',  'vault_access_log_insert', 'INSERT', 'WITH CHECK (true)'),
+            ('vault_access_log',  'vault_access_log_read',   'SELECT', 'USING (true)'),
+            ('project_salts',     'vault_salts_read',        'SELECT', 'USING (true)'),
+            ('project_salts',     'vault_salts_insert',      'INSERT', 'WITH CHECK (true)')
+        ) AS p(tbl, polname, cmd, clause)
+    LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = 'pii_vault'
+              AND tablename  = pol.tbl
+              AND policyname = pol.polname
+        ) THEN
+            EXECUTE format(
+                'CREATE POLICY %I ON pii_vault.%I FOR %s TO mcp_vault_reader %s',
+                pol.polname, pol.tbl, pol.cmd, pol.clause
+            );
+        END IF;
+    END LOOP;
+END
+$$;
 
 -- Grant permissions
 GRANT SELECT, INSERT, DELETE ON pii_vault.original_content TO mcp_vault_reader;

--- a/init-db/008_audit_rls.sql
+++ b/init-db/008_audit_rls.sql
@@ -19,23 +19,50 @@ BEGIN
 END
 $$;
 
--- Grant connect + usage so mcp_auditor can query the table
-GRANT CONNECT ON DATABASE powerbrain TO mcp_auditor;
+-- Grant connect + usage so mcp_auditor can query the table.
+-- The database name comes from the connection rather than a literal: this
+-- used to hard-code "powerbrain", which has never existed on this deployment
+-- (the database is "knowledgebase"), so the GRANT failed on every single run.
+-- ON_ERROR_STOP=0 swallowed it, leaving mcp_auditor without CONNECT.
+DO $$
+BEGIN
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO mcp_auditor', current_database());
+END
+$$;
+
 GRANT USAGE ON SCHEMA public TO mcp_auditor;
 
 -- Enable RLS
 ALTER TABLE agent_access_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE agent_access_log FORCE ROW LEVEL SECURITY;
 
--- Policy: mcp_app can only INSERT (write audit entries)
-CREATE POLICY audit_insert_only ON agent_access_log
-    FOR INSERT TO mcp_app
-    WITH CHECK (true);
+-- Policies, guarded against pg_policies the same way 014/022/024 do it
+-- (Postgres has no CREATE POLICY IF NOT EXISTS):
+--   - mcp_app can only INSERT (write audit entries)
+--   - mcp_auditor can only SELECT (read for compliance)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'agent_access_log'
+          AND policyname = 'audit_insert_only'
+    ) THEN
+        EXECUTE 'CREATE POLICY audit_insert_only ON agent_access_log '
+             || 'FOR INSERT TO mcp_app WITH CHECK (true)';
+    END IF;
 
--- Policy: mcp_auditor can only SELECT (read for compliance)
-CREATE POLICY audit_read_only ON agent_access_log
-    FOR SELECT TO mcp_auditor
-    USING (true);
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'agent_access_log'
+          AND policyname = 'audit_read_only'
+    ) THEN
+        EXECUTE 'CREATE POLICY audit_read_only ON agent_access_log '
+             || 'FOR SELECT TO mcp_auditor USING (true)';
+    END IF;
+END
+$$;
 
 -- Explicit: mcp_app gets INSERT, mcp_auditor gets SELECT
 GRANT INSERT ON agent_access_log TO mcp_app;

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,18 +1,26 @@
-mcp[server]>=1.27.1
-httpx>=0.28.1
-asyncpg>=0.31.0
-qdrant-client>=1.18.0
-pydantic>=2.13.4
-uvicorn[standard]>=0.48.0
-starlette>=1.2.0
-prometheus-client>=0.25.0
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+#
+# IMPORTANT: mcp is held at 1.x. 2.0.0 is a breaking API change — it drops the
+# `Server.list_tools()` decorator used in server.py. Do not accept a 2.x bump
+# without porting server.py first.
+# The former `[server]` extra was dropped: no 1.x release provides it either
+# (pip: "does not provide the extra 'server'"), so it installed nothing.
+mcp==1.29.0
+httpx==0.28.1
+asyncpg==0.31.0
+qdrant-client==1.19.0
+pydantic==2.13.4
+uvicorn[standard]==0.52.2
+starlette==1.6.0
+prometheus-client==0.26.0
 # OpenTelemetry (optional, aktiviert via OTEL_ENABLED=true)
-opentelemetry-api>=1.41.1
-opentelemetry-sdk>=1.42.1
-opentelemetry-exporter-otlp>=1.42.1
-opentelemetry-instrumentation-httpx>=0.63b1
-opentelemetry-instrumentation-fastapi>=0.62b1
-tenacity>=9.1.4
-cachetools>=7.1.1
-jsonschema>=4.26.0
-pyyaml>=6.0.3
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp==1.44.0
+opentelemetry-instrumentation-httpx==0.65b0
+opentelemetry-instrumentation-fastapi==0.65b0
+tenacity==9.1.4
+cachetools==7.1.7
+jsonschema==4.26.0
+pyyaml==6.0.3

--- a/pb-proxy/requirements.txt
+++ b/pb-proxy/requirements.txt
@@ -1,15 +1,20 @@
-fastapi>=0.136.3
-uvicorn[standard]>=0.48.0
-litellm>=1.83.7
-mcp>=1.27.2
-httpx>=0.28.1
-pydantic>=2.13.4
-pyyaml>=6.0.3
-prometheus-client>=0.25.0
-tenacity>=9.1.4
-asyncpg>=0.31.0
-opentelemetry-api>=1.42.1
-opentelemetry-sdk>=1.42.1
-opentelemetry-exporter-otlp-proto-grpc>=1.42.1
-opentelemetry-instrumentation-fastapi>=0.62b1
-opentelemetry-instrumentation-httpx>=0.63b1
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+fastapi==0.141.1
+uvicorn[standard]==0.52.2
+litellm==1.96.2
+# IMPORTANT: mcp is held at 1.x. 2.0.0 removes
+# `mcp.client.streamable_http.streamablehttp_client`, used in tool_injection.py.
+# Do not accept a 2.x bump without porting the client code first.
+mcp==1.29.0
+httpx==0.28.1
+pydantic==2.13.4
+pyyaml==6.0.3
+prometheus-client==0.26.0
+tenacity==9.1.4
+asyncpg==0.31.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+opentelemetry-instrumentation-fastapi==0.65b0
+opentelemetry-instrumentation-httpx==0.65b0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,11 @@
-pytest>=8.0
-pytest-asyncio>=0.24
-pytest-mock>=3.14
-respx>=0.22
-coverage>=7.0
-pytest-cov>=6.0
-pip-audit>=2.7
-bandit>=1.8
-locust>=2.20
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+pytest==9.1.1
+pytest-asyncio==1.4.0
+pytest-mock==3.15.1
+respx==0.23.1
+coverage==7.15.4
+pytest-cov==7.1.0
+pip-audit==2.10.1
+bandit==1.9.4
+locust==2.46.3

--- a/reranker/Dockerfile
+++ b/reranker/Dockerfile
@@ -2,13 +2,17 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Install from reranker/requirements.txt so its pinned versions are the single
+# source of truth (see CLAUDE.md "Dependency Pinning"). This step used to
+# install an unpinned inline list, which bypassed those pins entirely and also
+# omitted pydantic and the OpenTelemetry packages — so the tracing this service
+# is configured for in docker-compose.yml silently degraded to disabled.
+# The PyTorch CPU index keeps the image small: `torch==X` also matches `X+cpu`,
+# which that index serves and pip prefers over the PyPI (CUDA) wheel.
+COPY reranker/requirements.txt .
 RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
-    fastapi \
-    "uvicorn[standard]" \
-    sentence-transformers \
-    torch \
-    prometheus-client
+    -r requirements.txt
 
 COPY shared/ ./shared/
 COPY reranker/service.py .

--- a/reranker/requirements.txt
+++ b/reranker/requirements.txt
@@ -1,10 +1,12 @@
-fastapi>=0.136.3
-uvicorn[standard]>=0.49.0
-sentence-transformers>=5.5.1
-torch>=2.12.0
-pydantic>=2.13.4
-prometheus-client>=0.25.0
-opentelemetry-api>=1.42.1
-opentelemetry-sdk>=1.42.1
-opentelemetry-exporter-otlp-proto-grpc>=1.42.1
-opentelemetry-instrumentation-fastapi>=0.63b1
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
+fastapi==0.141.1
+uvicorn[standard]==0.52.2
+sentence-transformers==5.7.0
+torch==2.13.0
+pydantic==2.13.4
+prometheus-client==0.26.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+opentelemetry-instrumentation-fastapi==0.65b0

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,11 +1,11 @@
 # pb-worker dependencies.
-# Ranges (not hard pins) so pip-audit / Dependabot can pick up patches;
-# upper bounds cap at the next major to block incompatible rewrites.
+# Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
+# Dependabot proposes bumps; every change is reviewed in a PR.
 # IMPORTANT: APScheduler 4.x is a full rewrite and NOT compatible with the
-# 3.x scheduler API used in worker/scheduler.py — keep the `<4.0` ceiling.
-apscheduler>=3.11,<4.0
-asyncpg>=0.31.0,<1.0
-httpx>=0.28.1,<1.0
-prometheus-client>=0.25,<1.0
-qdrant-client>=1.18.0,<2.0
-python-dotenv>=1.2.2,<2.0
+# 3.x scheduler API used in worker/scheduler.py — do not accept a 4.x bump.
+apscheduler==3.11.3
+asyncpg==0.31.0
+httpx==0.28.1
+prometheus-client==0.26.0
+qdrant-client==1.19.0
+python-dotenv==1.2.2


### PR DESCRIPTION
Release 0.11.3.

## Contents

- **#242 — `fix(init-db)`: make migrations 001-008 idempotent.** Files 001-008 were written as one-shot DDL while 009+ are replay-safe, so replaying `init-db` against an existing database produced a wall of hard errors. Two real bugs were hiding in that noise: `008` hard-coded the database name in `GRANT CONNECT`, so `mcp_auditor` silently never received CONNECT wherever `POSTGRES_DB` differs from the default; and `003` seeded demo graph nodes with plain `cypher(... CREATE ...)`, which never errors and therefore inserted a fresh copy of every node on each replay, with `MATCH ... CREATE` producing N² edges. Verified with three consecutive full passes under `ON_ERROR_STOP=1`: zero errors, object counts stable.

- **#241 — `chore(deps)`: pin all direct dependencies to exact versions.** Also restores CI: unpinned ranges had drifted into a `prometheus_client` / `mcp` combination that broke test collection on every branch based on `development`.

## Notes

No breaking changes. The migration changes are backward compatible — they add guards, they do not alter existing schema objects. The one behavioural change is that `003` no longer seeds demo nodes; existing demo data is not removed by the migration and needs a separate one-off cleanup where it accumulated.

`CHANGELOG.md` is not updated here — it already lagged behind (last entry 0.11.1 while v0.11.2 shipped) and had unrelated work in progress at the time of the release.
