### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-17
+
+### Fixed
+
+- **Outbound calls were indistinguishable in traces** — the httpx
+  instrumentation names client spans after the HTTP method alone, so every
+  dependency a service talks to collapsed into two spans, `GET` and `POST`. A
+  trace showed that a call happened but not who was called, which is the main
+  thing an outbound hop is worth recording. `shared/telemetry.py` now registers a
+  `request_hook` that renames them to `<METHOD> <host><path>`; there is no
+  span-name callback in this instrumentation, so the hook is the supported way.
+  Numeric and UUID path segments are generalised to `/{id}`, because span names
+  are a dimension for span-to-metric connectors and an id there costs one series
+  per record. The async client path needs its own coroutine wrapper: the
+  instrumentation validates that hook with `iscoroutinefunction` and silently
+  drops a plain function, so passing the sync hook would have renamed sync calls
+  while leaving async ones bare — covered by a test.
+
+
 ## [0.12.0] - 2026-08-17
 
 ### Security
@@ -60,20 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Outbound TLS (Certificate Trust)" in `docs/deployment.md`.
 
 ### Fixed
-
-- **Outbound calls were indistinguishable in traces** — the httpx
-  instrumentation names client spans after the HTTP method alone, so every
-  dependency a service talks to collapsed into two spans, `GET` and `POST`. A
-  trace showed that a call happened but not who was called, which is the main
-  thing an outbound hop is worth recording. `shared/telemetry.py` now registers a
-  `request_hook` that renames them to `<METHOD> <host><path>`; there is no
-  span-name callback in this instrumentation, so the hook is the supported way.
-  Numeric and UUID path segments are generalised to `/{id}`, because span names
-  are a dimension for span-to-metric connectors and an id there costs one series
-  per record. The async client path needs its own coroutine wrapper: the
-  instrumentation validates that hook with `iscoroutinefunction` and silently
-  drops a plain function, so passing the sync hook would have renamed sync calls
-  while leaving async ones bare — covered by a test.
 
 - **CI red since late July** — `mcp[server]>=1.27.1` resolved to `mcp 2.0.0`,
   whose API drops the `Server.list_tools()` decorator used in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Outbound calls were indistinguishable in traces** — the httpx
+  instrumentation names client spans after the HTTP method alone, so every
+  dependency a service talks to collapsed into two spans, `GET` and `POST`. A
+  trace showed that a call happened but not who was called, which is the main
+  thing an outbound hop is worth recording. `shared/telemetry.py` now registers a
+  `request_hook` that renames them to `<METHOD> <host><path>`; there is no
+  span-name callback in this instrumentation, so the hook is the supported way.
+  Numeric and UUID path segments are generalised to `/{id}`, because span names
+  are a dimension for span-to-metric connectors and an id there costs one series
+  per record. The async client path needs its own coroutine wrapper: the
+  instrumentation validates that hook with `iscoroutinefunction` and silently
+  drops a plain function, so passing the sync hook would have renamed sync calls
+  while leaving async ones bare — covered by a test.
+
 - **CI red since late July** — `mcp[server]>=1.27.1` resolved to `mcp 2.0.0`,
   whose API drops the `Server.list_tools()` decorator used in
   `mcp-server/server.py` and `streamablehttp_client` used in

--- a/shared/telemetry.py
+++ b/shared/telemetry.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+import re
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -139,6 +140,62 @@ def init_telemetry(service_name: str) -> Any:
         return None
 
 
