### PR TITLE
feat(mcp): port mcp-server and pb-proxy to MCP Python SDK 2.0

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -3,6 +3,13 @@ name: PR Validate
 on:
   pull_request:
     branches: [development, master]
+  # Requirements are resolved fresh on every run, so a dependency that ships a
+  # breaking major between PRs only surfaces the next time CI runs. Without a
+  # cadence that can be weeks, and the first symptom is a crashlooping image on
+  # someone's machine. Weekly run against the default branch closes that gap.
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
 
 jobs:
   unit-tests:
@@ -61,6 +68,17 @@ jobs:
       - name: Build mcp-server image
         run: docker build -f mcp-server/Dockerfile -t pb-mcp-server:pr-test .
 
+      # `docker build` only runs pip install — it never imports the app. An
+      # incompatible dependency bump therefore builds green and crashloops at
+      # runtime. Importing the CMD module is the cheapest check that the image
+      # can actually start. SKIP_INGESTION_AUTH_STARTUP_CHECK mirrors the test
+      # conftests: it bypasses the fail-closed auth guard, which has no token to
+      # find here and is not what this step is testing.
+      - name: Smoke-import mcp-server
+        run: |
+          docker run --rm -e SKIP_INGESTION_AUTH_STARTUP_CHECK=true \
+            pb-mcp-server:pr-test python -c "import server"
+
       - name: Build ingestion image
         run: docker build -f ingestion/Dockerfile -t pb-ingestion:pr-test .
 
@@ -69,6 +87,11 @@ jobs:
 
       - name: Build pb-proxy image
         run: docker build -f pb-proxy/Dockerfile -t pb-proxy:pr-test .
+
+      - name: Smoke-import pb-proxy
+        run: |
+          docker run --rm -e SKIP_INGESTION_AUTH_STARTUP_CHECK=true \
+            pb-proxy:pr-test python -c "import proxy"
 
       - name: Build worker image
         run: docker build -f worker/Dockerfile -t pb-worker:pr-test .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `reranker/requirements.txt` entirely. It now installs from that file, still
   via the PyTorch CPU index.
 
+### Changed
+
+- **Ported to MCP Python SDK 2.0** — `mcp` moves from `1.29.0` to `2.0.0` and
+  both services move with it. `mcp-server/server.py` binds its handlers through
+  the `on_list_tools` / `on_call_tool` constructor params instead of the removed
+  `@server.list_tools()` / `@server.call_tool()` decorators; the handlers now
+  take `(ctx, params)` and return `ListToolsResult` / `CallToolResult`. The tool
+  definitions and `TextContent(...)` blocks are untouched — 2.x keeps the
+  `inputSchema` field alias and populates by name, so only the two handler
+  signatures actually changed. In `pb-proxy/tool_injection.py` the replacement
+  `streamable_http_client` drops `headers=` in favour of a caller-supplied HTTP
+  client and yields two streams instead of three; both call sites now share one
+  `_mcp_session()` helper.
+- **httpx2 alongside httpx** — the MCP SDK's HTTP stack from 2.0 on is `httpx2`,
+  a separate distribution rather than a new httpx release. `pb-proxy` imports it
+  directly to attach auth headers. Passing a plain `httpx` client where the SDK
+  expects `httpx2` is *accepted* and then silently stops delivering
+  server-initiated messages, so client construction is centralised in
+  `_mcp_session()` with that caveat recorded at the call site.
+  `shared/telemetry.py` additionally registers `HTTPX2ClientInstrumentor`:
+  without it the pb-proxy → mcp-server hop loses its parent span and tool calls
+  surface as orphan traces in Tempo. Note for deployers: httpx2 defaults to the
+  OS trust store instead of certifi's bundle, so a private CA installed only at
+  OS level is honoured by MCP connections and rejected by everything else — both
+  clients accept `SSL_CERT_FILE`, which is now the documented lever. See
+  "Outbound TLS (Certificate Trust)" in `docs/deployment.md`.
+
 ### Fixed
 
 - **CI red since late July** — `mcp[server]>=1.27.1` resolved to `mcp 2.0.0`,
