### PR TITLE
release: v0.12.0

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -8,7 +8,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Run unit tests
         run: |
@@ -41,7 +41,7 @@ jobs:
   opa-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Download OPA
         run: |
@@ -56,7 +56,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Build mcp-server image
         run: docker build -f mcp-server/Dockerfile -t pb-mcp-server:pr-test .
@@ -76,7 +76,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -3,6 +3,13 @@ name: PR Validate
 on:
   pull_request:
     branches: [development, master]
+  # Requirements are resolved fresh on every run, so a dependency that ships a
+  # breaking major between PRs only surfaces the next time CI runs. Without a
+  # cadence that can be weeks, and the first symptom is a crashlooping image on
+  # someone's machine. Weekly run against the default branch closes that gap.
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
 
 jobs:
   unit-tests:
@@ -61,6 +68,17 @@ jobs:
       - name: Build mcp-server image
         run: docker build -f mcp-server/Dockerfile -t pb-mcp-server:pr-test .
 
+      # `docker build` only runs pip install — it never imports the app. An
+      # incompatible dependency bump therefore builds green and crashloops at
+      # runtime. Importing the CMD module is the cheapest check that the image
+      # can actually start. SKIP_INGESTION_AUTH_STARTUP_CHECK mirrors the test
+      # conftests: it bypasses the fail-closed auth guard, which has no token to
+      # find here and is not what this step is testing.
+      - name: Smoke-import mcp-server
+        run: |
+          docker run --rm -e SKIP_INGESTION_AUTH_STARTUP_CHECK=true \
+            pb-mcp-server:pr-test python -c "import server"
+
       - name: Build ingestion image
         run: docker build -f ingestion/Dockerfile -t pb-ingestion:pr-test .
 
@@ -69,6 +87,11 @@ jobs:
 
       - name: Build pb-proxy image
         run: docker build -f pb-proxy/Dockerfile -t pb-proxy:pr-test .
+
+      - name: Smoke-import pb-proxy
+        run: |
+          docker run --rm -e SKIP_INGESTION_AUTH_STARTUP_CHECK=true \
+            pb-proxy:pr-test python -c "import proxy"
 
       - name: Build worker image
         run: docker build -f worker/Dockerfile -t pb-worker:pr-test .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             dockerfile: worker/Dockerfile
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -58,7 +58,7 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Extract version from tag
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-17
+
 ### Security
 
 - **Exact dependency pins** — every `requirements*.txt` now pins exact versions
@@ -107,6 +109,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line, and the full traceback is emitted separately at debug level via
   `exc_info`. Applies to both the required (`log.error`) and optional
   (`log.warning`) branches.
+- **Healthchecks for `reranker` and `pb-proxy` could never pass** — both invoked
+  `curl`, which neither image contains: `reranker/Dockerfile` and
+  `pb-proxy/Dockerfile` build `FROM python:3.12-slim` and never install it, so
+  every probe exited with `exec: "curl": executable file not found in $PATH` and
+  both containers stayed perpetually unhealthy. Anything gating on
+  `depends_on: condition: service_healthy` against them would wait forever.
+  Both now use the `python3 -c "import urllib.request; …"` pattern already used
+  by `mcp-server` and `ingestion` instead of installing curl, so the images stay
+  small. Semantics are unchanged — `urlopen()` raises on any non-2xx exactly
+  where `curl -f` failed, and both endpoints answer 200 even while degraded
+  (`{"status":"loading"}` on the reranker, `{"status":"degraded"}` on the proxy,
+  whose auth middleware whitelists `/health`). Interval, timeout and retries are
+  untouched. `docker-compose.ghcr.yml` only overrides `image:`, so the prebuilt
+  GHCR images — broken identically, since they come from the same Dockerfiles —
+  are covered by the same change. The `ollama` and `vllm` healthchecks keep
+  using curl; those are third-party images that ship it.
 
 ## [0.11.1] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `reranker/requirements.txt` entirely. It now installs from that file, still
   via the PyTorch CPU index.
 
+### Changed
+
+- **Ported to MCP Python SDK 2.0** — `mcp` moves from `1.29.0` to `2.0.0` and
+  both services move with it. `mcp-server/server.py` binds its handlers through
+  the `on_list_tools` / `on_call_tool` constructor params instead of the removed
+  `@server.list_tools()` / `@server.call_tool()` decorators; the handlers now
+  take `(ctx, params)` and return `ListToolsResult` / `CallToolResult`. The tool
+  definitions and `TextContent(...)` blocks are untouched — 2.x keeps the
+  `inputSchema` field alias and populates by name, so only the two handler
+  signatures actually changed. In `pb-proxy/tool_injection.py` the replacement
+  `streamable_http_client` drops `headers=` in favour of a caller-supplied HTTP
+  client and yields two streams instead of three; both call sites now share one
+  `_mcp_session()` helper.
+- **httpx2 alongside httpx** — the MCP SDK's HTTP stack from 2.0 on is `httpx2`,
+  a separate distribution rather than a new httpx release. `pb-proxy` imports it
+  directly to attach auth headers. Passing a plain `httpx` client where the SDK
+  expects `httpx2` is *accepted* and then silently stops delivering
+  server-initiated messages, so client construction is centralised in
+  `_mcp_session()` with that caveat recorded at the call site.
+  `shared/telemetry.py` additionally registers `HTTPX2ClientInstrumentor`:
+  without it the pb-proxy → mcp-server hop loses its parent span and tool calls
+  surface as orphan traces in Tempo. Note for deployers: httpx2 defaults to the
+  OS trust store instead of certifi's bundle, so a private CA installed only at
+  OS level is honoured by MCP connections and rejected by everything else — both
+  clients accept `SSL_CERT_FILE`, which is now the documented lever. See
+  "Outbound TLS (Certificate Trust)" in `docs/deployment.md`.
+
 ### Fixed
 
 - **CI red since late July** — `mcp[server]>=1.27.1` resolved to `mcp 2.0.0`,
@@ -37,9 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mcp-server/server.py` and `streamablehttp_client` used in
   `pb-proxy/tool_injection.py`. Test collection failed on both; the cascading
   `DuplicateTimeseries` errors were a symptom of the half-executed imports, not
-  an independent fault. `mcp` is now held at `1.29.0`, the last 1.x release, and
-  the suite passes again (1115 passed, 20 skipped, 70.45% coverage). Porting to
-  the 2.x API remains a separate task.
+  an independent fault. `mcp` was first held at `1.29.0`, the last 1.x release,
+  to make the suite pass again (1115 passed, 20 skipped, 70.45% coverage). The
+  port to the 2.x API has since landed — see "Ported to MCP Python SDK 2.0"
+  under Changed above.
 - **Reranker tracing was silently disabled** — the image never installed the
   OpenTelemetry packages its `requirements.txt` declares, so
   `shared/telemetry.py` degraded to disabled even though `docker-compose.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead `[server]` extra** — `mcp[server]` requested an extra that no `mcp`
   release provides (pip: "does not provide the extra 'server'"), so it had
   always installed nothing. Dropped.
+- **MCP discovery failures logged without their cause** — a server that failed
+  tool discovery was logged as `Optional server '…' unreachable: unhandled
+  errors in a TaskGroup (1 sub-exception)`. The MCP streamable-http client runs
+  its read/write pumps in an anyio task group, so the real failure arrives
+  wrapped in an `ExceptionGroup` whose own `str()` carries no HTTP status, auth
+  rejection or connection error — and the line repeats once per refresh
+  interval with no way to tell why, so the cause could only be found by
+  re-running discovery by hand. Discovery failures are now flattened
+  (`_describe_exception`) to their leaf exceptions, recursively since groups
+  nest, and logged as `Type: message` — e.g. `HTTPStatusError: Client error
+  '401 Unauthorized' for url '…'` or `ConnectError: All connection attempts
+  failed`. Multi-line leaf messages are collapsed so one failure stays one log
+  line, and the full traceback is emitted separately at debug level via
+  `exc_info`. Applies to both the required (`log.error`) and optional
+  (`log.warning`) branches.
 
 ## [0.11.1] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dead `[server]` extra** — `mcp[server]` requested an extra that no `mcp`
   release provides (pip: "does not provide the extra 'server'"), so it had
   always installed nothing. Dropped.
+- **Doubled tool names for self-namespacing MCP servers** — pb-proxy applied a
+  server's configured `prefix` unconditionally, so a server that already
+  namespaces its own tools got the prefix twice. A timecockpit-mcp entry
+  configured with `prefix: tc` injected `tc_tc_list_timesheets`,
+  `tc_tc_create_timesheet`, … because that server publishes its tools as `tc_…`
+  already — names that no skill or prompt written against the MCP server
+  matches. Prefixing is now idempotent (`_prefixed_tool_name`): a name that
+  already starts with `<prefix>_` is left alone, everything else is still
+  prefixed, so names stay unique across servers. Dropping the prefix from the
+  config would not have fixed it — `McpServerConfig` defaults `prefix` to the
+  server name, which yields `timecockpit_tc_list_timesheets` — and an empty
+  prefix would leave that server's non-`tc_` tools unnamespaced. No behaviour
+  change for the powerbrain server, whose tools are not named `powerbrain_*`.
+  PII routing is unaffected: `ToolEntry.needs_pii_scan` matches
+  `pii_scanned_tools` against the unprefixed `original_name`.
 
 ## [0.11.1] - 2026-05-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -530,7 +530,7 @@ docker run --rm -v "$(pwd):/app" -w /app python:3.12-slim bash -c "
 ### Structured Telemetry
 All 4 services (mcp-server, proxy, reranker, ingestion) share a common telemetry module (`shared/telemetry.py`):
 
-- **OTel Tracing** — `init_telemetry(service_name)` creates TracerProvider + OTLP exporter to Tempo. Auto-instrumentation for FastAPI and httpx (W3C `traceparent` propagation). Configurable via `OTEL_ENABLED` (default `true`), `OTLP_ENDPOINT` (default `http://tempo:4317`).
+- **OTel Tracing** — `init_telemetry(service_name)` creates TracerProvider + OTLP exporter to Tempo. Auto-instrumentation for FastAPI, httpx and httpx2 (W3C `traceparent` propagation). Both HTTP clients are instrumented because the MCP SDK speaks httpx2 from 2.0 on while the services' own calls use httpx — instrumenting only one leaves the proxy → mcp-server hop as an orphan trace. Configurable via `OTEL_ENABLED` (default `true`), `OTLP_ENDPOINT` (default `http://tempo:4317`).
 - **Per-Request Telemetry** — `RequestTelemetry` + `PipelineStep` dataclasses accumulate timing breakdown per request. `trace_operation()` context manager creates OTel span and records step simultaneously. Responses include `_telemetry` block when `TELEMETRY_IN_RESPONSE=true` (default).
 - **JSON Metrics Endpoint** — Each service exposes `GET /metrics/json` returning structured metrics from Prometheus registry via `MetricsAggregator`. Designed for demo-UI consumption without PromQL knowledge.
 - **Graceful degradation** — If OTel packages not installed or exporter unreachable, tracing silently disables. Prometheus metrics always available.
@@ -555,7 +555,7 @@ All 4 services (mcp-server, proxy, reranker, ingestion) share a common telemetry
 16. ✅ **Proxy Authentication** — ASGI middleware (`pb-proxy/middleware.py`) for global `pb_` API-key auth, identity propagation to MCP servers
 17. ✅ **Multi-MCP-Server Aggregation** — Proxy aggregates tools from N MCP servers with per-server auth, prefix namespacing, and OPA-controlled access (`pb.proxy.mcp_servers_allowed`)
 18. ✅ **T1 Production Hardening** — Embedding cache (in-process LRU), batch embedding API, OPA result cache, configurable PG pool sizes, Docker health checks for all services
