### PR TITLE
fix(pb-proxy): log the real cause of MCP discovery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead `[server]` extra** — `mcp[server]` requested an extra that no `mcp`
   release provides (pip: "does not provide the extra 'server'"), so it had
   always installed nothing. Dropped.
+- **MCP discovery failures logged without their cause** — a server that failed
+  tool discovery was logged as `Optional server '…' unreachable: unhandled
+  errors in a TaskGroup (1 sub-exception)`. The MCP streamable-http client runs
+  its read/write pumps in an anyio task group, so the real failure arrives
+  wrapped in an `ExceptionGroup` whose own `str()` carries no HTTP status, auth
+  rejection or connection error — and the line repeats once per refresh
+  interval with no way to tell why, so the cause could only be found by
+  re-running discovery by hand. Discovery failures are now flattened
+  (`_describe_exception`) to their leaf exceptions, recursively since groups
+  nest, and logged as `Type: message` — e.g. `HTTPStatusError: Client error
+  '401 Unauthorized' for url '…'` or `ConnectError: All connection attempts
+  failed`. Multi-line leaf messages are collapsed so one failure stays one log
+  line, and the full traceback is emitted separately at debug level via
+  `exc_info`. Applies to both the required (`log.error`) and optional
+  (`log.warning`) branches.
 
 ## [0.11.1] - 2026-05-27
 

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -227,3 +227,199 @@ def test_mcp_headers_forward_combined_with_bearer_auth():
         "Authorization": "Bearer pb_key_123",
         "x-tenant-id": "tenant-42",
     }
