### PR TITLE
docs(security): assess the cryptography 48.0.1 advisories and accept them

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -137,10 +137,23 @@ jobs:
           rows=$(mktemp)
           details=$(mktemp)
 
+          # Advisories assessed as not reachable from this codebase. Each one is
+          # an entry in docs/dependency-audit.md carrying the assessment, a
+          # review date and the triggers that reopen it — do not add a line here
+          # without adding the entry there. Suppressed rather than tolerated,
+          # because a summary that always shows the same findings trains
+          # everyone to skip it, and this audit is only worth keeping
+          # non-blocking as long as a reported finding means something new.
+          ignore=(
+            --ignore-vuln PYSEC-2026-3552  # cryptography: PKCS#7 decrypt oracle
+            --ignore-vuln PYSEC-2026-3553  # cryptography: X.509 path-building DoS
+            --ignore-vuln PYSEC-2026-3554  # cryptography: X.509 wildcard SAN escape
+          )
+
           while IFS= read -r req; do
             log=$(mktemp)
             echo "::group::pip-audit $req"
-            if pip-audit --strict -r "$req" >"$log" 2>&1; then
+            if pip-audit --strict "${ignore[@]}" -r "$req" >"$log" 2>&1; then
               printf '| `%s` | no known vulnerabilities |\n' "$req" >>"$rows"
             else
               status=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Three `cryptography` advisories assessed and accepted, with an expiry** —