-19. ✅ **Structured Telemetry** — Shared OTel module (`shared/telemetry.py`), per-request `_telemetry` in search/chat responses, `/metrics/json` endpoints on all 4 services (mcp-server, proxy, reranker, ingestion), W3C traceparent propagation via auto-instrumented httpx
+19. ✅ **Structured Telemetry** — Shared OTel module (`shared/telemetry.py`), per-request `_telemetry` in search/chat responses, `/metrics/json` endpoints on all 4 services (mcp-server, proxy, reranker, ingestion), W3C traceparent propagation via auto-instrumented httpx + httpx2
 20. ✅ **Per-Provider Key Management** — Flexible LLM API key resolution (central/user/hybrid modes) via `provider_keys` in `litellm_config.yaml`, `X-Provider-Key` header support
 21. ✅ **PII Scan Observability & Strict Defaults** — `PII_SCAN_FORCED` defaults to `true` (fail-closed). Telemetry step `pii_pseudonymize` includes `mode`, `entities_found`, `entity_types`, `fail_mode`. OPA policy `pb.proxy.pii_scan_forced` defaults to `true`, admin can override via `pii_scan_forced_override: false`
 22. ✅ **Reranker Provider Abstraction** — Configurable reranker backend via `RERANKER_BACKEND` env var (`powerbrain`/`tei`/`cohere`). Strategy pattern in `shared/rerank_provider.py`, transparent format translation, graceful fallback preserved

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -246,7 +246,7 @@ services:
       - pb-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8082/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8082/health')"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -628,7 +628,7 @@ services:
       - pb-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,6 +132,46 @@ pb.example.com {
 }
 ```
 
+## Outbound TLS (Certificate Trust)
+
+The sections above cover *inbound* TLS — the certificates Powerbrain serves. This
+one covers *outbound*: which certificates Powerbrain accepts when it calls other
+systems (MCP servers, LLM providers, your Git server, Microsoft Graph).
+
+Two HTTP clients are in play, and they differ in **which CAs they trust by
+default**:
+
+| Client | Used for | Default trust store |
+|---|---|---|
+| `httpx` | Services' own calls (ingestion, embeddings, OPA, reranker, LLM providers) | certifi's bundled CA list |
+| `httpx2` | The MCP SDK's transport (pb-proxy → MCP servers), from `mcp` 2.0 on | The operating system trust store, via `truststore` |
+
+For deployments that only talk to endpoints with publicly-trusted certificates,
+this never surfaces. It matters when an endpoint presents a certificate signed by
+a **private or internal CA** — a self-hosted Forgejo or GitLab, an internal MCP
+server, a corporate TLS-inspecting proxy. Installing that CA only in the
+container's OS trust store is not enough: MCP connections would accept it while
+every other call still rejects it, which looks like "the proxy works but
+ingestion doesn't".
+
+**Set `SSL_CERT_FILE` to your CA bundle.** Both clients honour it, so one setting
+covers every outbound call:
+
+```yaml
+# docker-compose.override.yml
+services:
+  mcp-server:
+    environment:
+      SSL_CERT_FILE: /etc/ssl/private-ca/bundle.pem
+    volumes:
+      - ./private-ca:/etc/ssl/private-ca:ro
+```
+
+The bundle must contain the full chain **plus** the public roots you still need
+(`cat /etc/ssl/certs/ca-certificates.crt your-ca.pem > bundle.pem`) — pointing
+`SSL_CERT_FILE` at a file holding only your private CA makes every
+publicly-trusted endpoint fail verification.
+
 ## Docker Secrets Setup
 
 Powerbrain supports Docker Secrets for sensitive configuration values. This is the recommended approach for production deployments.

--- a/docs/plans/2026-05-20-claude-chat-audit-mirror.md
+++ b/docs/plans/2026-05-20-claude-chat-audit-mirror.md
@@ -1,9 +1,10 @@
 # Claude Chat Audit-Mirror — Konzept
 
-**Date:** 2026-05-20
+**Date:** 2026-05-20 (refresh 2026-05-22 für Drei-Tab-Struktur)
 **Status:** Draft (Konzept zur Diskussion)
-**Scope:** Detektivische PII-Audits über Claude-Pro/Max-Konversationen, die am
-`pb-proxy` vorbeilaufen.
+**Scope:** Detektivische PII-Audits über Claude-Pro/Max-Konversationen (alle drei
+Tabs: Chat, Cowork, Code), die am `pb-proxy` vorbeilaufen.
+**Companion-Spec:** [Claude Desktop Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md) — dieser Plan ist Komponente **B (Audit Mirror)** in der dort formulierten Vier-Komponenten-Verteidigung.
 
 ---
 
@@ -12,43 +13,72 @@
 Claude Pro/Max (Abo) authentifiziert sich per OAuth gegen `claude.ai`.
 `ANTHROPIC_BASE_URL` ist effektiv hartkodiert — Traffic kann **nicht** durch
 `pb-proxy` umgeleitet werden (siehe [editions.md](../editions.md) +
-[compliance-claude-desktop.md](../compliance-claude-desktop.md)). Folge: der
-Chat-Kanal ist im Abo-Modus für Powerbrain unsichtbar. Eine echte Realtime-
-Prävention von PII-Leaks ist über den Proxy nicht erreichbar.
+[compliance-claude-desktop.md](../compliance-claude-desktop.md)). Folge: alle
+drei Claude-Desktop-Tabs (**Chat**, **Cowork**, **Code**) leiten Inhalte am
+Powerbrain-Proxy vorbei direkt zu Anthropic.
 
-Wirtschaftlich auf API-Tier zu wechseln ist für Solo-/Kleinteam-Setups oft
-nicht attraktiv (Pro-Abo deckt 95 % der Coding-Sessions ab). Der Pragmatismus
-heißt: **detektivisch statt präventiv**. Wir akzeptieren, dass Chat-Inhalte
-ungescannt zu Anthropic gehen, schaffen aber einen Audit-Pfad, der retroaktiv
-zeigt, *welche* personenbezogenen Daten in welcher Konversation gelandet sind.
+Anthropics 2026er Policy-Bewegungen verstärken die Notwendigkeit eines
+detektivischen Pfads zusätzlich:
+
+- **2026-02 Authentication and Credential Use Policy** — OAuth-Credentials sind
+  "intended exclusively for Claude Code and claude.ai". Drittclients mit
+  Pro/Max-Token sind explizit policy-widrig. Damit fällt jeder Wrapper-/
+  Proxy-Ansatz für Pro/Max aus.
+- **2026-04-04 Third-Party-Harness-Enforcement** — technische Sperre für
+  programmatische Pro/Max-Nutzung. Verhindert pragmatische Workarounds.
+
+Eine echte Realtime-Prävention von PII-Leaks ist im Abo-Modus mit
+Powerbrain-Mitteln **nicht erreichbar**. Wirtschaftlich auf API-Tier zu
+wechseln ist für Solo-/Kleinteam-Setups oft nicht attraktiv (Pro-Abo deckt
+95% der Coding-Sessions ab), und für Heavy-Coding-Agent-Use auf Org-Ebene
+ist API-Pricing prohibitiv (5–20× der Abo-Kosten).
+
+Der Pragmatismus heißt: **detektivisch statt präventiv**. Wir akzeptieren,
+dass Inhalte aus allen drei Tabs ungescannt zu Anthropic gehen, schaffen
+aber einen Audit-Pfad, der retroaktiv zeigt, *welche* personenbezogenen
+Daten in welcher Konversation gelandet sind — und in welcher Tab-Kategorie.
 
 ## 2. Ziel
 
-Drei messbare Ergebnisse:
+Drei messbare Ergebnisse, jeweils tab-übergreifend (Chat/Cowork/Code):
 
 1. **Vollständigkeit** — jede Conversation einer kontrollierten Anthropic-
-   Identität wird mindestens einmal gegen `pb-ingestion /scan` geprüft.
-2. **Auditierbarkeit** — Treffer (PII-Entitäten + Score + Quelle) landen
+   Identität wird mindestens einmal gegen `pb-ingestion /scan` geprüft. Code-Tab-
+   Konversationen umfassen zusätzlich File-Edit-Diffs und Terminal-Command-
+   Logs aus der Session-History.
+2. **Auditierbarkeit** — Treffer (PII-Entitäten + Score + Tab + Quelle) landen
    tamper-evident im Powerbrain Audit-Log (Art. 12, `audit_log_entries`).
 3. **Reaktion** — bei Treffern existiert ein definierter Workflow: Conversation
    in claude.ai löschen + Anthropic-Löschanforderung (Art. 17) + interne
    Incident-Notiz (`privacy_incidents`).
 
 Explizit **kein** Ziel: Live-Tampering von Outgoing-Messages. Das geht im
-Abo-Modus technisch nicht ohne TLS-MITM (siehe Abschnitt 4D).
+Abo-Modus technisch nicht ohne TLS-MITM (siehe Abschnitt 4D) und ist nach
+2026-04 Anthropic-Enforcement auch policy-widrig.
 
-## 3. Begriffsklärung — "Mirror"
+## 3. Begriffsklärung — "Mirror" und Abgrenzung zu Pre-flight
 
 Drei Interpretationen, die im Gespräch durcheinandergehen:
 
 | Begriff | Was es heißt | Wird hier behandelt? |
 |---|---|---|
-| **Mirror** (Audit) | Conversations werden kopiert + nachträglich gescannt | ✅ Ja |
-| **Inline-Scrubbing** | Outgoing-Text wird *vor* Anthropic mutiert | ❌ Nein (nur via Proxy oder Browser-Extension möglich) |
-| **Realtime-Warning** | UI zeigt PII-Warnung *vor* dem Submit | Teilweise — Abschnitt 4B |
+| **Mirror** (Audit) | Conversations werden kopiert + nachträglich gescannt | ✅ Ja, das ist der Kern dieses Plans |
+| **Inline-Scrubbing** | Outgoing-Text wird *vor* Anthropic mutiert | ❌ Nein (für Claude Desktop nicht möglich; für claude.ai-Web theoretisch via Extension/Pre-flight, siehe unten) |
+| **Realtime-Warning** | UI zeigt PII-Warnung *vor* dem Submit | Teilweise — Abschnitt 4B für claude.ai-Web; via separatem Tool [Pre-flight](../specs/2026-05-22-claude-desktop-coverage-strategy.md#d-pre-flight-new-component--this-specs-only-new-build) für Desktop-Workflows |
 
-Dieser Plan adressiert primär den Audit-Pfad. Browser-Extension wird als
-nahezu kostenlose Erweiterung mitgeführt.
+Dieser Plan adressiert primär den Audit-Pfad (Komponente B in der Coverage
+Strategy). Browser-Extension (4B) und Pre-flight (separater Spec) sind die
+präventiven Pendants:
+
+- **Browser-Extension** — claude.ai-Web spezifisch, intercepted Composer-DOM,
+  zeigt Warnung vor Submit. Funktioniert nur im Browser-Tab, nicht in Claude
+  Desktop.
+- **Pre-flight (separater Spec)** — Tauri-App, hilft dem User PII zu pseudonymi-
+  sieren *bevor* er in Claude Desktop pastet. Klipboard-basiert, ToS-clean, weil
+  sie Claude Desktop nicht anfasst.
+
+Die Komponenten sind komplementär: Audit-Mirror fängt detektivisch auf, was
+Pre-flight präventiv verpasst.
 
 ## 4. Optionsraum
 
@@ -84,6 +114,9 @@ Endpoint, aber undokumentiert und sessionbasiert).
 - Heute machbar, keine Anthropic-seitige Mitwirkung nötig.
 - Funktioniert für Web + Desktop + Mobile (alle Clients schreiben in dieselbe
   serverseitige Conversation-Liste).
+- **Tab-übergreifend:** Export liefert Chat-, Cowork- und Code-Tab-Sessions im
+  selben Dump (jeweils mit `tab`-Metadatum), inklusive Code-Tab-spezifischer
+  Artefakte (File-Edit-Diffs, Terminal-Commands, Computer-Use-Events).
 - Vollständig seit Account-Start.
 
 **Nachteile:**
@@ -97,6 +130,10 @@ Endpoint, aber undokumentiert und sessionbasiert).
 **Aufwand:** ~1 Tag (Skript + Cron + Audit-Insert + Report-Mail).
 
 ### B) Browser-Extension für claude.ai
+
+*Scope-Hinweis: deckt **nur** claude.ai-Web ab (Chat-Tab im Browser). Für
+Claude Desktop nicht anwendbar — siehe Pre-flight-Spec in der Coverage
+Strategy für Desktop-Workflows.*
 
 Chrome/Firefox-Extension, die das Composer-`<div contenteditable>` von claude.ai
 beobachtet. Bei jedem Submit:
@@ -125,13 +162,22 @@ UI, Packaging).
 
 Claude Desktop (Electron) cached Conversations lokal:
 `%APPDATA%\Claude\` (Windows), `~/Library/Application Support/Claude/` (macOS).
-LevelDB/IndexedDB-Format. Ein Watcher könnte periodisch auslesen.
+LevelDB/IndexedDB-Format. Ein Watcher könnte periodisch auslesen — pro Tab
+liegen die Session-Daten in unterschiedlichen Sub-Stores (Chat / Cowork / Code).
 
-**Verworfen — Begründung:**
-- Undokumentiertes Storage-Format.
+**Verworfen für die primäre Pipeline — Begründung:**
+- Undokumentiertes Storage-Format, pro Tab unterschiedliches Schema.
 - Verschlüsselung-at-rest in neueren Versionen.
 - Schema kann sich mit jedem Desktop-Update ändern → permanenter Wartungsbedarf.
 - Liefert dieselben Daten wie Variante A (Server-Authority), nur fragiler.
+- Code-Tab speichert Datei-Inhalte teilweise als Referenz auf den User-Filesystem-
+  Pfad statt embedded — Inspektion müsste dem Pfad folgen und Datei-Inhalt
+  nachladen.
+
+**Bleibt als Fallback dokumentiert** für Cases, in denen Anthropic-Export-Endpoint
+unverfügbar oder gedrosselt ist (Stand 2026-05-22 unproblematisch, aber API-Wandel
+ist eine reale Sorge). In dem Fall braucht es einen Per-Tab-Schema-Adapter ähnlich
+dem in der Coverage Strategy (Open Question §2) skizzierten DOM-Adapter-Modell.
 
 ### D) Lokaler MITM-Proxy
 
@@ -139,44 +185,55 @@ mitmproxy + selbstsigniertes CA-Cert im OS-Trust-Store. Fängt
 `api.anthropic.com`-Traffic ab, leitet 1:1 weiter, kopiert Bodies in eine
 Audit-Queue.
 
-**Verworfen für jetzt — Begründung:**
+**Verworfen — Begründung:**
 - Eingriff ins OS-Trust-Modell (Risikoexposition für *alle* HTTPS-Apps).
 - Cert-Pinning in Claude Desktop wahrscheinlich → Connect-Fail.
 - OAuth-Tokens an Hostname + Cert gebunden → hohes Brick-Risiko.
 - Aufwand für sauberen Betrieb (CA-Rotation, Cert-Refresh, Auto-Start) erheblich.
+- **2026-02 Anthropic Authentication Policy:** OAuth-Credentials sind
+  ausschließlich für Anthropic-eigene Clients freigegeben. Ein MITM-Proxy ist
+  per Definition kein Anthropic-Client und damit policy-widrig — selbst wenn
+  technisch betriebsfähig.
 
-Wird als Fallback für Anthropic-Enterprise-Cases dokumentiert, falls A nicht
-vollständig genug ist.
+Damit ist D nicht mehr als "Enterprise-Fallback" haltbar; für Enterprise-Cases
+verweist die [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md)
+auf Endpoint-DLP (Komponente C) + API-Key-Mode-Workloads als getrennten Pfad.
 
 ## 5. Empfohlene Architektur
 
-**Stack: A (Pflicht) + B (Quick-Win)**
+**Stack: A (Pflicht, alle Tabs) + B (Quick-Win, claude.ai-Web nur)**
+**Komplementär: Pre-flight aus der [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md) für präventive Desktop-Workflows.**
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│  Claude-Konsum (Abo)                                          │
-│  ┌─────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│  │ claude.ai   │  │ Claude       │  │ Claude       │         │
-│  │ (Browser)   │  │ Desktop      │  │ Mobile       │         │
-│  └──────┬──────┘  └──────┬───────┘  └──────┬───────┘         │
-│         │                │                  │                │
-│         ▼ (B: live)      │                  │                │
-│  ┌─────────────┐         │                  │                │
-│  │ pb-guardian │         │                  │                │
-│  │ Extension   │         │                  │                │
-│  └──────┬──────┘         │                  │                │
-└─────────┼────────────────┼──────────────────┼────────────────┘
-          │                │                  │
-          │                ▼ (alles)          │
-          │         ┌─────────────────────────┴─┐
-          │         │  Anthropic Cloud           │
-          │         │  (Conversations gespeichert)│
-          │         └─────────────┬──────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│  Claude-Konsum (Pro/Max-Abo)                                          │
+│                                                                       │
+│  ┌─────────────┐    ┌────────────────────────────────────────────┐   │
+│  │ claude.ai   │    │ Claude Desktop                              │   │
+│  │ (Browser)   │    │ ┌──────┐ ┌────────┐ ┌────────────────────┐ │   │
+│  │             │    │ │ Chat │ │ Cowork │ │ Code               │ │   │
+│  └──────┬──────┘    │ │      │ │        │ │ (file edits,       │ │   │
+│         │           │ │      │ │        │ │  terminal, CU)     │ │   │
+│         │           │ └──────┘ └────────┘ └────────────────────┘ │   │
+│         │           └─────────────────┬───────────────────────────┘   │
+│         ▼ (B: live)                   │                               │
+│  ┌─────────────┐                      │                               │
+│  │ pb-guardian │                      │                               │
+│  │ Extension   │                      │                               │
+│  └──────┬──────┘                      │                               │
+└─────────┼─────────────────────────────┼───────────────────────────────┘
+          │                             │
+          │                ▼ (alles, alle Tabs)
+          │         ┌─────────────────────────────┐
+          │         │  Anthropic Cloud             │
+          │         │  Conversations + Code-Sessions│
+          │         │  (Server-side storage)        │
+          │         └─────────────┬────────────────┘
           │                       │
           │           ┌───────────┴──────────┐
-          │           │  A: Wöchentlicher    │
+          │           │  A: Periodischer     │
           │           │  Export-Worker       │
-          │           │  (cron, int-baumeister)│
+          │           │  (cron, pb-worker)   │
           │           └───────────┬──────────┘
           │                       │
           └───────────┬───────────┘
@@ -184,18 +241,23 @@ vollständig genug ist.
             ┌──────────────────┐
             │ pb-ingestion     │
             │  POST /scan      │
+            │  (text + diffs +  │
+            │   commands)       │
             └────────┬─────────┘
                      │
                      ▼
-            ┌──────────────────┐
-            │ pb-mcp-server    │
-            │  audit_log_entries│
-            │  privacy_incidents│
-            └──────────────────┘
+            ┌──────────────────────┐
+            │ pb-mcp-server        │
+            │  audit_log_entries   │  ← findings tagged {tab, source}
+            │  privacy_incidents   │
+            │  chat_audit_findings │
+            └──────────────────────┘
 ```
 