+
+
+# ── ExceptionGroup flattening for discovery failures ─────────
+
+
+def test_leaf_exceptions_plain_exception_is_its_own_leaf():
+    """A non-group exception flattens to just itself."""
+    from tool_injection import _leaf_exceptions
+
+    exc = ValueError("boom")
+    assert _leaf_exceptions(exc) == [exc]
+
+
+def test_leaf_exceptions_flattens_nested_groups():
+    """Groups nest, so flattening recurses to the real leaves."""
+    from tool_injection import _leaf_exceptions
+
+    inner_a = ConnectionRefusedError("connect refused")
+    inner_b = TimeoutError("read timeout")
+    outer = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ExceptionGroup("inner group", [inner_a, inner_b])],
+    )
+    assert _leaf_exceptions(outer) == [inner_a, inner_b]
+
+
+def test_describe_exception_plain_exception_names_type():
+    """A plain exception is rendered as `Type: message`."""
+    from tool_injection import _describe_exception
+
+    assert _describe_exception(ValueError("bad url")) == "ValueError: bad url"
+
+
+def test_describe_exception_surfaces_taskgroup_leaf_cause():
+    """The leaf cause replaces the TaskGroup group's own useless str().
+
+    The MCP streamable-http client wraps failures in an anyio task group, so
+    logging the group with %s used to yield only "unhandled errors in a
+    TaskGroup (1 sub-exception)" with no HTTP status or auth error.
+    """
+    from tool_injection import _describe_exception
+
+    class HTTPStatusError(Exception):
+        pass
+
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [HTTPStatusError("Client error '401 Unauthorized' for url 'http://tc:8080/mcp'")],
+    )
+
+    # What the old `%s` formatting produced — the bug being fixed.
+    assert "TaskGroup" in str(group)
+    assert "401" not in str(group)
+
+    described = _describe_exception(group)
+    assert described == (
+        "HTTPStatusError: Client error '401 Unauthorized' for url 'http://tc:8080/mcp'"
+    )
+    assert "TaskGroup" not in described
+
+
+def test_describe_exception_joins_multiple_leaves():
+    """Several sub-exceptions are all reported, not just the first."""
+    from tool_injection import _describe_exception
+
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ConnectionRefusedError("connect refused"), TimeoutError("read timeout")],
+    )
+    assert _describe_exception(group) == (
+        "ConnectionRefusedError: connect refused; TimeoutError: read timeout"
+    )
+
+
+def test_describe_exception_collapses_multiline_messages():
+    """A multi-line leaf message is collapsed to keep the log one line.
+
+    httpx raises `Client error '401 Unauthorized' for url '…'\\nFor more
+    information check: …`, which would otherwise wrap the warning.
+    """
+    from tool_injection import _describe_exception
+
+    class HTTPStatusError(Exception):
+        pass
+
+    leaf = HTTPStatusError(
+        "Client error '401 Unauthorized' for url 'http://tc:8080/mcp'\n"
+        "For more information check: https://developer.mozilla.org/…/401"
+    )
+    described = _describe_exception(ExceptionGroup("unhandled errors in a TaskGroup", [leaf]))
+    assert "\n" not in described
+    assert described == (
+        "HTTPStatusError: Client error '401 Unauthorized' for url 'http://tc:8080/mcp' "
+        "For more information check: https://developer.mozilla.org/…/401"
+    )
+
+
+def test_describe_exception_message_less_leaf_falls_back_to_type():
+    """An exception with an empty str() still names its type."""
+    from tool_injection import _describe_exception
+
+    class ConnectError(Exception):
+        pass
+
+    assert _describe_exception(ConnectError()) == "ConnectError"
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [ConnectError()])
+    assert _describe_exception(group) == "ConnectError"
+
+
+def _cached_tool_entry():
+    """A single cached ToolEntry, so refresh keeps cache instead of raising."""
+    from tool_injection import ToolEntry
+
+    return ToolEntry(
+        server_name="powerbrain",
+        original_name="search_knowledge",
+        schema={},
+        server_config=McpServerConfig(
+            name="powerbrain", url="http://mcp:8080/mcp",
+            auth="bearer", prefix="powerbrain", required=True,
+        ),
+    )
+
+
+async def test_refresh_logs_leaf_cause_for_optional_server(caplog):
+    """The optional-server warning names the leaf cause, not the TaskGroup."""
+    import logging
+
+    from tool_injection import ToolInjector
+
+    server = McpServerConfig(
+        name="timecockpit", url="http://tc:8080/mcp", auth="static",
+        prefix="tc", required=False,
+    )
+    injector = ToolInjector.__new__(ToolInjector)
+    injector._servers = [server]
+    injector._server_status = {}
+    injector._tools = {"powerbrain_search_knowledge": _cached_tool_entry()}
+
+    async def _boom(_self, _server):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [PermissionError("401 Unauthorized")],
+        )
+
+    with patch.object(ToolInjector, "_discover_server_tools", _boom):
+        with caplog.at_level(logging.DEBUG, logger="pb-proxy.tools"):
+            await injector._refresh_all_tools()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    unreachable = [r for r in warnings if "timecockpit" in r.getMessage()]
+    assert len(unreachable) == 1
+    message = unreachable[0].getMessage()
+    assert "PermissionError: 401 Unauthorized" in message
+    assert "TaskGroup" not in message
+
+    # Traceback is still available, but only at debug level.
+    debug_with_traceback = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and r.exc_info is not None
+    ]
+    assert debug_with_traceback, "expected a debug record carrying the traceback"
+
+    assert injector._server_status["timecockpit"] is False
+
+
+async def test_refresh_logs_leaf_cause_for_required_server(caplog):
+    """The required-server error line gets the same flattening."""
+    import logging
+
+    from tool_injection import ToolInjector
+
+    server = McpServerConfig(
+        name="powerbrain", url="http://mcp:8080/mcp", auth="bearer",
+        prefix="powerbrain", required=True,
+    )
+    injector = ToolInjector.__new__(ToolInjector)
+    injector._servers = [server]
+    injector._server_status = {}
+    injector._tools = {"powerbrain_search_knowledge": _cached_tool_entry()}
+
+    async def _boom(_self, _server):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [ConnectionRefusedError("connect refused")])],
+        )
+
+    with patch.object(ToolInjector, "_discover_server_tools", _boom):
+        with caplog.at_level(logging.DEBUG, logger="pb-proxy.tools"):
+            await injector._refresh_all_tools()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    message = errors[0].getMessage()
+    assert "ConnectionRefusedError: connect refused" in message
+    assert "TaskGroup" not in message

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -85,6 +85,40 @@ def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
     }
 
 