@@ -37,9 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mcp-server/server.py` and `streamablehttp_client` used in
   `pb-proxy/tool_injection.py`. Test collection failed on both; the cascading
   `DuplicateTimeseries` errors were a symptom of the half-executed imports, not
-  an independent fault. `mcp` is now held at `1.29.0`, the last 1.x release, and
-  the suite passes again (1115 passed, 20 skipped, 70.45% coverage). Porting to
-  the 2.x API remains a separate task.
+  an independent fault. `mcp` was first held at `1.29.0`, the last 1.x release,
+  to make the suite pass again (1115 passed, 20 skipped, 70.45% coverage). The
+  port to the 2.x API has since landed — see "Ported to MCP Python SDK 2.0"
+  under Changed above.
 - **Reranker tracing was silently disabled** — the image never installed the
   OpenTelemetry packages its `requirements.txt` declares, so
   `shared/telemetry.py` degraded to disabled even though `docker-compose.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,7 @@ docker run --rm -v "$(pwd):/app" -w /app python:3.12-slim bash -c "
 ### Structured Telemetry
 All 4 services (mcp-server, proxy, reranker, ingestion) share a common telemetry module (`shared/telemetry.py`):
 
-- **OTel Tracing** — `init_telemetry(service_name)` creates TracerProvider + OTLP exporter to Tempo. Auto-instrumentation for FastAPI and httpx (W3C `traceparent` propagation). Configurable via `OTEL_ENABLED` (default `true`), `OTLP_ENDPOINT` (default `http://tempo:4317`).
+- **OTel Tracing** — `init_telemetry(service_name)` creates TracerProvider + OTLP exporter to Tempo. Auto-instrumentation for FastAPI, httpx and httpx2 (W3C `traceparent` propagation). Both HTTP clients are instrumented because the MCP SDK speaks httpx2 from 2.0 on while the services' own calls use httpx — instrumenting only one leaves the proxy → mcp-server hop as an orphan trace. Configurable via `OTEL_ENABLED` (default `true`), `OTLP_ENDPOINT` (default `http://tempo:4317`).
 - **Per-Request Telemetry** — `RequestTelemetry` + `PipelineStep` dataclasses accumulate timing breakdown per request. `trace_operation()` context manager creates OTel span and records step simultaneously. Responses include `_telemetry` block when `TELEMETRY_IN_RESPONSE=true` (default).
 - **JSON Metrics Endpoint** — Each service exposes `GET /metrics/json` returning structured metrics from Prometheus registry via `MetricsAggregator`. Designed for demo-UI consumption without PromQL knowledge.
 - **Graceful degradation** — If OTel packages not installed or exporter unreachable, tracing silently disables. Prometheus metrics always available.
@@ -555,7 +555,7 @@ All 4 services (mcp-server, proxy, reranker, ingestion) share a common telemetry
 16. ✅ **Proxy Authentication** — ASGI middleware (`pb-proxy/middleware.py`) for global `pb_` API-key auth, identity propagation to MCP servers
 17. ✅ **Multi-MCP-Server Aggregation** — Proxy aggregates tools from N MCP servers with per-server auth, prefix namespacing, and OPA-controlled access (`pb.proxy.mcp_servers_allowed`)
 18. ✅ **T1 Production Hardening** — Embedding cache (in-process LRU), batch embedding API, OPA result cache, configurable PG pool sizes, Docker health checks for all services