-A liefert **Vollständigkeit** über alle Clients. B liefert **Realtime-
-Prävention** für den häufigsten Einzelfall (claude.ai Web).
+A liefert **Vollständigkeit** über alle Clients und alle Tabs (Chat/Cowork/Code).
+B liefert **Realtime-Prävention** für den häufigsten Einzelfall (claude.ai Web).
+Pre-flight (separater Spec) ergänzt B für Desktop-Workflows ohne in Claude
+Desktop einzugreifen.
 
 ## 6. Komponenten
 
@@ -221,17 +283,31 @@ CHAT_AUDIT_REPORT_WEBHOOK: str   # optional, Slack/Teams
 1. **Fetch** — Headless-Browser (Playwright) loggt sich via Cookie ein,
    triggert Export, wartet auf Download. Fallback: REST-Polling der internen
    `claude.ai/api/organizations/{org}/chat_conversations` (Pro-Account).
+   Export umfasst alle drei Tabs; pro Conversation ist das Feld `tab` (oder
+   ein äquivalenter Discriminator) auszuwerten.
 2. **Diff** — Zustand des letzten Runs (gespeichert in
    `chat_audit_state.last_conversation_ts`) bestimmt, welche Conversations neu
    oder geändert sind.
-3. **Scan** — Für jede neue/geänderte Message: `POST /scan` mit `text`,
-   `language: "de"`. Antwort enthält `pii_entities[]`.
+3. **Scan — pro Tab unterschiedliche Payload-Typen:**
+   - **Chat-Tab:** je Message → `POST /scan` mit `text`, `language: "de"`.
+     Antwort enthält `pii_entities[]`.
+   - **Cowork-Tab:** je Task-Phase + jeder Reportabschnitt → `POST /scan`. Längere
+     Texte, ggf. Chunking auf ~2KB-Stücke vor dem Scan.
+   - **Code-Tab:** zusätzlich zur Chat-History sind zu scannen:
+     - **File-Edit-Diffs** — pro Edit der Diff-Text (`+` und `-` Zeilen). PII
+       in Kommentaren / Strings / Variablennamen ist hier real.
+     - **Terminal-Commands** — Command-Line + stdout/stderr-Capture. Häufige
+       Treffer: Pfade mit User-Home, hostname, IP-Adressen, Tokens in env-Dumps.
+     - **Computer-Use-Actions** — UI-Actions (click, type) protokollieren
+       getippten Text. Falls vorhanden im Session-Log: scannen.
 4. **Persist** — Bei Treffer: Insert in `audit_log_entries`
-   (`action=chat_audit`, `metadata={conversation_id, message_id, entities,
-   max_score}`). Hash-Chain stellt Manipulation fest. Bei `score >= 0.8` oder
-   sensiblen Typen (IBAN, PASSPORT): zusätzlich `privacy_incidents`-Row mit
-   `status=detected`, `category=external_disclosure`.
-5. **Report** — Aggregierter Report (HTML oder Markdown) per Mail/Webhook.
+   (`action=chat_audit`, `metadata={conversation_id, message_id, tab,
+   artifact_type, entities, max_score}`). Hash-Chain stellt Manipulation
+   fest. Bei `score >= 0.8` oder sensiblen Typen (IBAN, PASSPORT):
+   zusätzlich `privacy_incidents`-Row mit `status=detected`,
+   `category=external_disclosure`, `data_category` abgeleitet aus `tab`.
+5. **Report** — Aggregierter Report (HTML oder Markdown) per Mail/Webhook,
+   gruppiert nach Tab und Artifact-Type.
 
 **Neue Tabellen:**
 