+def _leaf_exceptions(exc: BaseException) -> list[BaseException]:
+    """Flatten a possibly-nested ExceptionGroup into its leaf exceptions.
+
+    Groups can contain groups, so this recurses. A plain exception is its own
+    only leaf.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        for sub in exc.exceptions:
+            leaves.extend(_leaf_exceptions(sub))
+        return leaves
+    return [exc]
+
+
+def _describe_exception(exc: BaseException) -> str:
+    """Render an exception as `Type: message` for a single log line.
+
+    The MCP streamable-http client runs its read/write pumps inside an anyio
+    task group, so a failed connection surfaces as an ExceptionGroup whose own
+    str() is the useless "unhandled errors in a TaskGroup (1 sub-exception)" —
+    the HTTP status, auth rejection or connection error that actually broke
+    discovery sits in the sub-exceptions. Report the leaves instead, so the
+    warning names the cause without needing the full traceback.
+    """
+    parts: list[str] = []
+    for leaf in _leaf_exceptions(exc):
+        # httpx spreads its messages over several lines ("Client error '401
+        # Unauthorized' …\nFor more information check: …"); collapse the
+        # whitespace so one failure stays one log line.
+        message = " ".join(str(leaf).split())
+        parts.append(f"{type(leaf).__name__}: {message}" if message else type(leaf).__name__)
+    return "; ".join(parts) if parts else type(exc).__name__
+
+
 class ToolInjector:
     """Discovers tools from multiple MCP servers and injects them into LLM requests."""
 
@@ -138,10 +172,13 @@ class ToolInjector:
                 )
             except Exception as e:
                 self._server_status[server.name] = False
+                cause = _describe_exception(e)
                 if server.required:
-                    log.error("Required server '%s' unreachable: %s", server.name, e)
+                    log.error("Required server '%s' unreachable: %s", server.name, cause)
                 else:
-                    log.warning("Optional server '%s' unreachable: %s", server.name, e)
+                    log.warning("Optional server '%s' unreachable: %s", server.name, cause)
+                # Full traceback only at debug level, so the line above stays readable.
+                log.debug("Discovery failure for server '%s'", server.name, exc_info=True)
 
         if new_tools:
             self._tools = new_tools


### PR DESCRIPTION
## Problem

A server that failed tool discovery was logged as

```
Optional server '...' unreachable: unhandled errors in a TaskGroup (1 sub-exception)
```

The MCP streamable-http client runs its read/write pumps in an anyio task group, so the real failure arrives wrapped in an `ExceptionGroup`. Formatting that group with `%s` yields only its own `str()`, which carries no HTTP status, no auth rejection and no connection error — and the line repeats once per refresh interval, so the cause could only be recovered by re-running the discovery path by hand.

## Fix

Discovery failures are flattened to their leaf exceptions and rendered as `Type: message`:

```
Optional server '...' unreachable: HTTPStatusError: Client error '401 Unauthorized' for url '...'
Optional server '...' unreachable: ConnectError: All connection attempts failed
```

- `_leaf_exceptions` recurses, since groups can nest inside groups.
- `_describe_exception` joins multiple leaves with `; `, so a group carrying several failures reports all of them.
- Leaf messages get their whitespace collapsed — httpx spreads its text over two lines, which would otherwise wrap the warning and defeat the point.
- An exception whose `str()` is empty falls back to its bare type name.

Applied to both branches: required servers (`log.error`) and optional ones (`log.warning`). The full traceback is still available, emitted separately at debug level via `exc_info`; logging checks the level before touching `exc_info`, so this costs nothing when debug is off.

## Tests

Verified against the real client rather than only synthetic groups: a dead port and a throwaway local HTTP server returning 401 both produced the useless TaskGroup string before, and the leaf cause after.

## Interaction with #250

Both PRs touch `pb-proxy/tool_injection.py` and both add a bullet to `CHANGELOG.md` under `[Unreleased]` / `### Fixed`. The code files auto-merge cleanly (the two changes sit in different regions, confirmed with `git merge-tree`); whichever PR merges second will hit a `CHANGELOG.md` conflict whose resolution is simply to keep both bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
