### PR TITLE
fix(pb-proxy): stop doubling tool names for self-namespacing MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead `[server]` extra** — `mcp[server]` requested an extra that no `mcp`
   release provides (pip: "does not provide the extra 'server'"), so it had
   always installed nothing. Dropped.
+- **Doubled tool names for self-namespacing MCP servers** — pb-proxy applied a
+  server's configured `prefix` unconditionally, so a server that already
+  namespaces its own tools got the prefix twice. A timecockpit-mcp entry
+  configured with `prefix: tc` injected `tc_tc_list_timesheets`,
+  `tc_tc_create_timesheet`, … because that server publishes its tools as `tc_…`
+  already — names that no skill or prompt written against the MCP server
+  matches. Prefixing is now idempotent (`_prefixed_tool_name`): a name that
+  already starts with `<prefix>_` is left alone, everything else is still
+  prefixed, so names stay unique across servers. Dropping the prefix from the
+  config would not have fixed it — `McpServerConfig` defaults `prefix` to the
+  server name, which yields `timecockpit_tc_list_timesheets` — and an empty
+  prefix would leave that server's non-`tc_` tools unnamespaced. No behaviour
+  change for the powerbrain server, whose tools are not named `powerbrain_*`.
+  PII routing is unaffected: `ToolEntry.needs_pii_scan` matches
+  `pii_scanned_tools` against the unprefixed `original_name`.
 
 ## [0.11.1] - 2026-05-27
 

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -110,6 +110,58 @@ def test_merge_tools_filters_by_allowed_servers():
     assert "github_list" not in names
 
 
+# ── prefix application tests ─────────────────────────────────
+
+
+def test_prefixed_tool_name_applies_prefix():
+    """A tool that is not namespaced gets the server prefix."""
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("powerbrain", "search_knowledge") == "powerbrain_search_knowledge"
+    assert _prefixed_tool_name("tc", "list_timesheets") == "tc_list_timesheets"
+
+
+def test_prefixed_tool_name_is_idempotent():
+    """A tool already named `<prefix>_…` is not prefixed twice.
+
+    timecockpit-mcp publishes `tc_list_timesheets` etc., so the `prefix: tc`
+    entry must not produce `tc_tc_list_timesheets`.
+    """
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("tc", "tc_list_timesheets") == "tc_list_timesheets"
+    assert _prefixed_tool_name("tc", "tc_find_similar_entries") == "tc_find_similar_entries"
+
+
+def test_prefixed_tool_name_partial_match_still_prefixed():
+    """A name that merely starts with the prefix letters still gets prefixed."""
+    from tool_injection import _prefixed_tool_name
+
+    # "tcfoo" starts with "tc" but is not namespaced ("tc_"), so it needs the prefix.
+    assert _prefixed_tool_name("tc", "tcfoo") == "tc_tcfoo"
+
+
+def test_prefixed_tool_name_no_prefix():
+    """An empty or missing prefix leaves the name untouched."""
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("", "search_knowledge") == "search_knowledge"
+    assert _prefixed_tool_name(None, "search_knowledge") == "search_knowledge"
+
+
+def test_mcp_tool_to_openai_uses_idempotent_prefix():
+    """Schema name and lookup key agree for an already-namespaced tool."""
+    from tool_injection import _mcp_tool_to_openai
+
+    class _Tool:
+        name = "tc_create_timesheet"
+        description = "Create a timesheet entry"
+        inputSchema = {"type": "object", "properties": {}}
+
+    schema = _mcp_tool_to_openai(_Tool(), "tc")
+    assert schema["function"]["name"] == "tc_create_timesheet"
+
+
 # ── _mcp_headers auth logic tests ────────────────────────────
 
 

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -72,9 +72,25 @@ def _mcp_headers(
     return headers
 
 
+def _prefixed_tool_name(prefix: str | None, name: str) -> str:
+    """Namespace an MCP tool name with its server prefix.
+
+    Idempotent: a server that already namespaces its own tools keeps the
+    names it publishes. timecockpit-mcp, for example, names every tool
+    `tc_…`, so the `prefix: tc` entry yields `tc_list_timesheets` rather
+    than `tc_tc_list_timesheets` — which is what the LLM (and the skills
+    and prompts written against those names) expects. Tools that are not
+    already namespaced still get the prefix, so names stay unique across
+    servers.
+    """
+    if not prefix or name.startswith(f"{prefix}_"):
+        return name
+    return f"{prefix}_{name}"
+
+
 def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
     """Convert an MCP Tool to OpenAI function-calling format with prefix."""
-    prefixed_name = f"{prefix}_{tool.name}" if prefix else tool.name
+    prefixed_name = _prefixed_tool_name(prefix, tool.name)
     return {
         "type": "function",
         "function": {
@@ -168,7 +184,7 @@ class ToolInjector:
                     # Apply whitelist filter
                     if server.tool_whitelist and tool.name not in server.tool_whitelist:
                         continue
-                    prefixed_name = f"{server.prefix}_{tool.name}" if server.prefix else tool.name
+                    prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
                     tools[prefixed_name] = ToolEntry(
                         server_name=server.name,
                         original_name=tool.name,


### PR DESCRIPTION
## Problem

pb-proxy applies a server's configured `prefix` unconditionally, so a server that already namespaces its own tools gets the prefix twice. A `timecockpit-mcp` entry configured with `prefix: tc` injects `tc_tc_list_timesheets`, `tc_tc_create_timesheet`, … because that server publishes its tools as `tc_…` already — names that no skill or prompt written against the MCP server matches.

This was latent until timecockpit-mcp's credential-less discovery stopped returning 401 (timecockpit-mcp `c2050e2`): before that the tools were never registered at all, so the doubling never showed.

## Fix

Prefixing is now idempotent via `_prefixed_tool_name()` — a name that already starts with `<prefix>_` is left alone, everything else is still prefixed, so names stay unique across servers.

The logic lived in two independent copies: the schema builder (`_mcp_tool_to_openai`) and the discovery loop (`_discover_server_tools`). They had to agree or the schema name and the routing key would disagree; both now call one helper.

## Alternatives rejected

- **Drop `prefix: tc` from the config.** `McpServerConfig.__post_init__` defaults `prefix` to the server name, so removing the line yields `timecockpit_tc_list_timesheets` — worse, not better.
- **Set `prefix: ""`.** Works for the `tc_…` tools, but that server also publishes tools that are *not* self-namespaced (`gh_…`, `generate_timesheet_description`). An empty prefix drops those into the namespace shared with every other server, and it collides with the duplicate-prefix validation if a second server ever wants the same.

## Scope

- No behaviour change for the `powerbrain` server — none of its tools are named `powerbrain_*` (checked against `mcp-server/server.py`).
- PII routing untouched: `ToolEntry.needs_pii_scan` matches `pii_scanned_tools` against the unprefixed `original_name`, and `tools_used` likewise reports `original_name`.

## Tests

Five new tests in `pb-proxy/tests/test_tool_injection.py` cover prefix application, idempotence, the partial-match case (`tcfoo` → `tc_tcfoo`, since only `tc_` counts as namespaced), the empty/`None` prefix, and schema/lookup-key agreement.

```
python -m pytest pb-proxy/tests/ -q -m "not integration"
175 passed, 2 skipped
```

Also verified against a running timecockpit-mcp instance: every tool it publishes maps to a unique name, with the `tc_…` tools keeping the names they publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