@@ -248,9 +324,11 @@ CREATE TABLE chat_audit_findings (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     detected_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
     source          TEXT NOT NULL,       -- 'anthropic'
+    tab             TEXT NOT NULL,       -- 'chat' | 'cowork' | 'code'
+    artifact_type   TEXT NOT NULL,       -- 'message' | 'file_diff' | 'terminal_command' | 'cu_action' | 'cowork_phase'
     conversation_id TEXT NOT NULL,
-    message_id      TEXT NOT NULL,
-    role            TEXT NOT NULL,       -- 'user' | 'assistant'
+    message_id      TEXT NOT NULL,       -- für Code-Tab: edit-id / command-id
+    role            TEXT NOT NULL,       -- 'user' | 'assistant' | 'tool'
     entities        JSONB NOT NULL,      -- [{type, score, start, end}]
     max_score       REAL NOT NULL,
     audit_log_id    UUID REFERENCES audit_log_entries(id),
@@ -258,6 +336,7 @@ CREATE TABLE chat_audit_findings (
 );
 CREATE INDEX idx_chat_audit_findings_conversation ON chat_audit_findings(conversation_id);
 CREATE INDEX idx_chat_audit_findings_detected_at ON chat_audit_findings(detected_at DESC);
+CREATE INDEX idx_chat_audit_findings_tab ON chat_audit_findings(tab, detected_at DESC);
 ```
 
 ### 6.2 Browser-Extension (Variante B)
@@ -326,15 +405,22 @@ Admin kann Schwellwerte und Auto-Incident-Trigger ohne Restart über
 
 ## 7. Rollout
 
-| Phase | Inhalt | Aufwand | Wert |
-|---|---|---|---|
-| **0** | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
-| **1** | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report | 1.5 d | ✅ Vollständige Auditierung |
-| **2** | B — pb-guardian Extension, Chrome-Store-Submit | 2 d | ⚠️ Live-Prävention claude.ai Web |
-| **3** | Dashboard in Grafana: "Chat PII Findings per Week" + Auto-Incident-Tile | 0.5 d | Sichtbarkeit |
-| **4** | OPA-Policy-Tuning auf Basis erster Treffer (false-positive-Rate) | iterativ | Qualität |
+Aligned mit der [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md#roll-out)
+Phasen-Nummerierung:
 
-Phasen 1 und 2 können parallel laufen (verschiedene Skill-Sets).
+| Phase | Coverage-Strategy-Mapping | Inhalt | Aufwand | Wert |
+|---|---|---|---|---|
+| **A.0** | (Voraussetzung) | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
+| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
+| **A.2** | Phase 2 Erweiterung | A erweitert auf **Cowork**-Tab (Task-Phase-Chunking) | 0.5 d | ✅ Tab-`cowork` auditiert |
+| **A.3** | Phase 2 Erweiterung | A erweitert auf **Code**-Tab (File-Diffs, Terminal-Commands, Computer-Use-Actions) | 2 d | ✅ Tab-`code` auditiert — der größte Coverage-Sprung |
+| **B.1** | Phase 2 Defence-in-Depth | B — pb-guardian Extension, Chrome-Store-Submit (claude.ai-Web nur, Chat-Composer) | 2 d | ⚠️ Live-Prävention für den Browser-Use-Case |
+| **C.1** | Phase 1 "Document + position" | Dashboard in Grafana: "Chat PII Findings per Tab per Week" + Auto-Incident-Tile | 0.5 d | Sichtbarkeit |
+| **C.2** | (laufend) | OPA-Policy-Tuning auf Basis erster Treffer (false-positive-Rate, per Tab) | iterativ | Qualität |
+
+Phasen A.1 / B.1 / C.1 können parallel laufen (verschiedene Skill-Sets).
+A.3 ist der höchste Aufwand, hat aber auch den höchsten Compliance-Wert —
+Code-Tab ist im Kunden-Use-Case der Hauptkanal.
 
 ## 8. Compliance-Wirkung
 
@@ -373,6 +459,21 @@ haben — und schnell reagieren können.
    Conversations lesen — das ist gewollt, aber sollte in der internen Policy
    transparent gemacht werden (Mitarbeiterinformation falls jemals
    Mehr-User-Setup).
+7. **Code-Tab — File-Inhalte vs. Diffs.** Der Server-Export liefert die
+   Diffs (Edit-Operationen), nicht zwingend den vollständigen File-Inhalt
+   nach jeder Edit. Wenn PII nur in unveränderten File-Teilen existiert,
+   die der Coding-Agent gelesen aber nicht geändert hat, ist die im Diff
+   nicht sichtbar. Mitigation: Pre-flight (separater Spec) `resolve file`-
+   Mode kann ergänzend ganze Files gegen den Vault scannen.
+8. **Code-Tab — Computer-Use-Captures.** Ob Anthropic-Export die Computer-
+   Use-Actions (incl. getippter Text in andere Apps) lückenlos protokolliert,
+   ist nicht vollständig dokumentiert. Falls nicht: Audit-Lücke für diesen
+   Modus. Endpoint-DLP (Coverage Strategy Komponente C) ist hier die
+   ergänzende Antwort.
+9. **Cowork-Tab — Long-Context-Chunking.** Cowork-Tasks können sehr lange
+   Texte enthalten. Naïves `/scan` läuft in Presidio-Timeouts. Chunking auf
+   ~2KB ist nötig, mit Aufmerksamkeit auf Entity-Splits über Chunk-Grenzen
+   (Mitigation: 200-Byte-Overlap zwischen Chunks).
 
 ## 10. Offene Fragen
 
@@ -391,22 +492,32 @@ haben — und schnell reagieren können.
 
 ## 11. Nächste Schritte
 
-Wenn das Konzept grundsätzlich abgenommen ist:
+Wenn das Konzept (und die übergeordnete [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md))
+grundsätzlich abgenommen sind:
 
-1. Spec für Phase 0 (`/provider/scan`-Endpoint) schreiben → `docs/specs/`.
-2. Spec für Phase 1 (Export-Worker) schreiben → `docs/specs/`.
-3. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`).
-4. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
+1. Spec für Phase A.0 (`/provider/scan`-Endpoint im pb-proxy) schreiben → `docs/specs/`.
+2. Spec für Phase A.1 (Export-Worker, Chat-Tab) schreiben → `docs/specs/`.
+3. Tab-Adapter-Spezifikation für A.2 (Cowork) + A.3 (Code) als
+   Folge-Spec — die Adapter folgen demselben Selector-Adapter-Muster, das in
+   der Coverage Strategy für Pre-flight skizziert ist.
+4. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`) — Scope explizit
+   auf claude.ai-Web halten, Desktop-Workflows decken durch Pre-flight ab.
+5. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
    `nuts/powerbrain` einreichen.
 
 ---
 
 **Cross-References:**
 
-- [editions.md](../editions.md) — Edition-Boundary, drei Datenpfade
+- [editions.md](../editions.md) — Edition-Boundary, drei Datenpfade (ingest /
+  tool-calls / chat-content)
 - [compliance-claude-desktop.md](../compliance-claude-desktop.md) — Drei-Tier-
   Mitigation-Modell, hier ist Tier 2 (detective chat-history ingest)
   spezifiziert
+- [Coverage Strategy](../specs/2026-05-22-claude-desktop-coverage-strategy.md)
+  — übergeordneter Spec, in dem dieser Plan als Komponente B verankert ist;
+  enthält das Vier-Komponenten-Modell (MCP Connector / Audit Mirror /
+  Endpoint DLP / Pre-flight) und das Decision-Record gegen Wrapper-Ansätze
 - [gdpr-external-ai-services.md](../gdpr-external-ai-services.md) — DPA-
   Matrix, AVV-Status pro Anthropic-Plan
 - [risk-management.md](../risk-management.md) — Risikoregister-Eintrag für

--- a/docs/plans/2026-05-20-claude-chat-audit-mirror.md
+++ b/docs/plans/2026-05-20-claude-chat-audit-mirror.md
@@ -312,7 +312,7 @@ CHAT_AUDIT_REPORT_WEBHOOK: str   # optional, Slack/Teams
 **Neue Tabellen:**
 
 ```sql