+# Path segments that would otherwise make every call its own span name: numeric
+# ids and UUIDs. Span names are a metric dimension for span-to-metric
+# connectors, so an un-generalised id there costs one series per record.
+_CLIENT_SPAN_ID_SEGMENT = re.compile(
+    r"/(?:\d+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?=/|$)"
+)
+
+
+def _name_client_span(span: Any, request: Any) -> None:
+    """Rename an httpx client span from `<METHOD>` to `<METHOD> <host><path>`.
+
+    The instrumentation names client spans after the HTTP method alone, which is
+    what the HTTP semantic conventions prescribe when no URL template is known.
+    For a service whose outbound calls all use plain paths that collapses every
+    dependency into two buckets, `GET` and `POST`: a trace then shows that a call
+    happened but not who was called, which is the one thing worth knowing about
+    an outbound hop.
+
+    Registered as a `request_hook`, because this instrumentation offers no
+    span-name callback. Ids in the path are generalised (see above).
+
+    Never raises: the hook runs inside the request path, so a naming problem must
+    not be able to fail the request it is describing.
+    """
+    if span is None or not span.is_recording():
+        return
+    try:
+        method = request.method
+        if isinstance(method, bytes):
+            method = method.decode()
+        url = request.url
+        if isinstance(url, tuple):
+            # Transport-level hook: (scheme, host, port, path), each bytes.
+            _scheme, host, _port, path = url
+            host = host.decode() if isinstance(host, bytes) else host
+            path = path.decode() if isinstance(path, bytes) else path
+        else:
+            # httpx.URL
+            host, path = url.host, url.path
+        span.update_name(f"{method} {host}{_CLIENT_SPAN_ID_SEGMENT.sub('/{id}', path)}")
+    except Exception as e:  # pragma: no cover - defensive, see docstring
+        log.debug("could not rename httpx client span: %s", e)
+
+
+async def _name_client_span_async(span: Any, request: Any) -> None:
+    """Async variant of `_name_client_span`, needed as a separate coroutine.
+
+    The instrumentation checks the async hook with `iscoroutinefunction` and
+    silently sets it to `None` when it is a plain function. Passing the sync hook
+    for `async_request_hook` therefore looks accepted and renames nothing, so the
+    async client path would keep the bare `<METHOD>` names while the sync path
+    got proper ones.
+    """
+    _name_client_span(span, request)
+
+
 def setup_auto_instrumentation(app: Any = None) -> None:
     """Set up auto-instrumentation for FastAPI and httpx.
 
@@ -148,7 +205,10 @@ def setup_auto_instrumentation(app: Any = None) -> None:
         return
     try:
         from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-        HTTPXClientInstrumentor().instrument()
+        HTTPXClientInstrumentor().instrument(
+            request_hook=_name_client_span,
+            async_request_hook=_name_client_span_async,
+        )
         log.info("httpx auto-instrumentation enabled (traceparent propagation)")
     except ImportError:
         log.debug("opentelemetry-instrumentation-httpx not installed")
@@ -159,7 +219,10 @@ def setup_auto_instrumentation(app: Any = None) -> None:
     # pb-proxy pull httpx2 in (via mcp), so absence here is normal, not an error.
     try:
         from opentelemetry.instrumentation.httpx import HTTPX2ClientInstrumentor
-        HTTPX2ClientInstrumentor().instrument()
+        HTTPX2ClientInstrumentor().instrument(
+            request_hook=_name_client_span,
+            async_request_hook=_name_client_span_async,
+        )
         log.info("httpx2 auto-instrumentation enabled (traceparent propagation)")
     except Exception as e:
         log.debug("httpx2 auto-instrumentation unavailable: %s", e)

--- a/shared/tests/test_telemetry.py
+++ b/shared/tests/test_telemetry.py
@@ -1,6 +1,7 @@
 # shared/tests/test_telemetry.py
 """Tests for shared telemetry module."""
 import time
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -85,6 +86,89 @@ class TestInitTelemetry:
         else:
             # Graceful degradation: returns None when OTel not installed
             assert tracer is None
+
+
+class TestNameClientSpan:
+    """The request_hook that renames httpx client spans.
+
+    The instrumentation names them after the method alone, so without this hook
+    every outbound dependency collapses into `GET` and `POST`.
+    """
+
+    def _span(self):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        return span
+
+    def test_uses_host_and_path_from_transport_tuple(self):
+        from shared.telemetry import _name_client_span
+        span = self._span()
+        request = MagicMock()
+        request.method = b"GET"
+        request.url = (b"http", b"example.internal", 8080, b"/readyz")
+        _name_client_span(span, request)
+        span.update_name.assert_called_once_with("GET example.internal/readyz")
+
+    def test_uses_host_and_path_from_url_object(self):
+        from shared.telemetry import _name_client_span
+        span = self._span()
+        request = MagicMock()
+        request.method = "POST"
+        request.url = SimpleNamespace(host="example.internal", path="/v1/query")
+        _name_client_span(span, request)
+        span.update_name.assert_called_once_with("POST example.internal/v1/query")
+
+    def test_generalises_numeric_and_uuid_segments(self):
+        from shared.telemetry import _name_client_span
+        for path, expected in (
+            ("/items/12345", "/items/{id}"),
+            ("/runs/8b1f4c2e-1111-2222-3333-444455556666/log", "/runs/{id}/log"),
+            ("/v1/models", "/v1/models"),
+        ):
+            span = self._span()
+            request = MagicMock()
+            request.method = "GET"
+            request.url = SimpleNamespace(host="h", path=path)
+            _name_client_span(span, request)
+            span.update_name.assert_called_once_with(f"GET h{expected}")
+
+    def test_ignores_non_recording_span(self):
+        from shared.telemetry import _name_client_span
+        span = MagicMock()
+        span.is_recording.return_value = False
+        _name_client_span(span, MagicMock())
+        span.update_name.assert_not_called()
+
+    def test_async_hook_is_a_coroutine_function(self):
+        """Guards a silent-failure trap in the instrumentation.
+
+        It validates the async hook with `iscoroutinefunction` and sets it to
+        `None` when it is a plain function -- no error, just no renaming on the
+        async client path. If this ever collapses back into one plain function,
+        this test is what catches it.
+        """
+        import asyncio
+        from shared.telemetry import _name_client_span_async
+        assert asyncio.iscoroutinefunction(_name_client_span_async)
+
+    def test_async_hook_delegates_to_the_sync_one(self):
+        import asyncio
+        from shared.telemetry import _name_client_span_async
+        span = self._span()
+        request = MagicMock()
+        request.method = "GET"
+        request.url = SimpleNamespace(host="example.internal", path="/readyz")
+        asyncio.run(_name_client_span_async(span, request))
+        span.update_name.assert_called_once_with("GET example.internal/readyz")
+
+    def test_never_raises_on_unexpected_request(self):
+        """A naming problem must not fail the request the span describes."""
+        from shared.telemetry import _name_client_span
+        span = self._span()
+        broken = MagicMock()
+        type(broken).method = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        _name_client_span(span, broken)
+        span.update_name.assert_not_called()
 
 
 class TestTraceOperation:


### PR DESCRIPTION
Release merge for **v0.12.1**.

Names httpx client spans after the target instead of the HTTP method alone, so
outbound dependencies become distinguishable in traces (#255). Includes the
coroutine wrapper the async client path needs — the instrumentation validates
that hook with `iscoroutinefunction` and silently drops a plain function, so
without it sync calls would be renamed and async ones left bare.

Also moves the changelog entry into its own `[0.12.1]` section; it had landed
under `[0.12.0]`, which was already tagged when the branch was cut.

No migrations, no new environment variables.
