### PR TITLE
fix(docker-compose): use urllib healthchecks for reranker and pb-proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,7 +246,7 @@ services:
       - pb-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8082/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8082/health')"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -628,7 +628,7 @@ services:
       - pb-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Problem

The `reranker` and `pb-proxy` healthchecks invoked `curl`, which is not present in either image. Both are `FROM python:3.12-slim` (`reranker/Dockerfile`, `pb-proxy/Dockerfile`) and neither installs curl — Debian slim ships none. Every probe failed:

```
exec: "curl": executable file not found in $PATH
```

Both containers therefore stayed **perpetually unhealthy**, and anything using `depends_on: condition: service_healthy` against them would hang.

## Fix

Use the urllib pattern already established in the same file by `mcp-server` (:8080) and `ingestion` (:8081), rather than installing curl — this keeps the images small.

```diff
-      test: ["CMD", "curl", "-f", "http://localhost:8082/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8082/health')"]
```

Semantics are unchanged: `urlopen()` raises `HTTPError` on any non-2xx, so it fails exactly where `curl -f` did. Interval/timeout/retries are left untouched.

Checked that neither endpoint can return non-200 in normal operation:
- reranker `/health` returns 200 with `{"status":"loading"}` while the model loads
- pb-proxy `/health` returns 200 with `{"status":"degraded"}` when no tools are loaded, and its auth middleware whitelists `/health` (`pb-proxy/middleware.py`) despite `AUTH_REQUIRED=true`

## Verification

Started both services and confirmed with `docker inspect --format '{{.State.Health.Status}}'`:

| Container | Status |
|---|---|
| `pb-reranker` (`--profile local-reranker`) | `healthy` |
| `pb-proxy` (`--profile proxy`) | `healthy` (`Restarts=0`, probe exit 0) |

The old `curl` command was also run as a control in the same images and confirmed to fail with `executable file not found in $PATH`, so the bug was real rather than theoretical.

## Notes

- `docker-compose.ghcr.yml` is a pure `image:` override with `build: !reset null`, so it inherits these healthchecks. The prebuilt GHCR images come from the same two Dockerfiles and were broken identically — this fix covers that path too.
- The `ollama` / `vllm` healthchecks also use curl but are third-party images that do ship it, so they are left alone.
- `docs/plans/2026-03-21-*.md` still contains the old curl healthcheck in two places; those are dated design records rather than live config, so they were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)