--- init-db/021_chat_audit.sql
+-- init-db/027_chat_audit.sql
 CREATE TABLE chat_audit_state (
     source         TEXT PRIMARY KEY,    -- 'anthropic'
     last_export_at TIMESTAMPTZ,
@@ -411,7 +411,7 @@ Phasen-Nummerierung:
 | Phase | Coverage-Strategy-Mapping | Inhalt | Aufwand | Wert |
 |---|---|---|---|---|
 | **A.0** | (Voraussetzung) | `POST /provider/scan` Endpoint im pb-proxy (Voraussetzung für B) | 0.5 d | unlocks B |
-| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 021, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
+| **A.1** | Phase 2 "Audit Mirror MVP" — macOS | A — Export-Worker als pb-worker-Job, Migration 027, Mail-Report, **Chat-Tab only**, Schema mit `tab`/`artifact_type` aber populated nur für Chat | 1.5 d | ✅ Tab-`chat` vollständig auditiert |
 | **A.2** | Phase 2 Erweiterung | A erweitert auf **Cowork**-Tab (Task-Phase-Chunking) | 0.5 d | ✅ Tab-`cowork` auditiert |
 | **A.3** | Phase 2 Erweiterung | A erweitert auf **Code**-Tab (File-Diffs, Terminal-Commands, Computer-Use-Actions) | 2 d | ✅ Tab-`code` auditiert — der größte Coverage-Sprung |
 | **B.1** | Phase 2 Defence-in-Depth | B — pb-guardian Extension, Chrome-Store-Submit (claude.ai-Web nur, Chat-Composer) | 2 d | ⚠️ Live-Prävention für den Browser-Use-Case |
@@ -502,7 +502,7 @@ grundsätzlich abgenommen sind:
    der Coverage Strategy für Pre-flight skizziert ist.
 4. Browser-Extension-Repo aufsetzen (`nuts/pb-guardian`) — Scope explizit
    auf claude.ai-Web halten, Desktop-Workflows decken durch Pre-flight ab.
-5. OPA-Policy-Section + Migration 021 als kleinen Vorlauf-PR auf
+5. OPA-Policy-Section + Migration 027 als kleinen Vorlauf-PR auf
    `nuts/powerbrain` einreichen.
 
 ---

--- a/docs/specs/2026-05-22-claude-desktop-coverage-strategy.md
+++ b/docs/specs/2026-05-22-claude-desktop-coverage-strategy.md
@@ -1,0 +1,250 @@
+# Claude Desktop Coverage Strategy — Spec
+
+**Status:** Draft 2026-05-22, not yet approved
+**Owner:** Powerbrain core team
+**Supersedes:** [PR #174 — Pseudonym Bridge spec, closed 2026-05-22](https://github.com/nuetzliches/powerbrain/pull/174)
+**Related:** [docs/editions.md](../editions.md), [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md), [docs/plans/2026-05-20-claude-chat-audit-mirror.md](../plans/2026-05-20-claude-chat-audit-mirror.md)
+
+## Motivation
+
+Enterprise customers want to keep using **Claude Desktop on Pro/Max subscriptions** with Powerbrain mediating as much of the data flow as possible for GDPR / EU AI Act compliance. Three constraints are non-negotiable from the customer side:
+
+1. **Pro/Max stays.** Per-developer Pro/Max is the cost model that fits org budgets. API-priced usage at scale (heavy coding-agent workloads, hundreds of devs) is prohibitively expensive — often 5–20× the subscription cost.
+2. **Claude Desktop stays.** Especially the Code tab — the integrated coding-agent UX with sessions, Git isolation, terminal, computer use, and visual diff review is what the org has standardized on. Replacing it with a CLI or a different tool is organisationally not feasible.
+3. **"Just ban it" is not viable.** Without an officially supported path, employees use Claude Desktop anyway via shadow IT. Compliance then has zero visibility — worse than a partial-coverage sanctioned solution.
+
+The customer ask is therefore: *what is the maximum honest coverage Powerbrain can deliver for Claude Desktop on Pro/Max, given Anthropic's 2026 policy posture, and what can compliance teams credibly tell their DPO and DPA based on that coverage?*
+
+This spec is the honest answer. It supersedes the Pseudonym Bridge spec, which targeted the wrong abstraction (claude.ai chat webview) and the wrong threat model.
+
+## What changed in 2026 that closes the obvious paths
+
+Three Anthropic policy / enforcement moves reshape the design space:
+
+1. **2026-02 — "Authentication and Credential Use" policy.** OAuth credentials (Free / Pro / Max) are *"intended exclusively for Claude Code and claude.ai"*. Third-party clients using Pro/Max OAuth are now explicitly policy-violating.
+2. **2026-04-04 — Third-party harness enforcement.** Anthropic technically blocked third-party harnesses from using Max subscription limits. Projects in the [CLIProxyAPI](https://rogs.me/2026/02/use-your-claude-max-subscription-as-an-api-with-cliproxyapi/) / [Claw Code](https://claw-code.codes/) class were the direct target.
+3. **2025-10-08 Consumer Terms Section 3** remains: prohibits reverse-engineering, decompilation, and access to the Service through "automated or non-human means" except via Anthropic API key.
+
+What these close, definitively:
+
+- Wrapping or modifying the Claude Desktop binary
+- Forking Claude Code and using Pro/Max OAuth in the fork
+- Building a proxy that relays Pro/Max OAuth credentials to api.claude.ai
+- DOM-injecting into Anthropic's proprietary client UI
+
+What they do **not** close:
+
+- Powerbrain components running alongside Claude Desktop, used voluntarily by the user
+- Powerbrain MCP servers registered through Claude Desktop's official Connectors mechanism
+- Network-level controls applied by the customer's IT department to their own endpoints
+- Detective audit of conversations after the fact, from data the user already has access to
+
+This spec lives entirely in the "do not close" half.
+
+## Claude Desktop in May 2026 — three tabs, three flow profiles
+
+Claude Desktop (macOS + Windows; Linux still uses the CLI) has three tabs:
+
+| Tab | Purpose | Primary data flow | Tool calls | File access | Computer use |
+|---|---|---|---|---|---|
+| **Chat** | Free-form conversation | Prompt → LLM → Response | Limited (search etc.) | None | No |
+| **Cowork** | Dispatched / longer agentic work | Task → background agent → report | Moderate | Workspace-scoped | No |
+| **Code** | Software development (coding agent) | Prompt → agent loop → file edits, terminal, computer use | Extensive | Full project access | Yes (research preview) |
+
+All three authenticate via OAuth against Anthropic. All three send chat content directly to Anthropic's edge. Powerbrain currently sits in two places:
+
+- As a **Connector** (MCP server) registered in Claude Desktop's settings — touches the tool-call layer
+- As an **ingestion sink** for content the user explicitly imports via Powerbrain adapters (GitHub, Office 365, etc.) — touches the knowledge-base layer
+
+Everything else flows past Powerbrain.
+
+## Coverage matrix
+
+What each Powerbrain mechanism covers, per Claude Desktop data path:
+
+| Data path | MCP Connector (existing) | Audit Mirror (planned) | Endpoint DLP (customer IT) | Pre-flight (new, this spec) |
+|---|---|---|---|---|
+| **User prompt** (text typed by user) | ❌ Bypass | ✅ Post-hoc record | ⚠️ Allow/block only, no content inspection | ✅ Pre-submit pseudonymisation, user-driven |
+| **LLM response** | ❌ Bypass | ✅ Post-hoc record | ❌ | ✅ Post-receive resolution, user-driven |
+| **File attachments** uploaded into Claude | ❌ Bypass | ✅ Mirrored as ref | ⚠️ Block by MIME possible | ✅ Pre-upload scan + pseudonymise |
+| **Tool calls** to Powerbrain MCP | ✅ Full OPA + audit | ✅ Identical | n/a | n/a |
+| **Tool calls** to other connectors | depends on connector | ✅ Mirrored as event | ⚠️ Network-level | n/a |
+| **File edits** by Code tab on user filesystem | n/a (local) | ✅ Diff mirrored | ⚠️ Filesystem ACL | n/a |
+| **Terminal commands** in Code tab | n/a (local) | ✅ Command + output mirrored | ⚠️ Process ACL | n/a |
+| **Computer use** (mouse/keyboard control) | n/a (local) | ✅ Action log mirrored | ⚠️ Accessibility-API gating | n/a |
+
+The matrix shows the honest picture: **no single Powerbrain mechanism covers everything; the combination of MCP + audit-mirror + endpoint-DLP + pre-flight closes most of the gap most of the time, without ever requiring us to intercept Claude Desktop itself.**
+
+## Components
+
+### A. MCP Connector (existing — formalise as part of strategy)
+
+Powerbrain's `mcp-server` registered as a Connector in Claude Desktop's settings. Provides 28 tools to the agent in any tab. Already covers:
+
+- OPA policy enforcement per tool call
+- Vault-token-based PII resolution for tool results
+- Audit chain on `agent_access_log`
+- Knowledge graph, search, document retrieval, incident reporting
+
+**Status:** Production today. Documented in [docs/mcp-tools.md](../mcp-tools.md) and the Connectors capability row in [docs/editions.md](../editions.md).
+
+**What changes in this spec:** None to the component itself; the spec formalises that the MCP Connector is the **primary coverage layer** and frames the other components as defence-in-depth around it.
+
+### B. Audit Mirror (planned — see [chat-audit-mirror plan](../plans/2026-05-20-claude-chat-audit-mirror.md))
+
+Reads Claude Desktop's local conversation storage (SQLite under `~/Library/Application Support/Claude/...` on macOS, `%AppData%\Claude\...` on Windows), mirrors conversations into Powerbrain's audit chain after the fact.
+
+Coverage:
+
+- Every prompt and response across all three tabs
+- File-edit diffs and terminal-command events from the Code tab (Claude Desktop's session log captures these)
+- Tool-call invocations (visible in session log even when the connector wasn't Powerbrain)
+
+What it provides:
+
+- GDPR Art. 5 (lawfulness, accountability) — record of every PII-touching interaction
+- GDPR Art. 30 (records of processing) — auditable per-user log
+- EU AI Act Art. 12 (record keeping) — interactions with high-risk AI system
+- Incident response (Art. 33/34) — forensic trace when something leaks
+
+What it does **not** provide:
+
+- Prevention — PII has already reached Anthropic by the time we see it
+- Real-time blocking
+- Cross-device visibility (mirror runs per host; centralised aggregation is a separate concern)
+
+**Status:** Plan exists, implementation not started. This spec promotes it to the "coverage strategy backbone."
+
+### C. Endpoint DLP (customer-IT deployment pattern)
+
+Network-level controls on the user's endpoint. Customer IT can:
+
+- Allow `api.claude.ai` only for specific roles / classified workstations
+- Block uploads above N bytes via egress filtering (limits attachment exfiltration risk)
+- Require VPN-tunnelled connection so traffic is at least visible at the boundary (though TLS hides content)
+- Block `api.claude.ai` entirely on workstations handling restricted data, falling back to API-keyed Powerbrain proxy
+
+This is **not a Powerbrain component**; Powerbrain documents the pattern and provides recommended firewall / proxy rules.
+
+**Status:** Pattern only. Spec adds a recommendations section in [docs/deployment.md](../deployment.md) with concrete configs for common DLP suites.
+
+### D. Pre-flight (new component — this spec's only new build)
+
+A small client-side application that helps users **pseudonymise text before they paste it into Claude Desktop** and **resolve pseudonyms in Claude's responses after they paste them back**. Critically: Pre-flight does **not** interact with Claude Desktop itself in any way — no DOM injection, no clipboard hooks into Claude's window, no automation. It is a separate tool the user voluntarily invokes.
+
+#### UX
+
+Three invocation patterns, all opt-in:
+
+1. **Global hotkey + popup** (default) — `Ctrl/Cmd+Shift+P` opens a small Pre-flight window. User pastes text → sees pseudonymised version → copies it → switches to Claude Desktop → pastes it. Same flow in reverse for responses.
+2. **Clipboard offer** (opt-in) — when Pre-flight is running and the user copies text, a notification offers "Pseudonymise before paste?" Click accept → clipboard is replaced. User pastes into Claude. Skip → clipboard unchanged.
+3. **Browser-extension hand-off** — for the rare user that also wants chat-content-side governance on `claude.ai` (the website, not the desktop app), Pre-flight provides hooks the extension uses. Out of scope as a deliverable here; covered in [docs/editions.md](../editions.md) chat-content path.
+
+Pre-flight UI shows:
+
+- Original text (input)
+- Pseudonymised text (output, copyable)
+- Detected PII categories and counts ("3 person names, 1 email, 1 IBAN")
+- Resolution mode for responses: paste a Claude response containing `[TYPE:hash]` tokens → see resolved text alongside
+
+#### Architecture
+
+| Aspect | Choice | Rationale |
+|---|---|---|
+| Framework | Tauri (Rust backend + system webview UI) | Small footprint (~5MB), no Chromium bundling, OS-keychain integration via `tauri-plugin-keychain` |
+| Backend integration | Existing `/pseudonymize` (ingestion) + `/vault/resolve` (mcp-server) | Zero new backend services |
+| Auth | Local `pb_` key in OS keychain | Same key model as the rest of Powerbrain; rotatable |
+| Offline | No — Pre-flight requires Powerbrain reachable | Acceptable: corporate deploy, Powerbrain on intranet |
+| Distribution | Signed installers (macOS notarised, Windows code-signed), org-wide MDM-deployable | Compliance customers run MDM; this is friction-free |
+| Branding | "Powerbrain Pre-flight" — explicit, not pretending to be anything else | ToS clarity; user knows they're using a Powerbrain tool |
+
+#### Why this is ToS-clean
+
+- Does not interact with Claude Desktop's process, binary, DOM, or network traffic
+- Does not use Anthropic API or Anthropic OAuth credentials
+- Is just a clipboard / text utility that calls Powerbrain endpoints
+- User explicitly invokes it; nothing automated against Anthropic
+
+The pre-flight pattern is the same as a desktop password manager that helps you generate strong passwords before pasting them into a website. The website never knows the password manager exists.
+
+#### Limitations
+
+- **User must remember to use it.** Pure UX problem. Mitigated by hotkey + clipboard-offer ergonomics + training.
+- **Doesn't catch in-app file uploads.** When the user drags a file into Claude Desktop directly, Pre-flight isn't involved. Mitigation: Pre-flight has a "scan file" mode that pseudonymises a file's text content to a clipboard-ready blob; user pastes that instead of dragging the file. Awkward but defensible.
+- **Responses stay pseudonymised in Claude's session.** Anthropic stores Claude's response text containing `[PERSON:abc]` tokens. The audit-mirror picks this up correctly. If the user wants resolved text, they paste-back through Pre-flight.
+- **Code-tab file edits.** When Claude edits a file in the user's project, the file content is whatever Claude produces. If the user pseudonymised the original prompt with PII tokens, Claude may write code that references `[PERSON:abc]` literally. Pre-flight provides a "resolve file" command that walks a file (or a project directory) and replaces pseudonyms.
+
+These limitations exist; the spec is honest about them.
+
+## What customers can claim, honestly
+
+Combining the four components, a compliance customer can defensibly assert:
+
+| Claim | Substantiated by |
+|---|---|
+| "Tool-call layer is fully governed by Powerbrain policy and audit" | MCP Connector (A) |
+| "Every interaction with Claude Desktop is recorded for GDPR Art. 30 record-keeping" | Audit Mirror (B) |
+| "Restricted-classified workstations have technical egress controls preventing direct Claude Desktop access" | Endpoint DLP (C) |
+| "Users have a sanctioned mechanism to remove PII from prompts before submission" | Pre-flight (D) |
+| "We can demonstrate evidence of prompt-side PII protection per incident" | A + B + D combined |
+
+What they cannot claim:
+
+| ❌ Inflated claim | Actual reality |
+|---|---|
+| "Every Claude Desktop prompt is pseudonymised at the wire" | Only prompts the user runs through Pre-flight are |
+| "Claude never sees raw PII from our employees" | Depends on user discipline + Pre-flight adoption |
+| "Powerbrain intercepts and rewrites all Claude Desktop traffic" | It does not — that path is closed by Anthropic policy |
+
+This honest framing is what DPOs need. Inflated claims fail under scrutiny; honest claims with documented evidence chains pass.
+
+## Decision record — what we deliberately do not build
+
+Captured here so the question doesn't keep coming back:
+
+| Considered approach | Decision | Reason |
+|---|---|---|
+| DOM-inject into claude.ai webview | **Rejected.** | Claude Desktop's Code tab is not a webview of claude.ai. Pseudonym Bridge spec (PR #174) targeted the wrong abstraction. |
+| Modify Claude Desktop's `app.asar` | **Rejected.** | Consumer Terms Section 3 (reverse-engineering / modification). Also: Anthropic's auto-updater overwrites the patch. Compliance product cannot stand on a ToS violation. |
+| Fork Claude Code / build OAuth proxy / third-party harness on Pro/Max | **Rejected.** | Feb 2026 Authentication policy + April 2026 enforcement explicitly target this class. |
+| Repackage like aaddrick/claude-desktop-debian for our purposes | **Rejected.** | aaddrick relies on Anthropic's continued tolerance of a hobby Linux port. Powerbrain as commercial compliance product would not enjoy the same tolerance. |
+| Use Claude Code CLI hooks on Pro/Max OAuth | **Deferred — not recommended for Code tab coverage.** | CLI hooks exist (`UserPromptSubmit`) but using them with Pro/Max OAuth in a commercial Powerbrain workflow conflicts with the spirit of the Feb 2026 policy. We do not actively recommend this to customers. |
+| Run our own LLM gateway and ask users to point Claude Desktop at it | **Not possible.** | Claude Desktop's endpoint is hardcoded; `ANTHROPIC_BASE_URL` has no effect in the GUI. |
+
+## Roll-out
+
+| Phase | Deliverables | Customer-facing outcome |
+|---|---|---|
+| **1. Document + position** | This spec landed, [docs/editions.md](../editions.md) coverage-matrix updated, [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md) refreshed with the 2026 policy moves, DLP recommendations in [docs/deployment.md](../deployment.md) | Sales / compliance teams have an honest pitch deck |
+| **2. Audit Mirror MVP** | Implement [chat-audit-mirror plan](../plans/2026-05-20-claude-chat-audit-mirror.md) for macOS first, then Windows | Customers get the Art. 30 record-keeping claim immediately |
+| **3. Pre-flight v1** | Tauri app, macOS + Windows, hotkey + popup UI, OS-keychain `pb_` key, signed installers | Customers can train users on a sanctioned pseudonymisation workflow |
+| **4. Pre-flight v2** | Clipboard-offer mode, file-scan mode, project-resolve mode | Higher adoption via lower friction; addresses file-upload limitation |
+| **5. Cross-device aggregation** | Audit Mirror reports per-user logs centrally to Powerbrain | Org-level compliance dashboards |
+
+Each phase is independent — customers can buy / deploy in any order.
+
+## Open questions
+
+1. **Audit-mirror legality per jurisdiction.** Some employee-monitoring regulations require explicit consent before logging chat. Customer-side concern, but Powerbrain should provide a recommended consent flow (banner on Pre-flight first run, etc.).
+2. **Storage format of Claude Desktop session logs.** Need to reverse-engineer (lawfully — accessing data the user already owns) the SQLite schema; assume it changes across versions. Adapter strategy similar to the DOM-adapter idea in the closed Pseudonym Bridge spec.
+3. **MDM deployment story.** Compliance customers run MDM (Jamf, Intune). Pre-flight needs a silent-install / preconfigured-`pb_`-key story. Spec out as part of Phase 3.
+4. **Pricing.** Pre-flight is an enterprise-tier feature. Is it bundled with `pb-proxy` license or separately licensed? Out of spec scope; product decision.
+5. **Linux story.** Pre-flight on Linux is feasible (Tauri supports it). Claude Desktop is not available on Linux — those users use Claude Code CLI which already has API-key + `ANTHROPIC_BASE_URL=pb-proxy` as the supported path. So Pre-flight on Linux is value-additive for users of other AI tools, not for Claude Desktop coverage.
+
+## Test plan
+
+Doc + minor-component spec only. The single new buildable component (Pre-flight) gets its own implementation plan once approved.
+
+- [ ] Spec reviewed against [docs/editions.md](../editions.md) three-paths matrix — does the coverage matrix here align?
+- [ ] Spec reviewed against [docs/compliance-claude-desktop.md](../compliance-claude-desktop.md) — does the decision-record cite the right Anthropic policy timestamps?
+- [ ] Compliance team confirms the "what customers can claim" table is defensibly accurate for German GDPR / EU AI Act framing
+- [ ] Sales team confirms the strategy addresses the actual customer ask ("Pro/Max stays, Powerbrain dazwischen")
+- [ ] Decision on Pre-flight tech stack (Tauri vs Electron vs native) before Phase 3 plan
+
+## Out of scope (deliberately)
+
+- Anything that intercepts, modifies, or proxies Claude Desktop's network traffic, process, binary, or UI
+- Any product feature that relies on continued Anthropic tolerance of policy-violating patterns
+- API-key-mode Claude Code coverage — already addressed by `pb-proxy` + `ANTHROPIC_BASE_URL`, not a Pro/Max scenario
+- Replacing Claude Desktop with a Powerbrain-built coding agent
+- Bridging non-Anthropic AI tools (ChatGPT, Gemini, Copilot). Pre-flight architecturally works for them too, but per-tool integration is a separate product question.

--- a/ingestion/requirements.txt
+++ b/ingestion/requirements.txt
@@ -1,7 +1,7 @@
 # Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 # Dependabot proposes bumps; every change is reviewed in a PR.
 fastapi==0.141.1
-uvicorn[standard]==0.52.2
+uvicorn[standard]==0.52.3
 httpx==0.28.1
 asyncpg==0.31.0
 qdrant-client==1.19.0

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -11,7 +11,7 @@ httpx==0.28.1
 asyncpg==0.31.0
 qdrant-client==1.19.0
 pydantic==2.13.4
-uvicorn[standard]==0.52.2
+uvicorn[standard]==0.52.3
 starlette==1.6.0
 prometheus-client==0.26.0
 # OpenTelemetry (optional, aktiviert via OTEL_ENABLED=true)

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,12 +1,10 @@
 # Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 # Dependabot proposes bumps; every change is reviewed in a PR.
 #
-# IMPORTANT: mcp is held at 1.x. 2.0.0 is a breaking API change — it drops the
-# `Server.list_tools()` decorator used in server.py. Do not accept a 2.x bump
-# without porting server.py first.
-# The former `[server]` extra was dropped: no 1.x release provides it either
-# (pip: "does not provide the extra 'server'"), so it installed nothing.
-mcp==1.29.0
+# mcp 2.x: the lowlevel Server binds handlers via on_list_tools/on_call_tool
+# constructor params instead of decorators — see server.py "MCP-Server-Instanz".
+# The `[server]` extra does not exist in either 1.x or 2.x, so it is not used.
+mcp==2.0.0
 httpx==0.28.1
 asyncpg==0.31.0
 qdrant-client==1.19.0

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -23,9 +23,16 @@ import httpx
 import asyncpg
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import Filter, FieldCondition, MatchValue, FilterSelector
-from mcp.server import Server
+from mcp.server import Server, ServerRequestContext
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.types import Tool, TextContent
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 from mcp.server.auth.provider import TokenVerifier, AccessToken
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend, RequireAuthMiddleware
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_access_token
@@ -1294,12 +1301,14 @@ async def check_feedback_warning(query: str, pool: asyncpg.Pool):
 
 
 # ── MCP-Server ───────────────────────────────────────────────
-server = Server("pb-mcp-server")
-
-
-@server.list_tools()
-async def list_tools() -> list[Tool]:
-    return [
+# mcp 2.x replaced the @server.list_tools()/@server.call_tool() decorators with
+# on_* constructor params. The handlers are therefore plain functions and the
+# Server instance is built below them — see "MCP-Server-Instanz".
+async def list_tools(
+    ctx: ServerRequestContext,
+    params: PaginatedRequestParams | None,
+) -> ListToolsResult:
+    return ListToolsResult(tools=[
         Tool(
             name="search_knowledge",
             description="Semantic search over the knowledge base. "
@@ -1867,13 +1876,18 @@ async def list_tools() -> list[Tool]:
                 "required": ["incident_id", "subject_ref", "channel"]
             }
         ),
-    ]
+    ])
 
 
 # ── Tool-Implementierungen ───────────────────────────────────
 
-@server.call_tool()
-async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+async def call_tool(
+    ctx: ServerRequestContext,
+    params: CallToolRequestParams,
+) -> CallToolResult:
+    name = params.name
+    arguments = params.arguments or {}
+
     # ── Identity from auth token (preferred) or arguments (legacy) ──
     access_token = get_access_token()
     if access_token is not None:
@@ -1886,7 +1900,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         log.warning("Unauthenticated request for tool '%s' from agent_id='%s'", name, agent_id)
     else:
         # Should not reach here (RequireAuthMiddleware already rejected)
-        return [TextContent(type="text", text=json.dumps({"error": "authentication required"}))]
+        return CallToolResult(content=[
+            TextContent(type="text", text=json.dumps({"error": "authentication required"}))
+        ])
 
     t_start = time.perf_counter()
     status  = "ok"
@@ -1917,7 +1933,17 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     mcp_requests_total.labels(tool=name, status=status).inc()
     mcp_request_duration.labels(tool=name).observe(elapsed)
 
-    return result
+    # is_error stays at its default False: _dispatch reports failures as an
+    # {"error": ...} payload in the content, which is what clients already parse.
+    return CallToolResult(content=result)
+
+
+# ── MCP-Server-Instanz ───────────────────────────────────────
+server = Server(
+    "pb-mcp-server",
+    on_list_tools=list_tools,
+    on_call_tool=call_tool,
+)
 
 
 def _build_delete_filter(source_type: str | None, project: str | None,

--- a/mcp-server/tests/test_manage_policies.py
+++ b/mcp-server/tests/test_manage_policies.py
@@ -4,7 +4,22 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from mcp.types import CallToolRequestParams
+
 import server
+
+
+async def _call(name: str, arguments: dict):
+    """Invoke the tool handler and return its content blocks.
+
+    mcp 2.x calls handlers as (ctx, params) and wraps the reply in a
+    CallToolResult; these tests assert on the content blocks either way. The
+    handler ignores ctx, so None is sufficient here.
+    """
+    result = await server.call_tool(
+        None, CallToolRequestParams(name=name, arguments=arguments),
+    )
+    return result.content
 
 
 @pytest.fixture(autouse=True)
@@ -65,7 +80,7 @@ class TestManagePoliciesList:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {"action": "list"})
+        result = await _call("manage_policies", {"action": "list"})
         data = json.loads(result[0].text)
         assert "sections" in data
         # All 17 required sections should be listed
@@ -83,7 +98,7 @@ class TestManagePoliciesList:
         token.scopes = ["analyst"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {"action": "list"})
+        result = await _call("manage_policies", {"action": "list"})
         data = json.loads(result[0].text)
         assert "error" in data
         assert "admin" in data["error"]
@@ -102,7 +117,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -117,7 +132,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "nonexistent"
         })
         data = json.loads(result[0].text)
@@ -134,7 +149,7 @@ class TestManagePoliciesRead:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "read", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -158,7 +173,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         new_roles = ["viewer", "analyst", "developer", "admin", "auditor"]
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": new_roles
         })
         data = json.loads(result[0].text)