+  `cryptography==48.0.1` carries PYSEC-2026-3552, -3553 and -3554. It is
+  transitive, so no pin fixes it: `presidio-anonymizer==2.2.364` declares
+  `cryptography>=48.0.1,<49.0.0` while the fixes ship in 49.0.0 and 50.0.0, and
+  `2.2.364` is the latest release on PyPI — pinning higher yields a resolver
+  conflict, not a fix. What the cap does do is scope the blast radius:
+  `pb-ingestion` is the only image installing `presidio-anonymizer` and
+  therefore the only one resolving `cryptography` to 48.0.1. All three
+  advisories are confined to two API surfaces — `pkcs7_decrypt_*` and
+  `cryptography.x509.verification` — and neither is reachable here. The three
+  packages that pull the library in use it for something else entirely: RS256
+  signing of the GitHub App assertion (`pyjwt[crypto]`), AES operators that the
+  PII scanner never configures because it pseudonymises by direct replacement
+  (`presidio-anonymizer`), and an Entra ID client-secret grant that parses no
+  certificate (`msal`). Outbound TLS verification runs through `ssl`/OpenSSL and
+  `certifi`, not through this library's verifier; inbound TLS is terminated by
+  Caddy, which is Go. Recorded as an accepted risk in the new
+  `docs/dependency-audit.md` with a review date of 2026-11-18 and the four
+  conditions that reopen it, and suppressed in the audit step via
+  `--ignore-vuln` so that a reported finding continues to mean something new
+  rather than the same three lines every run. (#258)
+
 ### Fixed
 
 - **The dependency audit skipped files and still reported success** — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,7 +617,12 @@ reviewed event instead of an automatic one. Upper bounds at the next major
   security patches, which is strictly worse than an open range.
 - Transitive dependencies stay unpinned. Closing that gap needs a lockfile with
   hashes (`pip-compile --generate-hashes` plus `pip install --require-hashes`)
-  and a rewrite of the Dockerfile and CI install steps — not done yet.
+  and a rewrite of the Dockerfile and CI install steps — not done yet. It also
+  means a vulnerable transitive package cannot always be fixed by a pin: an
+  intermediate dependency may cap it below the fix. See
+  `docs/dependency-audit.md` for how those are assessed, and for the ledger of
+  advisories accepted with a review date — a suppression in the audit step
+  without an entry there is not allowed.
 - When changing a version, resolve the whole set at once
   (`pip install --dry-run --report`) so shared packages (httpx, pydantic,
   OpenTelemetry, …) stay identical across services: CI installs every

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,3 +23,12 @@ If you discover a security vulnerability in Powerbrain, please report it respons
 ## Scope
 
 This policy covers the Powerbrain codebase and its Docker Compose deployment. Third-party dependencies (Qdrant, PostgreSQL, OPA, Ollama) should be reported to their respective maintainers.
+
+## Dependency Advisories
+
+Every pull request audits all Python requirement files with `pip-audit`. Where an
+advisory has no upgrade path and the vulnerable code is not reachable from this
+codebase, it is accepted rather than fixed — with the assessment, a review date
+and the conditions that reopen it recorded in
+[docs/dependency-audit.md](docs/dependency-audit.md). If you believe an accepted
+entry is wrong, that is worth reporting through the process above.

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -1,0 +1,129 @@
+# Dependency Audit and Accepted Risks
+
+**Scope:** how Powerbrain audits its Python dependencies, and the ledger of
+advisories that were assessed and consciously accepted rather than fixed.
+**Status:** living document — every accepted entry carries a review date and the
+triggers that reopen it.
+
+## How the audit runs
+
+The `security-scan` job in `.github/workflows/pr-validate.yml` runs
+`pip-audit --strict` over **every** tracked `requirements*.txt`, discovered via
+`git ls-files` rather than a hand-kept list. The per-file result is written to
+the GitHub job summary, and a finding raises a workflow annotation.
+
+The step is `continue-on-error: true`. A CVE published in a transitive
+dependency is not something a PR author can fix, and blocking every unrelated PR
+on it converts a security signal into an obstacle to route around. The trade
+only works if a finding is actually visible, which is why the result goes to the
+job summary instead of a collapsed log group (see [#257]).
+
+A finding is then triaged into exactly one of two outcomes:
+
+1. **Fix it** — bump the pin, or bump the direct dependency that pulls the
+   vulnerable package in. This is the default.
+2. **Accept it** — only when the vulnerable code is not reachable from this
+   codebase *and* there is no upgrade path. It gets an entry below, a
+   `--ignore-vuln` suppression in the workflow, a review date, and the
+   conditions that reopen it.
+
+Suppression is what keeps the audit readable: with known-and-assessed advisories
+filtered out, anything the summary reports is new and unassessed. An audit that
+always shows the same three findings trains everyone to skip it.
+
+## Accepted risks
+
+### A-01 — `cryptography` 48.0.1, three advisories, capped by `presidio-anonymizer`
+
+| Field | Value |
+| --- | --- |
+| Package | `cryptography==48.0.1` (transitive) |
+| Advisories | PYSEC-2026-3552 (CVE-2026-69247, GHSA-g6cj-pr64-35w5)<br>PYSEC-2026-3553 (CVE-2026-69249, GHSA-jwv3-5hgf-82ww)<br>PYSEC-2026-3554 (CVE-2026-69248, GHSA-m2h6-j472-rp4c) |
+| Affected image | `pb-ingestion` only |
+| Assessed | 2026-08-18 |
+| Decision | Accepted — vulnerable APIs not reachable |
+| Review by | 2026-11-18, or earlier on any trigger below |
+| Issue | [#258] |
+
+#### Why a pin does not fix it
+
+`cryptography` appears in no `requirements*.txt` — it is pulled in transitively.
+Three packages declare it:
+
+| Declaring package | Constraint | Where |
+| --- | --- | --- |
+| `presidio-anonymizer==2.2.364` | `cryptography>=48.0.1,<49.0.0` | `ingestion/requirements.txt` |
+| `pyjwt[crypto]==2.13.0` | `cryptography>=3.4.0` | `ingestion/requirements.txt` |
+| `msal==1.37.0` | `cryptography>=2.5,<51` | `ingestion/adapters/office365/requirements.txt` |
+
+The fixes ship in 49.0.0 (3553, 3554) and 50.0.0 (3552). `presidio-anonymizer`
+caps below 49, so pinning `cryptography` higher produces a resolver conflict
+rather than a fix. `2.2.364` was the latest release on PyPI when this was
+assessed and still carries the cap, so there is no upgrade path to wait for
+today.
+
+The cap is also what scopes the exposure: `pb-ingestion` is the only image that
+installs `presidio-anonymizer`, and therefore the only one that resolves
+`cryptography` to 48.0.1. Where nothing caps it, the resolver takes a fixed
+version.
+
+#### Exposure assessment
+
+All three advisories are confined to two API surfaces. Neither is used here:
+
+| Advisory | Vulnerable API | Reachable? |
+| --- | --- | --- |
+| PYSEC-2026-3552 — PKCS#7 `EnvelopedData` decryption leaks a Bleichenbacher oracle through distinguishable errors and timing | `pkcs7_decrypt_der`, `pkcs7_decrypt_pem`, `pkcs7_decrypt_smime` | **No** — no PKCS#7 decryption anywhere in the codebase. The advisory's error-path case additionally requires OpenSSL 3.0/3.1, LibreSSL or BoringSSL; the PyPI wheels link OpenSSL 3.2+, where implicit rejection removes it. |
+| PYSEC-2026-3553 — duplicate self-signed intermediates cause exponential path-building (DoS) | `cryptography.x509.verification` | **No** — no X.509 chain verification. |
+| PYSEC-2026-3554 — a wildcard DNS SAN escapes an intermediate CA's `permittedSubtrees` | `cryptography.x509.verification` | **No** — same as above. |
+
+What the three declaring packages actually use `cryptography` for, none of which
+touches those surfaces:
+
+- **`pyjwt[crypto]`** — RS256 signing of the GitHub App assertion in
+  [`ingestion/adapters/providers/github.py:203`](../ingestion/adapters/providers/github.py).
+  RSA signature primitives, and only on the opt-in `github_app` auth mode.
+- **`presidio-anonymizer`** — declares `cryptography` for its AES-based
+  `encrypt`/`decrypt` operators. `ingestion/pii_scanner.py` instantiates
+  `AnonymizerEngine()` but pseudonymises by direct replacement and never
+  configures the `encrypt` operator, so the AES path is not entered either.
+- **`msal`** — Entra ID authentication for the Office 365 adapter. The adapter
+  uses the `client_credentials` grant with a client secret
+  ([`graph_client.py:125`](../ingestion/adapters/office365/graph_client.py)),
+  not certificate credentials, so no certificate is parsed or validated.
+
+Certificate validation for the services' own outbound TLS goes through Python's
+`ssl` module against OpenSSL and `certifi`, not through `cryptography`'s
+verifier, so 3553 and 3554 are out of the path there as well. Inbound TLS is
+terminated by Caddy, which is Go and does not use this library at all.
+
+`.msg` and `.eml` attachments are the closest adjacent surface — they are parsed
+for their message structure by `markitdown`, with no key material available and
+no S/MIME decryption. That is why a change there is a review trigger below.
+
+#### Decision
+
+Accepted. The three advisories are suppressed in the audit step via
+`--ignore-vuln` so that anything the audit reports is new, and this entry
+records why.
+
+Suppression is not a fix: if any of the assumptions above changes, the risk is
+real again. Reopen this entry when any of the following happens:
+
+- **`presidio-anonymizer` ships a release that widens the `cryptography` cap** —
+  the actual fix. Bump it, let `cryptography` resolve to ≥50.0.0, remove all
+  three suppressions. Dependabot watches `/ingestion` weekly and will propose it.
+- **A new `cryptography` advisory appears** — it is not suppressed and surfaces
+  in the job summary on its own. Assess it fresh; do not assume this entry
+  covers it.
+- **The codebase starts verifying X.509 chains** — most plausibly by switching
+  the Office 365 adapter to certificate credentials, or by adding certificate
+  validation of any kind that goes through `cryptography.x509.verification`.
+  3553 and 3554 become reachable that day.
+- **The codebase starts decrypting PKCS#7 / S/MIME** — e.g. extending the `.msg`
+  or `.eml` extraction path to handle encrypted mail. 3552 becomes reachable.
+- **2026-11-18 passes** — re-check upstream regardless. An accepted risk with no
+  expiry is an unmonitored one.
+
+[#257]: https://github.com/nuetzliches/powerbrain/issues/257
+[#258]: https://github.com/nuetzliches/powerbrain/issues/258


### PR DESCRIPTION
Closes #258. Follows #259, in the order the issue suggests — without that fix, the next finding here goes unnoticed again.

## What the audit reports

`pip-audit -r ingestion/requirements.txt`, reproduced locally against
`pip-audit==2.10.1`:

```
Found 3 known vulnerabilities in 1 package
Name         Version ID              Fix Versions
cryptography 48.0.1  PYSEC-2026-3552 50.0.0
cryptography 48.0.1  PYSEC-2026-3553 49.0.0
cryptography 48.0.1  PYSEC-2026-3554 49.0.0
```

## Why there is nothing to bump

`cryptography` is transitive. Three packages declare it, and one of them caps it
below the fix:

| Declaring package | Constraint |
| --- | --- |
| `presidio-anonymizer==2.2.364` | `cryptography>=48.0.1,<49.0.0` ← the cap |
| `pyjwt[crypto]==2.13.0` | `cryptography>=3.4.0` |
| `msal==1.37.0` | `cryptography>=2.5,<51` |

The fixes ship in 49.0.0 and 50.0.0. `2.2.364` is the latest
`presidio-anonymizer` on PyPI (checked 2026-08-18) and still carries the cap, so
pinning `cryptography` higher yields a resolver conflict, not a fix, and there is
no upstream release to wait for today.

The cap does scope the exposure, though: `pb-ingestion` is the only image that
installs `presidio-anonymizer`, so it is the only one that resolves
`cryptography` to 48.0.1. Everywhere else the resolver takes a fixed version.

## Exposure assessment — option 2 from the issue

All three advisories are confined to two API surfaces, and neither is reachable:

| Advisory | Vulnerable API | Reachable? |
| --- | --- | --- |
| 3552 — PKCS#7 `EnvelopedData` Bleichenbacher oracle | `pkcs7_decrypt_der/_pem/_smime` | No — no PKCS#7 decryption in the codebase. The error-path case also needs OpenSSL 3.0/3.1, LibreSSL or BoringSSL; the PyPI wheels link OpenSSL 3.2+. |
| 3553 — path-building blowup (DoS) | `cryptography.x509.verification` | No — no X.509 chain verification. |
| 3554 — wildcard SAN escapes `permittedSubtrees` | `cryptography.x509.verification` | No — same. |

What the three declaring packages actually use the library for:

- **`pyjwt[crypto]`** — RS256 signing of the GitHub App assertion,
  `ingestion/adapters/providers/github.py:203`. RSA signing, opt-in `github_app`
  auth mode only.
- **`presidio-anonymizer`** — declares it for the AES `encrypt`/`decrypt`
  operators. `ingestion/pii_scanner.py` constructs `AnonymizerEngine()` but
  pseudonymises by direct replacement and never configures `encrypt`, so even
  the AES path is not entered.
- **`msal`** — Entra ID auth for the Office 365 adapter, which uses the
  `client_credentials` grant with a client secret
  (`graph_client.py:125`) — no certificate is parsed or validated.

Outbound TLS verification in the Python services runs through `ssl`/OpenSSL and
`certifi`, not this library's verifier, so 3553 and 3554 are out of that path
too. Inbound TLS is terminated by Caddy, which is Go.

## Decision

Accepted, with an expiry — not silently. New `docs/dependency-audit.md` records
how the audit is run and triaged, and carries the assessment as entry A-01 with
a review date of **2026-11-18** and four conditions that reopen it: presidio
widening the cap (the actual fix, Dependabot will propose it), any new
`cryptography` advisory, the codebase starting to verify X.509 chains (most
plausibly certificate credentials for Entra ID), and the codebase starting to
decrypt PKCS#7/S/MIME (most plausibly extending `.msg`/`.eml` extraction).

The three IDs are suppressed in the audit step via `--ignore-vuln`. That is the
point of the assessment: with #259 the audit is non-blocking but visible, and a
summary that reports the same three known findings on every run trains everyone
to skip it. Suppressing what has been assessed is what keeps "the audit reported
something" meaning "something new". The workflow comment says a suppression
without a ledger entry is not allowed, and CLAUDE.md now says the same next to
the pinning policy.

## Verification

- `pip-audit --strict -r ingestion/requirements.txt` → 3 findings, exit 1
- same command with the three `--ignore-vuln` flags → `No known vulnerabilities
  found, 3 ignored`, exit 0
- the step script extracted from the workflow and run under `bash -e` against a
  stub: flags reach every invocation, all 8 files audited, exit 0
- the other seven requirements files audit clean locally, including the four
  #259 newly covered — so after this PR the audit is green on its own merits
  rather than by suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