-19. ✅ **Structured Telemetry** — Shared OTel module (`shared/telemetry.py`), per-request `_telemetry` in search/chat responses, `/metrics/json` endpoints on all 4 services (mcp-server, proxy, reranker, ingestion), W3C traceparent propagation via auto-instrumented httpx
+19. ✅ **Structured Telemetry** — Shared OTel module (`shared/telemetry.py`), per-request `_telemetry` in search/chat responses, `/metrics/json` endpoints on all 4 services (mcp-server, proxy, reranker, ingestion), W3C traceparent propagation via auto-instrumented httpx + httpx2
 20. ✅ **Per-Provider Key Management** — Flexible LLM API key resolution (central/user/hybrid modes) via `provider_keys` in `litellm_config.yaml`, `X-Provider-Key` header support
 21. ✅ **PII Scan Observability & Strict Defaults** — `PII_SCAN_FORCED` defaults to `true` (fail-closed). Telemetry step `pii_pseudonymize` includes `mode`, `entities_found`, `entity_types`, `fail_mode`. OPA policy `pb.proxy.pii_scan_forced` defaults to `true`, admin can override via `pii_scan_forced_override: false`
 22. ✅ **Reranker Provider Abstraction** — Configurable reranker backend via `RERANKER_BACKEND` env var (`powerbrain`/`tei`/`cohere`). Strategy pattern in `shared/rerank_provider.py`, transparent format translation, graceful fallback preserved

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,6 +132,46 @@ pb.example.com {
 }
 ```
 
+## Outbound TLS (Certificate Trust)
+
+The sections above cover *inbound* TLS — the certificates Powerbrain serves. This
+one covers *outbound*: which certificates Powerbrain accepts when it calls other
+systems (MCP servers, LLM providers, your Git server, Microsoft Graph).
+
+Two HTTP clients are in play, and they differ in **which CAs they trust by
+default**:
+
+| Client | Used for | Default trust store |
+|---|---|---|
+| `httpx` | Services' own calls (ingestion, embeddings, OPA, reranker, LLM providers) | certifi's bundled CA list |
+| `httpx2` | The MCP SDK's transport (pb-proxy → MCP servers), from `mcp` 2.0 on | The operating system trust store, via `truststore` |
+
+For deployments that only talk to endpoints with publicly-trusted certificates,
+this never surfaces. It matters when an endpoint presents a certificate signed by
+a **private or internal CA** — a self-hosted Forgejo or GitLab, an internal MCP
+server, a corporate TLS-inspecting proxy. Installing that CA only in the
+container's OS trust store is not enough: MCP connections would accept it while
+every other call still rejects it, which looks like "the proxy works but
+ingestion doesn't".
+
+**Set `SSL_CERT_FILE` to your CA bundle.** Both clients honour it, so one setting
+covers every outbound call:
+
+```yaml
+# docker-compose.override.yml
+services:
+  mcp-server:
+    environment:
+      SSL_CERT_FILE: /etc/ssl/private-ca/bundle.pem
+    volumes:
+      - ./private-ca:/etc/ssl/private-ca:ro
+```
+
+The bundle must contain the full chain **plus** the public roots you still need
+(`cat /etc/ssl/certs/ca-certificates.crt your-ca.pem > bundle.pem`) — pointing
+`SSL_CERT_FILE` at a file holding only your private CA makes every
+publicly-trusted endpoint fail verification.
+
 ## Docker Secrets Setup
 
 Powerbrain supports Docker Secrets for sensitive configuration values. This is the recommended approach for production deployments.

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,12 +1,10 @@
 # Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 # Dependabot proposes bumps; every change is reviewed in a PR.
 #
-# IMPORTANT: mcp is held at 1.x. 2.0.0 is a breaking API change — it drops the
-# `Server.list_tools()` decorator used in server.py. Do not accept a 2.x bump
-# without porting server.py first.
-# The former `[server]` extra was dropped: no 1.x release provides it either
-# (pip: "does not provide the extra 'server'"), so it installed nothing.
-mcp==1.29.0
+# mcp 2.x: the lowlevel Server binds handlers via on_list_tools/on_call_tool
+# constructor params instead of decorators — see server.py "MCP-Server-Instanz".
+# The `[server]` extra does not exist in either 1.x or 2.x, so it is not used.
+mcp==2.0.0
 httpx==0.28.1
 asyncpg==0.31.0
 qdrant-client==1.19.0

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -23,9 +23,16 @@ import httpx
 import asyncpg
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import Filter, FieldCondition, MatchValue, FilterSelector
-from mcp.server import Server
+from mcp.server import Server, ServerRequestContext
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import Tool, TextContent
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 from mcp.server.auth.provider import TokenVerifier, AccessToken
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend, RequireAuthMiddleware
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_access_token
@@ -1294,12 +1301,14 @@ async def check_feedback_warning(query: str, pool: asyncpg.Pool):
 
 
 # ── MCP-Server ───────────────────────────────────────────────
-server = Server("pb-mcp-server")
-
-
-@server.list_tools()
-async def list_tools() -> list[Tool]:
-    return [
+# mcp 2.x replaced the @server.list_tools()/@server.call_tool() decorators with
+# on_* constructor params. The handlers are therefore plain functions and the
+# Server instance is built below them — see "MCP-Server-Instanz".
+async def list_tools(
+    ctx: ServerRequestContext,
+    params: PaginatedRequestParams | None,
+) -> ListToolsResult:
+    return ListToolsResult(tools=[
         Tool(
             name="search_knowledge",
             description="Semantic search over the knowledge base. "
@@ -1867,13 +1876,18 @@ async def list_tools() -> list[Tool]:
                 "required": ["incident_id", "subject_ref", "channel"]
             }
         ),
-    ]
+    ])
 
 
 # ── Tool-Implementierungen ───────────────────────────────────
 
-@server.call_tool()
-async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+async def call_tool(
+    ctx: ServerRequestContext,
+    params: CallToolRequestParams,
+) -> CallToolResult:
+    name = params.name
+    arguments = params.arguments or {}
+
     # ── Identity from auth token (preferred) or arguments (legacy) ──
     access_token = get_access_token()
     if access_token is not None:
@@ -1886,7 +1900,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         log.warning("Unauthenticated request for tool '%s' from agent_id='%s'", name, agent_id)
     else:
         # Should not reach here (RequireAuthMiddleware already rejected)
-        return [TextContent(type="text", text=json.dumps({"error": "authentication required"}))]
+        return CallToolResult(content=[
+            TextContent(type="text", text=json.dumps({"error": "authentication required"}))
+        ])
 
     t_start = time.perf_counter()
     status  = "ok"
@@ -1917,7 +1933,17 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     mcp_requests_total.labels(tool=name, status=status).inc()
     mcp_request_duration.labels(tool=name).observe(elapsed)
 
-    return result
+    # is_error stays at its default False: _dispatch reports failures as an
+    # {"error": ...} payload in the content, which is what clients already parse.
+    return CallToolResult(content=result)
+
+
+# ── MCP-Server-Instanz ───────────────────────────────────────
+server = Server(
+    "pb-mcp-server",
+    on_list_tools=list_tools,
+    on_call_tool=call_tool,
+)
 
 
 def _build_delete_filter(source_type: str | None, project: str | None,

--- a/mcp-server/tests/test_manage_policies.py
+++ b/mcp-server/tests/test_manage_policies.py
@@ -4,7 +4,22 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from mcp.types import CallToolRequestParams
+
 import server
+
+
+async def _call(name: str, arguments: dict):
+    """Invoke the tool handler and return its content blocks.
+
+    mcp 2.x calls handlers as (ctx, params) and wraps the reply in a
+    CallToolResult; these tests assert on the content blocks either way. The
+    handler ignores ctx, so None is sufficient here.
+    """
+    result = await server.call_tool(
+        None, CallToolRequestParams(name=name, arguments=arguments),
+    )
+    return result.content
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +80,7 @@ class TestManagePoliciesList:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {"action": "list"})
+        result = await _call("manage_policies", {"action": "list"})
         data = json.loads(result[0].text)
         assert "sections" in data
         # All 17 required sections should be listed
@@ -83,7 +98,7 @@ class TestManagePoliciesList:
         token.scopes = ["analyst"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {"action": "list"})
+        result = await _call("manage_policies", {"action": "list"})
         data = json.loads(result[0].text)
         assert "error" in data
         assert "admin" in data["error"]
@@ -102,7 +117,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -117,7 +132,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "nonexistent"
         })
         data = json.loads(result[0].text)
@@ -134,7 +149,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -158,7 +173,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         new_roles = ["viewer", "analyst", "developer", "admin", "auditor"]
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": new_roles
         })
         data = json.loads(result[0].text)
@@ -178,7 +193,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         # roles must be an array, not a string
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": "not_an_array"
         })
         data = json.loads(result[0].text)
@@ -196,7 +211,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         # roles has minItems: 1, so empty array should fail
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": []
         })
         data = json.loads(result[0].text)
@@ -211,7 +226,7 @@ class TestManagePoliciesUpdate:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -232,7 +247,7 @@ class TestManagePoliciesUpdate:
         server._opa_cache["test_key"] = True
         server._fields_to_redact_cache["test_key"] = {"email"}
 
-        await server.call_tool("manage_policies", {
+        await _call("manage_policies", {
             "action": "update", "section": "roles",
             "data": ["viewer", "analyst", "admin"]
         })
@@ -251,7 +266,7 @@ class TestManagePoliciesUpdate:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles",
             "data": ["viewer", "admin"]
         })

--- a/pb-proxy/requirements.txt
+++ b/pb-proxy/requirements.txt
@@ -3,11 +3,13 @@
 fastapi==0.141.1
 uvicorn[standard]==0.52.2
 litellm==1.96.2
-# IMPORTANT: mcp is held at 1.x. 2.0.0 removes
-# `mcp.client.streamable_http.streamablehttp_client`, used in tool_injection.py.
-# Do not accept a 2.x bump without porting the client code first.
-mcp==1.29.0
+mcp==2.0.0
 httpx==0.28.1
+# httpx2 is the MCP SDK's HTTP stack from 2.0 on. tool_injection.py imports it
+# directly to attach auth headers, so it is pinned here rather than inherited.
+# Do not substitute httpx: the SDK accepts an httpx client and then silently
+# stops delivering server-initiated messages.
+httpx2==2.10.0
 pydantic==2.13.4
 pyyaml==6.0.3
 prometheus-client==0.26.0

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -156,7 +156,7 @@ def test_mcp_tool_to_openai_uses_idempotent_prefix():
     class _Tool:
         name = "tc_create_timesheet"
         description = "Create a timesheet entry"
-        inputSchema = {"type": "object", "properties": {}}
+        input_schema = {"type": "object", "properties": {}}
 
     schema = _mcp_tool_to_openai(_Tool(), "tc")
     assert schema["function"]["name"] == "tc_create_timesheet"

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -6,11 +6,13 @@ prefixes them with server name, and routes tool calls to the correct server.
 import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 
+import httpx2
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 import config
 from mcp_config import McpServerConfig, load_mcp_servers
@@ -96,7 +98,7 @@ def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
         "function": {
             "name": prefixed_name,
             "description": tool.description or "",
-            "parameters": tool.inputSchema or {"type": "object"},
+            "parameters": tool.input_schema or {"type": "object"},
         },
     }
 
@@ -133,6 +135,24 @@ def _describe_exception(exc: BaseException) -> str:
         message = " ".join(str(leaf).split())
         parts.append(f"{type(leaf).__name__}: {message}" if message else type(leaf).__name__)
     return "; ".join(parts) if parts else type(exc).__name__
+
+
+@asynccontextmanager
+async def _mcp_session(url: str, headers: dict[str, str]):
+    """Open an initialised MCP ClientSession over streamable HTTP.
+
+    mcp 2.x dropped the `headers=` argument: auth now rides on a caller-supplied
+    HTTP client. That client MUST be httpx2 — passing a plain httpx client is
+    accepted but silently stops delivering server-initiated messages instead of
+    raising, which on this path would break bearer auth without any error.
+    """
+    async with httpx2.AsyncClient(headers=headers) as http_client:
+        async with streamable_http_client(url, http_client=http_client) as (
+            read_stream, write_stream,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
 
 
 class ToolInjector:
@@ -210,24 +230,20 @@ class ToolInjector:
         headers = _mcp_headers(server)
         tools: dict[str, ToolEntry] = {}
 
-        async with streamablehttp_client(server.url, headers=headers) as (
-            read_stream, write_stream, _,
-        ):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                result = await session.list_tools()
+        async with _mcp_session(server.url, headers) as session:
+            result = await session.list_tools()
 
-                for tool in result.tools:
-                    # Apply whitelist filter
-                    if server.tool_whitelist and tool.name not in server.tool_whitelist:
-                        continue
-                    prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
-                    tools[prefixed_name] = ToolEntry(
-                        server_name=server.name,
-                        original_name=tool.name,
-                        schema=_mcp_tool_to_openai(tool, server.prefix),
-                        server_config=server,
-                    )
+            for tool in result.tools:
+                # Apply whitelist filter
+                if server.tool_whitelist and tool.name not in server.tool_whitelist:
+                    continue
+                prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
+                tools[prefixed_name] = ToolEntry(
+                    server_name=server.name,
+                    original_name=tool.name,
+                    schema=_mcp_tool_to_openai(tool, server.prefix),
+                    server_config=server,
+                )
 
         return tools
 
@@ -309,14 +325,10 @@ class ToolInjector:
         """
         headers = _mcp_headers(entry.server_config, user_token=user_token, client_headers=client_headers)
 
-        async with streamablehttp_client(
-            entry.server_config.url, headers=headers,
-        ) as (read_stream, write_stream, _):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                result = await session.call_tool(entry.original_name, arguments)
-                texts = []
-                for content in result.content:
-                    if hasattr(content, "text"):
-                        texts.append(content.text)
-                return "\n".join(texts) if texts else str(result.content)
+        async with _mcp_session(entry.server_config.url, headers) as session:
+            result = await session.call_tool(entry.original_name, arguments)
+            texts = []
+            for content in result.content:
+                if hasattr(content, "text"):
+                    texts.append(content.text)
+            return "\n".join(texts) if texts else str(result.content)

--- a/shared/telemetry.py
+++ b/shared/telemetry.py
@@ -153,6 +153,17 @@ def setup_auto_instrumentation(app: Any = None) -> None:
     except ImportError:
         log.debug("opentelemetry-instrumentation-httpx not installed")
 
+    # The MCP SDK (2.x) speaks httpx2, which the httpx instrumentor above does
+    # not cover. Without this the pb-proxy → mcp-server hop loses its parent
+    # span and tool calls surface as orphan traces in Tempo. Only mcp-server and
+    # pb-proxy pull httpx2 in (via mcp), so absence here is normal, not an error.
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPX2ClientInstrumentor
+        HTTPX2ClientInstrumentor().instrument()
+        log.info("httpx2 auto-instrumentation enabled (traceparent propagation)")
+    except Exception as e:
+        log.debug("httpx2 auto-instrumentation unavailable: %s", e)
+
     if app is not None:
         try:
             from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor


### PR DESCRIPTION
Ports both services to `mcp` 2.0.0 and removes the reason they were held back.

Supersedes #245 and #246 — those propose the same bump without the code changes it requires, which would build green and crashloop at runtime.

## What broke, and what didn't

The two services needed very different amounts of work, and not in the direction the pinning comments suggested.

**`mcp-server` was the smaller half.** Only the two decorators are gone; verified against a real 2.0.0 install that the rest of the surface is unchanged:

| Surface | 2.0 |
|---|---|
| `Tool(inputSchema=...)` (28 sites) | works — alias + `populate_by_name` |
| `TextContent(type="text", ...)` (~120 sites) | works |
| `StreamableHTTPSessionManager(app=, json_response=, stateless=)` | identical |
| `create_auth_routes(...)`, all 10 auth imports, `ClientSession` | present |
| `@server.list_tools()` / `@server.call_tool()` | **removed** |

So the change is: handlers become plain functions taking `(ctx, params)` and returning `ListToolsResult` / `CallToolResult`, bound via `on_list_tools` / `on_call_tool`, with the `Server` constructed below them.

**`pb-proxy` was the larger half.** `streamable_http_client` already exists in 1.x, but it is *not* an alias of `streamablehttp_client` — it is a different function with the 2.0 shape:

- `headers=` is gone. That is the entire auth path here (bearer, identity propagation, `forward_headers`); it moves onto a caller-supplied client.
- It yields two streams, not three.
- That client **must** be `httpx2`. Passing `httpx` is accepted and then silently stops delivering server-initiated messages — no exception. Both call sites now share one `_mcp_session()` helper so the constraint lives in one place.
- `tool.inputSchema` → `tool.input_schema` (attribute access; the kwarg alias does not help).

## httpx2

`mcp` 2.0 depends on `httpx2`, a separate distribution from `httpx`. Two consequences handled here:

- **Tracing.** `opentelemetry-instrumentation-httpx` does not instrument httpx2, so the proxy → mcp-server hop would have lost its parent span and tool calls would have shown up as orphan traces in Tempo. `shared/telemetry.py` now registers `HTTPX2ClientInstrumentor` as well; confirmed active in the pb-proxy startup log.
- **Certificate trust.** httpx2 defaults to the OS trust store instead of certifi's bundle. A private CA installed only at OS level would be honoured by MCP connections and rejected by everything else — which presents as "the proxy works but ingestion doesn't". Both clients honour `SSL_CERT_FILE`, so that is the documented lever; new "Outbound TLS (Certificate Trust)" section in `docs/deployment.md`.

## CI

Two gaps let this reach a local `docker compose build` instead of failing in CI:

- `docker-build` ran `pip install` and never imported the app, so a broken image built green. Both images now smoke-import their `CMD` module. This immediately caught the fail-closed `INGESTION_AUTH_TOKEN` guard, hence `SKIP_INGESTION_AUTH_STARTUP_CHECK` on that step, matching the test conftests.
- Requirements resolve fresh on every run, so a breaking major shipped between PRs stayed invisible until the next PR. A weekly `schedule:` closes that.

## Verification

- **710 passed, 20 skipped** against mcp 2.0.0 (`mcp-server/tests`, `pb-proxy/tests`, `shared/tests`)
- Both images build and import their `CMD` module
- `httpx2 auto-instrumentation enabled (traceparent propagation)` confirmed in the pb-proxy log

Two test breakages the build could not see were caught by the suite and fixed: `test_manage_policies.py` invoked the handler directly with the old signature (now via a `_call` helper that preserves the token-to-role coverage), and a fake tool in `test_tool_injection.py` carried `inputSchema`.

## Not included

`is_error` on `CallToolResult` stays at its default `False`. `_dispatch` already reports failures as an `{"error": ...}` payload in the content, which is what clients parse today; changing error semantics is a separate decision, not part of an API port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