@@ -178,7 +193,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         # roles must be an array, not a string
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": "not_an_array"
         })
         data = json.loads(result[0].text)
@@ -196,7 +211,7 @@ class TestManagePoliciesUpdate:
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
         # roles has minItems: 1, so empty array should fail
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles", "data": []
         })
         data = json.loads(result[0].text)
@@ -211,7 +226,7 @@ class TestManagePoliciesUpdate:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles"
         })
         data = json.loads(result[0].text)
@@ -232,7 +247,7 @@ class TestManagePoliciesUpdate:
         server._opa_cache["test_key"] = True
         server._fields_to_redact_cache["test_key"] = {"email"}
 
-        await server.call_tool("manage_policies", {
+        await _call("manage_policies", {
             "action": "update", "section": "roles",
             "data": ["viewer", "analyst", "admin"]
         })
@@ -251,7 +266,7 @@ class TestManagePoliciesUpdate:
         token.scopes = ["admin"]
         monkeypatch.setattr(server, "get_access_token", lambda: token)
 
-        result = await server.call_tool("manage_policies", {
+        result = await _call("manage_policies", {
             "action": "update", "section": "roles",
             "data": ["viewer", "admin"]
         })

--- a/pb-proxy/requirements.txt
+++ b/pb-proxy/requirements.txt
@@ -3,11 +3,13 @@
 fastapi==0.141.1
 uvicorn[standard]==0.52.2
 litellm==1.96.2
-# IMPORTANT: mcp is held at 1.x. 2.0.0 removes
-# `mcp.client.streamable_http.streamablehttp_client`, used in tool_injection.py.
-# Do not accept a 2.x bump without porting the client code first.
-mcp==1.29.0
+mcp==2.0.0
 httpx==0.28.1
+# httpx2 is the MCP SDK's HTTP stack from 2.0 on. tool_injection.py imports it
+# directly to attach auth headers, so it is pinned here rather than inherited.
+# Do not substitute httpx: the SDK accepts an httpx client and then silently
+# stops delivering server-initiated messages.
+httpx2==2.10.0
 pydantic==2.13.4
 pyyaml==6.0.3
 prometheus-client==0.26.0

--- a/pb-proxy/requirements.txt
+++ b/pb-proxy/requirements.txt
@@ -1,7 +1,7 @@
 # Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 # Dependabot proposes bumps; every change is reviewed in a PR.
 fastapi==0.141.1
-uvicorn[standard]==0.52.2
+uvicorn[standard]==0.52.3
 litellm==1.96.2
 # IMPORTANT: mcp is held at 1.x. 2.0.0 removes
 # `mcp.client.streamable_http.streamablehttp_client`, used in tool_injection.py.

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -227,3 +227,199 @@ def test_mcp_headers_forward_combined_with_bearer_auth():
         "Authorization": "Bearer pb_key_123",
         "x-tenant-id": "tenant-42",
     }
+
+
+# ── ExceptionGroup flattening for discovery failures ─────────
+
+
+def test_leaf_exceptions_plain_exception_is_its_own_leaf():
+    """A non-group exception flattens to just itself."""
+    from tool_injection import _leaf_exceptions
+
+    exc = ValueError("boom")
+    assert _leaf_exceptions(exc) == [exc]
+
+
+def test_leaf_exceptions_flattens_nested_groups():
+    """Groups nest, so flattening recurses to the real leaves."""
+    from tool_injection import _leaf_exceptions
+
+    inner_a = ConnectionRefusedError("connect refused")
+    inner_b = TimeoutError("read timeout")
+    outer = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ExceptionGroup("inner group", [inner_a, inner_b])],
+    )
+    assert _leaf_exceptions(outer) == [inner_a, inner_b]
+
+
+def test_describe_exception_plain_exception_names_type():
+    """A plain exception is rendered as `Type: message`."""
+    from tool_injection import _describe_exception
+
+    assert _describe_exception(ValueError("bad url")) == "ValueError: bad url"
+
+
+def test_describe_exception_surfaces_taskgroup_leaf_cause():
+    """The leaf cause replaces the TaskGroup group's own useless str().
+
+    The MCP streamable-http client wraps failures in an anyio task group, so
+    logging the group with %s used to yield only "unhandled errors in a
+    TaskGroup (1 sub-exception)" with no HTTP status or auth error.
+    """
+    from tool_injection import _describe_exception
+
+    class HTTPStatusError(Exception):
+        pass
+
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [HTTPStatusError("Client error '401 Unauthorized' for url 'http://tc:8080/mcp'")],
+    )
+
+    # What the old `%s` formatting produced — the bug being fixed.
+    assert "TaskGroup" in str(group)
+    assert "401" not in str(group)
+
+    described = _describe_exception(group)
+    assert described == (
+        "HTTPStatusError: Client error '401 Unauthorized' for url 'http://tc:8080/mcp'"
+    )
+    assert "TaskGroup" not in described
+
+
+def test_describe_exception_joins_multiple_leaves():
+    """Several sub-exceptions are all reported, not just the first."""
+    from tool_injection import _describe_exception
+
+    group = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ConnectionRefusedError("connect refused"), TimeoutError("read timeout")],
+    )
+    assert _describe_exception(group) == (
+        "ConnectionRefusedError: connect refused; TimeoutError: read timeout"
+    )
+
+
+def test_describe_exception_collapses_multiline_messages():
+    """A multi-line leaf message is collapsed to keep the log one line.
+
+    httpx raises `Client error '401 Unauthorized' for url '…'\\nFor more
+    information check: …`, which would otherwise wrap the warning.
+    """
+    from tool_injection import _describe_exception
+
+    class HTTPStatusError(Exception):
+        pass
+
+    leaf = HTTPStatusError(
+        "Client error '401 Unauthorized' for url 'http://tc:8080/mcp'\n"
+        "For more information check: https://developer.mozilla.org/…/401"
+    )
+    described = _describe_exception(ExceptionGroup("unhandled errors in a TaskGroup", [leaf]))
+    assert "\n" not in described
+    assert described == (
+        "HTTPStatusError: Client error '401 Unauthorized' for url 'http://tc:8080/mcp' "
+        "For more information check: https://developer.mozilla.org/…/401"
+    )
+
+
+def test_describe_exception_message_less_leaf_falls_back_to_type():
+    """An exception with an empty str() still names its type."""
+    from tool_injection import _describe_exception
+
+    class ConnectError(Exception):
+        pass
+
+    assert _describe_exception(ConnectError()) == "ConnectError"
+    group = ExceptionGroup("unhandled errors in a TaskGroup", [ConnectError()])
+    assert _describe_exception(group) == "ConnectError"
+
+
+def _cached_tool_entry():
+    """A single cached ToolEntry, so refresh keeps cache instead of raising."""
+    from tool_injection import ToolEntry
+
+    return ToolEntry(
+        server_name="powerbrain",
+        original_name="search_knowledge",
+        schema={},
+        server_config=McpServerConfig(
+            name="powerbrain", url="http://mcp:8080/mcp",
+            auth="bearer", prefix="powerbrain", required=True,
+        ),
+    )
+
+
+async def test_refresh_logs_leaf_cause_for_optional_server(caplog):
+    """The optional-server warning names the leaf cause, not the TaskGroup."""
+    import logging
+
+    from tool_injection import ToolInjector
+
+    server = McpServerConfig(
+        name="timecockpit", url="http://tc:8080/mcp", auth="static",
+        prefix="tc", required=False,
+    )
+    injector = ToolInjector.__new__(ToolInjector)
+    injector._servers = [server]
+    injector._server_status = {}
+    injector._tools = {"powerbrain_search_knowledge": _cached_tool_entry()}
+
+    async def _boom(_self, _server):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [PermissionError("401 Unauthorized")],
+        )
+
+    with patch.object(ToolInjector, "_discover_server_tools", _boom):
+        with caplog.at_level(logging.DEBUG, logger="pb-proxy.tools"):
+            await injector._refresh_all_tools()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    unreachable = [r for r in warnings if "timecockpit" in r.getMessage()]
+    assert len(unreachable) == 1
+    message = unreachable[0].getMessage()
+    assert "PermissionError: 401 Unauthorized" in message
+    assert "TaskGroup" not in message
+
+    # Traceback is still available, but only at debug level.
+    debug_with_traceback = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and r.exc_info is not None
+    ]
+    assert debug_with_traceback, "expected a debug record carrying the traceback"
+
+    assert injector._server_status["timecockpit"] is False
+
+
+async def test_refresh_logs_leaf_cause_for_required_server(caplog):
+    """The required-server error line gets the same flattening."""
+    import logging
+
+    from tool_injection import ToolInjector
+
+    server = McpServerConfig(
+        name="powerbrain", url="http://mcp:8080/mcp", auth="bearer",
+        prefix="powerbrain", required=True,
+    )
+    injector = ToolInjector.__new__(ToolInjector)
+    injector._servers = [server]
+    injector._server_status = {}
+    injector._tools = {"powerbrain_search_knowledge": _cached_tool_entry()}
+
+    async def _boom(_self, _server):
+        raise ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("inner", [ConnectionRefusedError("connect refused")])],
+        )
+
+    with patch.object(ToolInjector, "_discover_server_tools", _boom):
+        with caplog.at_level(logging.DEBUG, logger="pb-proxy.tools"):
+            await injector._refresh_all_tools()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    message = errors[0].getMessage()
+    assert "ConnectionRefusedError: connect refused" in message
+    assert "TaskGroup" not in message

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -156,7 +156,7 @@ def test_mcp_tool_to_openai_uses_idempotent_prefix():
     class _Tool:
         name = "tc_create_timesheet"
         description = "Create a timesheet entry"
