### PR TITLE
ci(security-scan): audit every requirements file and surface the result

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -106,16 +106,68 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Constrained rather than pinned inline: requirements-dev.txt already
+      # carries the pins, and an unpinned `pip install` of the scanner is the
+      # exact supply-chain hole this job exists to find — see CLAUDE.md
+      # "Dependency Pinning".
       - name: Install scanning tools
-        run: pip install pip-audit bandit
+        run: pip install --constraint requirements-dev.txt pip-audit bandit
 
+      # pip-audit exits 1 when it finds something. The four invocations used to
+      # be four plain lines under the default `bash -e`, so the first finding
+      # aborted the step and the files after it were never audited at all —
+      # while `continue-on-error` reported the job green. That is worse than no
+      # audit, because the step claims coverage it did not deliver (#257).
+      #
+      # Every file is audited now and the statuses are collected. Coverage comes
+      # from `git ls-files` instead of a hand-kept list, so a newly added
+      # requirements file cannot be silently left out by being forgotten here —
+      # the same gap `.github/dependabot.yml` guards against for updates.
+      # `--strict` makes a dependency that could not be resolved a failure
+      # rather than a skipped line in the middle of a passing run.
+      #
+      # `continue-on-error` stays: a CVE published in a transitive dependency
+      # should not block every unrelated PR. It no longer hides the finding —
+      # the result lands in the job summary and raises an annotation, so a
+      # finding is distinguishable from a clean run at a glance.
       - name: Dependency audit (pip-audit)
         continue-on-error: true
         run: |
-          pip-audit -r mcp-server/requirements.txt
-          pip-audit -r ingestion/requirements.txt
-          pip-audit -r pb-proxy/requirements.txt
-          pip-audit -r worker/requirements.txt
+          status=0
+          rows=$(mktemp)
+          details=$(mktemp)
+
+          while IFS= read -r req; do
+            log=$(mktemp)
+            echo "::group::pip-audit $req"
+            if pip-audit --strict -r "$req" >"$log" 2>&1; then
+              printf '| `%s` | no known vulnerabilities |\n' "$req" >>"$rows"
+            else
+              status=1
+              printf '| `%s` | :warning: **findings** |\n' "$req" >>"$rows"
+              {
+                printf '\n<details><summary><code>%s</code></summary>\n\n```\n' "$req"
+                cat "$log"
+                printf '```\n\n</details>\n'
+              } >>"$details"
+            fi
+            cat "$log"
+            echo "::endgroup::"
+          done < <(git ls-files '*requirements*.txt')
+
+          {
+            echo "## Dependency audit (pip-audit)"
+            echo
+            echo "| requirements file | result |"
+            echo "| --- | --- |"
+            cat "$rows"
+            cat "$details"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning title=Dependency audit::pip-audit reported findings — see the job summary for the affected requirements files."
+          fi
+          exit "$status"
 
       - name: Static security scan (bandit)
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The dependency audit skipped files and still reported success** — the
+  `security-scan` job ran four `pip-audit` invocations as four plain lines in a
+  `run:` block. GitHub runs those under `bash -e`, and `pip-audit` exits 1 when
+  it finds something, so a finding in the second file ended the step before the
+  third and fourth were ever audited. `continue-on-error: true` then swallowed
+  the failure and the check went green. Two requirement files were therefore
+  unaudited while the job actively signalled that they had been checked — worse
+  than having no audit at all, because nobody goes looking. The step now audits
+  each file, collects the statuses instead of aborting, and exits with the
+  collected result. The file list comes from `git ls-files '*requirements*.txt'`
+  rather than being spelled out, which also closes the four files that were
+  never in the list (`reranker`, `demo`, `requirements-dev`, the Office 365
+  adapter), and means a requirements file added later cannot be left out by
+  being forgotten. `--strict` turns a dependency that could not be resolved into
+  a reported failure rather than a skipped line inside a passing run.
+  `continue-on-error` stays — a CVE published in a transitive dependency should
+  not block every unrelated PR — but a finding is no longer indistinguishable
+  from a clean run: the per-file result is written to the job summary with the
+  audit output inlined, and a workflow annotation points at it. The scanners
+  themselves are installed with `--constraint requirements-dev.txt` instead of
+  unpinned, since an unpinned `pip install` in CI is the supply-chain hole this
+  job exists to find. (#257)
+
 ## [0.12.1] - 2026-08-17
 
 ### Fixed


### PR DESCRIPTION
Closes #257.

## Problem

The `security-scan` job ran four `pip-audit` invocations as four plain lines in
one `run:` block. GitHub executes those under `bash -e`, and `pip-audit` exits 1
when it finds something — so the finding in `ingestion/requirements.txt` ended
the step, and `pb-proxy` and `worker` were never audited. `continue-on-error:
true` then hid that the step had failed, and the check went green.

Two files unaudited, while the job actively signalled that they were checked.

## Changes

**Audit every file, collect the result.** The loop no longer aborts on the first
finding; each file is audited and the collected status is the step's exit code.

**Coverage from `git ls-files '*requirements*.txt'`.** The hand-kept list had
four files missing from it that are never audited today — `reranker`, `demo`,
`requirements-dev` and the Office 365 adapter — all of them watched by
Dependabot. Deriving the list means a file added later cannot be left out by
being forgotten, which is the same failure mode `.github/dependabot.yml`
documents for updates.

**`--strict`.** A dependency that cannot be resolved is now a reported failure
instead of a skipped line in the middle of a passing run — the same class of
problem as the one this PR fixes.

**Visibility, answering the issue's open question.** `continue-on-error: true`
stays: a CVE published in a transitive dependency should not block every
unrelated PR. But the finding is no longer invisible — the per-file result goes
to `$GITHUB_STEP_SUMMARY` as a table with the audit output inlined in a
`<details>` block, and a `::warning::` annotation points at it. A finding and a
clean run are now distinguishable at a glance, which they were not before.

**Scanners installed pinned.** `pip install --constraint requirements-dev.txt
pip-audit bandit` instead of unpinned. `requirements-dev.txt` already carries
`pip-audit==2.10.1` and `bandit==1.9.4`; an unpinned `pip install` in CI is the
exact supply-chain hole this job exists to find (CLAUDE.md, "Dependency
Pinning"). Constraint rather than a second inline pin, so there is one place to
update.

## Verification

The step script was extracted from the workflow and run under `bash -e` against
a stub `pip-audit` that fails on `ingestion/requirements.txt` only — mirroring
the real finding:

- all 8 tracked requirements files audited, the mid-list failure does not abort
- step exits 1, summary table marks exactly the failing file, its output inlined
- annotation raised
- clean-case run: 8 files, exit 0, no annotation

The workflow YAML parses and the `security-scan` step list is unchanged apart
from this step.

## Note

The finding this used to hide is tracked separately in #258 and is addressed in
a follow-up PR, in the order the issue suggests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