-        inputSchema = {"type": "object", "properties": {}}
+        input_schema = {"type": "object", "properties": {}}
 
     schema = _mcp_tool_to_openai(_Tool(), "tc")
     assert schema["function"]["name"] == "tc_create_timesheet"

--- a/pb-proxy/tests/test_tool_injection.py
+++ b/pb-proxy/tests/test_tool_injection.py
@@ -110,6 +110,58 @@ def test_merge_tools_filters_by_allowed_servers():
     assert "github_list" not in names
 
 
+# ── prefix application tests ─────────────────────────────────
+
+
+def test_prefixed_tool_name_applies_prefix():
+    """A tool that is not namespaced gets the server prefix."""
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("powerbrain", "search_knowledge") == "powerbrain_search_knowledge"
+    assert _prefixed_tool_name("tc", "list_timesheets") == "tc_list_timesheets"
+
+
+def test_prefixed_tool_name_is_idempotent():
+    """A tool already named `<prefix>_…` is not prefixed twice.
+
+    timecockpit-mcp publishes `tc_list_timesheets` etc., so the `prefix: tc`
+    entry must not produce `tc_tc_list_timesheets`.
+    """
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("tc", "tc_list_timesheets") == "tc_list_timesheets"
+    assert _prefixed_tool_name("tc", "tc_find_similar_entries") == "tc_find_similar_entries"
+
+
+def test_prefixed_tool_name_partial_match_still_prefixed():
+    """A name that merely starts with the prefix letters still gets prefixed."""
+    from tool_injection import _prefixed_tool_name
+
+    # "tcfoo" starts with "tc" but is not namespaced ("tc_"), so it needs the prefix.
+    assert _prefixed_tool_name("tc", "tcfoo") == "tc_tcfoo"
+
+
+def test_prefixed_tool_name_no_prefix():
+    """An empty or missing prefix leaves the name untouched."""
+    from tool_injection import _prefixed_tool_name
+
+    assert _prefixed_tool_name("", "search_knowledge") == "search_knowledge"
+    assert _prefixed_tool_name(None, "search_knowledge") == "search_knowledge"
+
+
+def test_mcp_tool_to_openai_uses_idempotent_prefix():
+    """Schema name and lookup key agree for an already-namespaced tool."""
+    from tool_injection import _mcp_tool_to_openai
+
+    class _Tool:
+        name = "tc_create_timesheet"
+        description = "Create a timesheet entry"
+        inputSchema = {"type": "object", "properties": {}}
+
+    schema = _mcp_tool_to_openai(_Tool(), "tc")
+    assert schema["function"]["name"] == "tc_create_timesheet"
+
+
 # ── _mcp_headers auth logic tests ────────────────────────────
 
 

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -6,11 +6,13 @@ prefixes them with server name, and routes tool calls to the correct server.
 import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
 
+import httpx2
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 import config
 from mcp_config import McpServerConfig, load_mcp_servers
@@ -96,7 +98,7 @@ def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
         "function": {
             "name": prefixed_name,
             "description": tool.description or "",
-            "parameters": tool.inputSchema or {"type": "object"},
+            "parameters": tool.input_schema or {"type": "object"},
         },
     }
 
@@ -133,6 +135,24 @@ def _describe_exception(exc: BaseException) -> str:
         message = " ".join(str(leaf).split())
         parts.append(f"{type(leaf).__name__}: {message}" if message else type(leaf).__name__)
     return "; ".join(parts) if parts else type(exc).__name__
+
+
+@asynccontextmanager
+async def _mcp_session(url: str, headers: dict[str, str]):
+    """Open an initialised MCP ClientSession over streamable HTTP.
+
+    mcp 2.x dropped the `headers=` argument: auth now rides on a caller-supplied
+    HTTP client. That client MUST be httpx2 — passing a plain httpx client is
+    accepted but silently stops delivering server-initiated messages instead of
+    raising, which on this path would break bearer auth without any error.
+    """
+    async with httpx2.AsyncClient(headers=headers) as http_client:
+        async with streamable_http_client(url, http_client=http_client) as (
+            read_stream, write_stream,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
 
 
 class ToolInjector:
@@ -210,24 +230,20 @@ class ToolInjector:
         headers = _mcp_headers(server)
         tools: dict[str, ToolEntry] = {}
 
-        async with streamablehttp_client(server.url, headers=headers) as (
-            read_stream, write_stream, _,
-        ):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                result = await session.list_tools()
+        async with _mcp_session(server.url, headers) as session:
+            result = await session.list_tools()
 
-                for tool in result.tools:
-                    # Apply whitelist filter
-                    if server.tool_whitelist and tool.name not in server.tool_whitelist:
-                        continue
-                    prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
-                    tools[prefixed_name] = ToolEntry(
-                        server_name=server.name,
-                        original_name=tool.name,
-                        schema=_mcp_tool_to_openai(tool, server.prefix),
-                        server_config=server,
-                    )
+            for tool in result.tools:
+                # Apply whitelist filter
+                if server.tool_whitelist and tool.name not in server.tool_whitelist:
+                    continue
+                prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
+                tools[prefixed_name] = ToolEntry(
+                    server_name=server.name,
+                    original_name=tool.name,
+                    schema=_mcp_tool_to_openai(tool, server.prefix),
+                    server_config=server,
+                )
 
         return tools
 
@@ -309,14 +325,10 @@ class ToolInjector:
         """
         headers = _mcp_headers(entry.server_config, user_token=user_token, client_headers=client_headers)
 
-        async with streamablehttp_client(
-            entry.server_config.url, headers=headers,
-        ) as (read_stream, write_stream, _):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                result = await session.call_tool(entry.original_name, arguments)
-                texts = []
-                for content in result.content:
-                    if hasattr(content, "text"):
-                        texts.append(content.text)
-                return "\n".join(texts) if texts else str(result.content)
+        async with _mcp_session(entry.server_config.url, headers) as session:
+            result = await session.call_tool(entry.original_name, arguments)
+            texts = []
+            for content in result.content:
+                if hasattr(content, "text"):
+                    texts.append(content.text)
+            return "\n".join(texts) if texts else str(result.content)

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -85,6 +85,40 @@ def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
     }
 
 
+def _leaf_exceptions(exc: BaseException) -> list[BaseException]:
+    """Flatten a possibly-nested ExceptionGroup into its leaf exceptions.
+
+    Groups can contain groups, so this recurses. A plain exception is its own
+    only leaf.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        for sub in exc.exceptions:
+            leaves.extend(_leaf_exceptions(sub))
+        return leaves
+    return [exc]
+
+
+def _describe_exception(exc: BaseException) -> str:
+    """Render an exception as `Type: message` for a single log line.
+
+    The MCP streamable-http client runs its read/write pumps inside an anyio
+    task group, so a failed connection surfaces as an ExceptionGroup whose own
+    str() is the useless "unhandled errors in a TaskGroup (1 sub-exception)" —
+    the HTTP status, auth rejection or connection error that actually broke
+    discovery sits in the sub-exceptions. Report the leaves instead, so the
+    warning names the cause without needing the full traceback.
+    """
+    parts: list[str] = []
+    for leaf in _leaf_exceptions(exc):
+        # httpx spreads its messages over several lines ("Client error '401
+        # Unauthorized' …\nFor more information check: …"); collapse the
+        # whitespace so one failure stays one log line.
+        message = " ".join(str(leaf).split())
+        parts.append(f"{type(leaf).__name__}: {message}" if message else type(leaf).__name__)
+    return "; ".join(parts) if parts else type(exc).__name__
+
+
 class ToolInjector:
     """Discovers tools from multiple MCP servers and injects them into LLM requests."""
 
@@ -138,10 +172,13 @@ class ToolInjector:
                 )
             except Exception as e:
                 self._server_status[server.name] = False
+                cause = _describe_exception(e)
                 if server.required:
-                    log.error("Required server '%s' unreachable: %s", server.name, e)
+                    log.error("Required server '%s' unreachable: %s", server.name, cause)
                 else:
-                    log.warning("Optional server '%s' unreachable: %s", server.name, e)
+                    log.warning("Optional server '%s' unreachable: %s", server.name, cause)
+                # Full traceback only at debug level, so the line above stays readable.
+                log.debug("Discovery failure for server '%s'", server.name, exc_info=True)
 
         if new_tools:
             self._tools = new_tools

--- a/pb-proxy/tool_injection.py
+++ b/pb-proxy/tool_injection.py
@@ -72,9 +72,25 @@ def _mcp_headers(
     return headers
 
 
+def _prefixed_tool_name(prefix: str | None, name: str) -> str:
+    """Namespace an MCP tool name with its server prefix.
+
+    Idempotent: a server that already namespaces its own tools keeps the
+    names it publishes. timecockpit-mcp, for example, names every tool
+    `tc_…`, so the `prefix: tc` entry yields `tc_list_timesheets` rather
+    than `tc_tc_list_timesheets` — which is what the LLM (and the skills
+    and prompts written against those names) expects. Tools that are not
+    already namespaced still get the prefix, so names stay unique across
+    servers.
+    """
+    if not prefix or name.startswith(f"{prefix}_"):
+        return name
+    return f"{prefix}_{name}"
+
+
 def _mcp_tool_to_openai(tool: Any, prefix: str) -> dict:
     """Convert an MCP Tool to OpenAI function-calling format with prefix."""
-    prefixed_name = f"{prefix}_{tool.name}" if prefix else tool.name
+    prefixed_name = _prefixed_tool_name(prefix, tool.name)
     return {
         "type": "function",
         "function": {
@@ -168,7 +184,7 @@ class ToolInjector:
                     # Apply whitelist filter
                     if server.tool_whitelist and tool.name not in server.tool_whitelist:
                         continue
-                    prefixed_name = f"{server.prefix}_{tool.name}" if server.prefix else tool.name
+                    prefixed_name = _prefixed_tool_name(server.prefix, tool.name)
                     tools[prefixed_name] = ToolEntry(
                         server_name=server.name,
                         original_name=tool.name,

--- a/reranker/requirements.txt
+++ b/reranker/requirements.txt
@@ -1,7 +1,7 @@
 # Exact pins (supply-chain hardening) — see CLAUDE.md "Dependency Pinning".
 # Dependabot proposes bumps; every change is reviewed in a PR.
 fastapi==0.141.1
-uvicorn[standard]==0.52.2
+uvicorn[standard]==0.52.3
 sentence-transformers==5.7.0
 torch==2.13.0
 pydantic==2.13.4

--- a/shared/telemetry.py
+++ b/shared/telemetry.py
@@ -153,6 +153,17 @@ def setup_auto_instrumentation(app: Any = None) -> None:
     except ImportError:
         log.debug("opentelemetry-instrumentation-httpx not installed")
 
+    # The MCP SDK (2.x) speaks httpx2, which the httpx instrumentor above does
+    # not cover. Without this the pb-proxy → mcp-server hop loses its parent
+    # span and tool calls surface as orphan traces in Tempo. Only mcp-server and
+    # pb-proxy pull httpx2 in (via mcp), so absence here is normal, not an error.
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPX2ClientInstrumentor
+        HTTPX2ClientInstrumentor().instrument()
+        log.info("httpx2 auto-instrumentation enabled (traceparent propagation)")
+    except Exception as e:
+        log.debug("httpx2 auto-instrumentation unavailable: %s", e)
+
     if app is not None:
         try:
             from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor


### PR DESCRIPTION
Release merge for **v0.12.0**. Tag is pushed on `master` after this lands, which triggers `release.yml` (build + push 5 images to GHCR + GitHub Release).

`development` is 21 commits ahead of `master`. Minor rather than patch because the MCP SDK 2.0 port changes handler signatures and swaps the HTTP stack to httpx2.

## Contents

| PR | Change |
|---|---|
| #252 | Port `mcp-server` + `pb-proxy` to MCP Python SDK 2.0 (`mcp==2.0.0`, httpx2, `on_list_tools`/`on_call_tool`) |
| #253 | Fix `reranker` + `pb-proxy` healthchecks — `curl` is absent from both images |
| #251 | Log the real cause of MCP discovery failures (flatten `ExceptionGroup`) |
| #250 | Stop doubling tool names for self-namespacing MCP servers |
| #247 | uvicorn 0.52.2 → 0.52.3 across all four services |
| #242 | Make migrations 001–008 idempotent |
| #241 | Pin all direct dependencies to exact versions |
| #223 / #237 | actions/checkout 6 → 7, actions/setup-python 6 → 7 |
| #175 / #176 | Claude Desktop coverage spec + audit-mirror plan refresh (docs only) |

## Verification

Beyond per-PR CI, the merged state was validated directly, since `development` pushes do not trigger CI:

- Full CI-equivalent suite locally against merged `development`: **1129 passed, 20 skipped**, coverage 70.94% ≥ 68% threshold
- Pin consistency across services: `uvicorn[standard]==0.52.3` ×4, `mcp==2.0.0` ×2, `httpx2==2.10.0`
- Healthcheck fix verified end-to-end: `pb-reranker` and `pb-proxy` both report `healthy` via `docker inspect --format '{{.State.Health.Status}}'`, `Restarts=0`

## Housekeeping in this cycle

22 stale Dependabot PRs were closed rather than merged. After #241 moved every `requirements*.txt` to exact pins, the older `>=`-style PRs would each have replaced a newer exact pin with an older lower bound — a downgrade plus a rollback of the pinning. #245/#246 (mcp 2.0.0 without the code port) were superseded by #252, and #244/#248/#249 by #247, which bumps uvicorn in all four services at once instead of one directory at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)