### PR TITLE
ci(security-scan): resolve bandit's findings and surface its result

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -169,16 +169,112 @@ jobs:
           fi
           exit "$status"
 
+      # Same failure mode the audit above had (#257): bandit exits 1 on any
+      # finding, `continue-on-error` turns that back into a green check, and a
+      # finding becomes indistinguishable from a clean run unless somebody opens
+      # the log. The result goes to the job summary and raises annotations now.
+      #
+      # The step used to invoke bandit twice — once for the JSON artifact, once
+      # for console output. One run produces the JSON and the summary is
+      # rendered from it, so the uploaded artifact and what you read can no
+      # longer disagree.
+      #
+      # `continue-on-error` stays, for the same reason as the audit: a finding
+      # in code the PR did not touch should not block it. What makes that
+      # tolerable is that the expected steady state is zero — findings that were
+      # assessed and accepted carry a `# nosec Bxxx` marker with the reason at
+      # the point of use, and the summary reports how many were suppressed that
+      # way, so suppressions cannot quietly accumulate.
       - name: Static security scan (bandit)
         continue-on-error: true
         run: |
+          status=0
           bandit -r shared/ mcp-server/ ingestion/ reranker/ pb-proxy/ worker/ \
             -x '*/tests/*' \
             --severity-level medium \
-            -f json -o bandit-report.json || true
-          bandit -r shared/ mcp-server/ ingestion/ reranker/ pb-proxy/ worker/ \
-            -x '*/tests/*' \
-            --severity-level medium
+            -f json -o bandit-report.json || status=$?
+
+          # Rendered in Python rather than bash: the report is JSON, and the
+          # setup-python step above already put an interpreter on PATH.
+          python3 - "$status" <<'PY'
+          import json
+          import os
+          import sys
+
+          exit_status = int(sys.argv[1])
+
+          with open("bandit-report.json", encoding="utf-8") as fh:
+              report = json.load(fh)
+
+          results = report.get("results", [])
+          totals = report.get("metrics", {}).get("_totals", {})
+          suppressed = int(totals.get("skipped_tests", 0) or 0)
+          errors = report.get("errors", [])
+
+          def cell(text):
+              """Collapse whitespace and escape pipes so a message cannot break the table."""
+              return " ".join(str(text).split()).replace("|", "\\|")
+
+          out = ["## Static security scan (bandit)", ""]
+          if results:
+              out += [
+                  f"**{len(results)} finding(s)** at or above medium severity.",
+                  "",
+                  "| file | line | test | severity / confidence | issue |",
+                  "| --- | --- | --- | --- | --- |",
+              ]
+              out += [
+                  "| `{}` | {} | [{}]({}) | {} / {} | {} |".format(
+                      cell(r.get("filename")),
+                      r.get("line_number"),
+                      cell(r.get("test_id")),
+                      r.get("more_info"),
+                      cell(r.get("issue_severity")),
+                      cell(r.get("issue_confidence")),
+                      cell(r.get("issue_text")),
+                  )
+                  for r in results
+              ]
+          else:
+              out.append("No findings at or above medium severity.")
+
+          out += [
+              "",
+              f"{suppressed} finding(s) suppressed by reviewed `# nosec` markers "
+              "(see the reason next to each marker in the source).",
+          ]
+          if errors:
+              out += ["", "**Scan errors:**", "", "```", json.dumps(errors, indent=2), "```"]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write("\n".join(out) + "\n")
+
+          # File annotations attach each finding to its line in the PR view.
+          for r in results:
+              print("::warning file={},line={},title=bandit {}::{}".format(
+                  r.get("filename"), r.get("line_number"),
+                  r.get("test_id"), cell(r.get("issue_text")),
+              ))
+          if results:
+              print(
+                  "::warning title=Static security scan::bandit reported "
+                  f"{len(results)} finding(s) — see the job summary."
+              )
+          # A file bandit could not parse is a hole in the scan's coverage, and
+          # it does not show up as a finding — annotate it in its own right.
+          if errors:
+              print(
+                  "::warning title=Static security scan::bandit could not scan "
+                  f"{len(errors)} file(s) — see the job summary."
+              )
+          if exit_status != 0 and not results and not errors:
+              print(
+                  "::warning title=Static security scan::bandit exited "
+                  f"{exit_status} without reporting findings — the scan may not have run."
+              )
+          PY
+
+          exit "$status"
 
       - name: Upload bandit report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ composit-diff.html
 .coverage.*
 htmlcov/
 .pytest_cache/
+
+# bandit report — the security-scan job writes it into the workspace and uploads
+# it as an artifact; running the same scan locally drops it here too.
+bandit-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The static security scan failed on every run and reported green** — `bandit`
+  found 12 medium-severity issues and exited 1 each time, but the step is
+  `continue-on-error: true`, so the check stayed green and the output only
+  existed inside a collapsed log nobody opens. Same failure mode as the
+  dependency audit below, on the step that was left out of scope there. All 12
+  are now resolved rather than tolerated, so the run is clean and the next
+  finding is the only thing in it: four queries that interpolated an
+  already-clamped `LIMIT` bind it as a parameter instead (`review_pending`,
+  `export_audit_log`, both `list_incidents` branches), which removes two
+  findings outright and leaves one rule behind — these queries interpolate
+  validated identifiers and literal fragments, never a caller value. The
+  remaining ten carry a `# nosec Bxxx` marker with the reason next to it: seven
+  `B608` where the dynamic part is a `$n`-placeholder fragment or a
+  module-level constant (and, for Apache AGE, a cypher string that cannot be
+  parameterised at all, built only by helpers that run every label through
+  `_require_identifier()` and every value through `_escape_cypher_value()`), and
+  three `B104` where a containerised service binds its own interfaces so it is
+  reachable on `pb-net` — what reaches the host is a compose port-publishing
+  decision. The step itself gets the same treatment the audit got: it invoked
+  bandit twice, once for the JSON artifact and once for console output, so the
+  uploaded report and the text people read could disagree; it now runs once and
+  renders the summary from that JSON. Findings land in the job summary as a
+  table, each one also raising a file annotation on its line, and a scan error
+  or an unexplained non-zero exit annotates too — a file bandit cannot parse is
+  a hole in coverage that never appears as a finding. The summary reports the
+  suppression count on every run, including clean ones, so `# nosec` markers
+  cannot quietly accumulate. (#257)
+
 - **The dependency audit skipped files and still reported success** — the
   `security-scan` job ran four `pip-audit` invocations as four plain lines in a
   `run:` block. GitHub runs those under `bash -e`, and `pip-audit` exits 1 when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,7 +489,7 @@ PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `developme
 - **unit-tests** — All service tests in `python:3.12-slim` container (`-m "not integration"`), coverage threshold 80% (`--cov-fail-under=80`)
 - **opa-tests** — OPA policy tests (`opa test opa-policies/`)
 - **docker-build** — Build all 5 images (no push)
-- **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis), non-blocking
+- **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis). Both are `continue-on-error`, so neither blocks a PR on a finding in code it did not touch — but both write their result to the job summary and raise a `::warning::` annotation, so a finding is not indistinguishable from a clean run. bandit's expected steady state is zero findings: each one is either fixed or annotated `# nosec Bxxx` with the reason at the point of use, and the summary reports how many were suppressed that way so they cannot quietly accumulate
 
 Running the full suite on `master` PRs too means the exact `development → master` merge commit is re-validated before a release lands — green-on-`development` alone is not relied upon, since direct pushes to `development` are permitted.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,14 @@ All PRs require passing CI checks (unit tests, OPA policy tests, Docker build) b
 - **Environment variables** for all configuration (no hardcoded values)
 - **Graceful degradation** — every service must work when optional dependencies (reranker, Ollama) are unavailable
 - **`pb` prefix** for all project-specific identifiers (containers, metrics, OPA packages, collections)
+- **`# nosec` carries a test ID and a reason** — a bandit finding is either fixed
+  or annotated `# nosec Bxxx` with a comment above it saying why it is not a
+  problem at that spot. Not a bare `# nosec`, which hides every check on the
+  line rather than the one you assessed, and not a project-wide skip, which
+  hides it everywhere including code not written yet. The scan is
+  `continue-on-error`, so its value rests entirely on the steady state being
+  zero: the job summary reports the suppression count next to the findings, and
+  anything it does report is something nobody has looked at yet.
 
 ## License
 

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -31,6 +31,38 @@ Suppression is what keeps the audit readable: with known-and-assessed advisories
 filtered out, anything the summary reports is new and unassessed. An audit that
 always shows the same three findings trains everyone to skip it.
 
+## Static analysis findings are not ledgered here
+
+The same job also runs `bandit` over the service code, under the same
+`continue-on-error` trade and with the same reporting: findings go to the job
+summary, each one raises an annotation on its line, and the summary states how
+many were suppressed even when the run is clean.
+
+What it does **not** have is a ledger. An accepted `bandit` finding is recorded
+as a `# nosec Bxxx` marker with its reason in the source, and that is the whole
+record. The asymmetry with the advisories above is deliberate, and rests on
+three differences:
+
+- **There is a line to annotate.** An advisory concerns third-party code that
+  does not exist in this repository, so the assessment has nowhere to live
+  except a document. A `bandit` finding is our own code.
+- **The suppression is not remote from what it suppresses.** `--ignore-vuln
+  PYSEC-2026-3552` sits in a workflow file, far from anything it refers to, and
+  is an unexplained magic string without an entry here. `# nosec B608` sits on
+  the line it excuses, with the reason directly above it, where whoever edits
+  that code is already reading.
+- **There is nothing to expire.** An advisory needs a review date because
+  upstream moves without anyone here touching anything — a new `presidio`
+  release could lift the cap tomorrow. A justification like "this identifier
+  came from a module-level literal list" can only stop being true through an
+  edit to that same line, which brings the reason back into view at exactly the
+  moment it stops holding.
+
+A copy of those reasons in this document would be the half that silently drifts
+when the code moves. The rule itself — fix it, or annotate it with the test id
+and a reason, never bare and never a project-wide skip — is in
+[CONTRIBUTING.md](../CONTRIBUTING.md) next to the other code conventions.
+
 ## Accepted risks
 
 ### A-01 — `cryptography` 48.0.1, three advisories, capped by `presidio-anonymizer`

--- a/ingestion/snapshot_service.py
+++ b/ingestion/snapshot_service.py
@@ -99,7 +99,9 @@ async def get_pg_row_counts(pool: asyncpg.Pool) -> dict:
     counts = {}
     for table in PG_SNAPSHOT_TABLES:
         try:
-            row = await pool.fetchrow(f"SELECT COUNT(*) AS cnt FROM {table}")
+            # B608 false positive: `table` iterates PG_SNAPSHOT_TABLES, a
+            # module-level literal list; no caller value reaches this statement.
+            row = await pool.fetchrow(f"SELECT COUNT(*) AS cnt FROM {table}")  # nosec B608
             counts[table] = row["cnt"] if row else 0
         except Exception:
             counts[table] = -1  # Table does not (yet) exist

--- a/mcp-server/graph_service.py
+++ b/mcp-server/graph_service.py
@@ -162,11 +162,13 @@ async def _execute_cypher(pool: asyncpg.Pool, cypher: str, params: dict | None =
     columns = _parse_return_columns(query)
     as_clause = ", ".join(f"{col} agtype" for col in columns)
 
-    sql = f"""
-    SELECT * FROM cypher('{GRAPH_NAME}', $$
-        {query}
-    $$) AS ({as_clause})
-    """
+    # B608 is unavoidable here: AGE has no parameter binding for cypher, so the
+    # query has to be interpolated. GRAPH_NAME is a module constant, `as_clause`
+    # is stripped to [A-Za-z0-9_] by _parse_return_columns(), and `query` only
+    # reaches here from the builders below, which run every label and property
+    # key through _require_identifier() and every value through
+    # _escape_cypher_value().
+    sql = f"SELECT * FROM cypher('{GRAPH_NAME}', $$\n{query}\n$$) AS ({as_clause})"  # nosec B608
 
     async with pool.acquire() as conn:
         await conn.execute(AGE_INIT)

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -154,7 +154,10 @@ _rerank_provider   = create_rerank_provider(
 from shared.embedding_cache import EmbeddingCache
 embedding_cache = EmbeddingCache()
 
-MCP_HOST       = os.getenv("MCP_HOST", "0.0.0.0")
+# B104 accepted: the service runs in a container and has to bind the container's
+# own interfaces to be reachable on pb-net; what is exposed to the host is
+# decided by docker compose port publishing, not here. Override with MCP_HOST.
+MCP_HOST       = os.getenv("MCP_HOST", "0.0.0.0")  # nosec B104
 MCP_PORT       = int(os.getenv("MCP_PORT", "8080"))
 MCP_PATH       = os.getenv("MCP_PATH", "/mcp")
 MCP_PUBLIC_URL = os.getenv("MCP_PUBLIC_URL", f"http://localhost:{MCP_PORT}")
@@ -2317,7 +2320,10 @@ async def _dispatch(name: str, arguments: dict[str, Any],
             params.append(str(value))
             idx += 1
 
-        q = f"SELECT data FROM dataset_rows WHERE {' AND '.join(where_clauses)} LIMIT ${idx}"
+        # B608 false positive: the only interpolated fragment is `where_clauses`,
+        # whose condition keys were rejected above unless validate_identifier()
+        # passed; every condition value and the limit are bound as $n.
+        q = f"SELECT data FROM dataset_rows WHERE {' AND '.join(where_clauses)} LIMIT ${idx}"  # nosec B608
         params.append(int(limit))
         rows = await pool.fetch(q, *params)
 
@@ -3002,8 +3008,11 @@ async def _dispatch(name: str, arguments: dict[str, Any],
         }, "errors": []}
 
         # 1. Fetch doc_ids from PostgreSQL (needed for graph cleanup + vault count)
+        # B608 false positive: pg_where comes from _build_delete_filter(), which
+        # emits literal column comparisons against $n placeholders only; the
+        # source_type/project values travel in pg_params.
         doc_rows = await pool.fetch(
-            f"SELECT id FROM documents_meta WHERE {pg_where}", *pg_params)
+            f"SELECT id FROM documents_meta WHERE {pg_where}", *pg_params)  # nosec B608
         doc_ids = [str(r["id"]) for r in doc_rows]
         result["deleted"]["documents_meta"] = len(doc_ids)
 
@@ -3041,8 +3050,10 @@ async def _dispatch(name: str, arguments: dict[str, Any],
 
         # 4. Delete from PostgreSQL (CASCADE handles vault)
         if doc_ids:
+            # B608 false positive: same _build_delete_filter() output as the
+            # SELECT above.
             await pool.execute(
-                f"DELETE FROM documents_meta WHERE {pg_where}", *pg_params)
+                f"DELETE FROM documents_meta WHERE {pg_where}", *pg_params)  # nosec B608
 
         # 5. Delete Document nodes from Knowledge Graph
         graph_deleted = 0
@@ -3096,7 +3107,8 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 "FROM pending_reviews "
                 "WHERE status = 'pending' "
                 "ORDER BY created_at ASC "
-                f"LIMIT {limit}"
+                "LIMIT $1",
+                limit,
             )
             out = [{
                 "review_id":      r["id"],
@@ -3334,18 +3346,22 @@ async def _dispatch(name: str, arguments: dict[str, Any],
             idx += 1
         where_sql = " AND ".join(where_parts) if where_parts else "TRUE"
 
+        params.append(limit)
+
         pool = await get_pg_pool()
         rows = await pool.fetch(
-            f"SELECT id, agent_id, agent_role, resource_type, resource_id, "
-            f"       action, policy_result, policy_reason, "
-            f"       contains_pii, purpose, legal_basis, data_category, "
-            f"       fields_redacted, created_at, "
-            f"       encode(prev_hash, 'hex')  AS prev_hash, "
-            f"       encode(entry_hash, 'hex') AS entry_hash "
-            f"FROM agent_access_log "
-            f"WHERE {where_sql} "
-            f"ORDER BY id ASC "
-            f"LIMIT {limit}",
+            "SELECT id, agent_id, agent_role, resource_type, resource_id, "
+            "       action, policy_result, policy_reason, "
+            "       contains_pii, purpose, legal_basis, data_category, "
+            "       fields_redacted, created_at, "
+            "       encode(prev_hash, 'hex')  AS prev_hash, "
+            "       encode(entry_hash, 'hex') AS entry_hash "
+            "FROM agent_access_log "
+            # B608 false positive: where_sql is joined from the literal fragments
+            # built above; every caller value is bound as $n, never interpolated.
+            f"WHERE {where_sql} "  # nosec B608
+            "ORDER BY id ASC "
+            f"LIMIT ${idx}",
             *params,
         )
 
@@ -3485,7 +3501,8 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 "       source::text, description, pii_types_found, notifiable_risk, "
                 "       frist_warnung "
                 "FROM v_incidents_requiring_attention "
-                f"LIMIT {limit}"
+                "LIMIT $1",
+                limit,
             )
             out = [{
                 "incident_id":            r["id"],
@@ -3511,14 +3528,17 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 params.append(source_filter)
                 idx += 1
             where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+            params.append(limit)
             rows = await pool.fetch(
                 "SELECT id::text, detected_at, detected_by, source::text, status::text, "
                 "       description, pii_types_found, data_category, notifiable_risk, "
                 "       authority_notified_at, subject_notified_at, resolved_at "
                 "FROM privacy_incidents"
-                + where_sql +
+                # B608 false positive: where_sql is joined from the literal
+                # fragments built above; the filter values are bound as $1/$2.
+                + where_sql +  # nosec B608
                 " ORDER BY detected_at DESC "
-                f"LIMIT {limit}",
+                f"LIMIT ${idx}",
                 *params,
             )
             out = [{

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -206,9 +206,11 @@ class TestExportAuditLog:
         )
         payload = json.loads(result[0].text)
         assert payload["limit"] == 50
-        # Generated SQL contains the capped limit
+        # The capped limit is bound as the last parameter, not interpolated
+        # into the SQL text.
         sql = mock_pool.fetch.call_args[0][0]
-        assert "LIMIT 50" in sql
+        assert "LIMIT $1" in sql
+        assert mock_pool.fetch.call_args[0][-1] == 50
 
     async def test_default_limit_when_missing(self, _patch_globals):
         mock_http, mock_pool = _patch_globals
@@ -221,7 +223,8 @@ class TestExportAuditLog:
 
         await _dispatch("export_audit_log", {}, "admin-1", "admin")
         sql = mock_pool.fetch.call_args[0][0]
-        assert "LIMIT 250" in sql
+        assert "LIMIT $1" in sql
+        assert mock_pool.fetch.call_args[0][-1] == 250
 
     async def test_filters_applied(self, _patch_globals):
         mock_http, mock_pool = _patch_globals

--- a/pb-proxy/config.py
+++ b/pb-proxy/config.py
@@ -15,7 +15,10 @@ log = logging.getLogger("pb-proxy")
 
 
 # ── Service ──────────────────────────────────────────────────
-PROXY_HOST = os.getenv("PROXY_HOST", "0.0.0.0")
+# B104 accepted: containerised service, binds the container's interfaces so it
+# is reachable on pb-net. Host exposure is a docker compose port-publishing
+# decision, not this default. Override with PROXY_HOST.
+PROXY_HOST = os.getenv("PROXY_HOST", "0.0.0.0")  # nosec B104
 PROXY_PORT = int(os.getenv("PROXY_PORT", "8090"))
 
 # ── MCP Server ───────────────────────────────────────────────

--- a/reranker/service.py
+++ b/reranker/service.py
@@ -244,4 +244,7 @@ async def list_models():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8082)
+    # B104 accepted: dev entrypoint mirroring the container CMD, which binds the
+    # same address so the service is reachable on pb-net. Host exposure is a
+    # docker compose port-publishing decision.
+    uvicorn.run(app, host="0.0.0.0", port=8082)  # nosec B104


### PR DESCRIPTION
Follows #259, on the step that was left out of scope there. The `bandit` step
found 12 medium-severity issues and exited 1 on every run, but
`continue-on-error: true` turned that back into a green check — the same failure
mode #257 described for pip-audit.

Fixing the visibility alone would just have produced a warning banner on every
PR, which people learn to ignore as fast as a green check they should not trust.
So the findings are resolved first, and the reporting second.

## Triage of the 12 findings

Reproduced with the pinned scanner (`bandit==1.9.4`) in the CI container.

**Fixed (2 findings removed outright).** Four queries interpolated a `LIMIT` that
was already `int`-clamped — safe, but it costs a reviewer the same
re-derivation every time. They bind it as a parameter now: `review_pending`,
`export_audit_log`, and both `list_incidents` branches. Two of those become
fully literal SQL and the finding disappears; the other two keep a dynamic
`WHERE`. Parameterising all four rather than only the two that pay off keeps one
rule in the file instead of a mix — **these queries interpolate validated
identifiers and literal fragments, never a caller value** — which is also what
the remaining annotations lean on.

**Annotated (10).** Each carries `# nosec Bxxx` with the reason next to it.

| Site | Test | Why it is not a problem here |
| --- | --- | --- |
| `mcp-server/server.py` `query_data` | B608 | Only `where_clauses` is interpolated; its condition keys are rejected unless `validate_identifier()` passes. Values and the limit are bound. |
| `mcp-server/server.py` `delete_documents` ×2 | B608 | `pg_where` comes from `_build_delete_filter()`, which emits literal comparisons against `$n` only. |
| `mcp-server/server.py` `export_audit_log` | B608 | `where_sql` is joined from literal fragments built directly above; every value is bound. |
| `mcp-server/server.py` `list_incidents` | B608 | Same shape, filter values bound as `$1`/`$2`. |
| `mcp-server/graph_service.py` `_execute_cypher` | B608 | AGE has no parameter binding for cypher, so this one is structural. `GRAPH_NAME` is a constant, `as_clause` is stripped to `[A-Za-z0-9_]`, and `query` only reaches it from builders that run every label through `_require_identifier()` and every value through `_escape_cypher_value()`. |
| `ingestion/snapshot_service.py` | B608 | `table` iterates `PG_SNAPSHOT_TABLES`, a module-level literal list. No caller value is involved. |
| `mcp-server/server.py`, `pb-proxy/config.py`, `reranker/service.py` | B104 ×3 | Containerised services binding their own interfaces so they are reachable on `pb-net`. What reaches the host is a compose port-publishing decision, and two of the three are already env-overridable. |

Two things worth flagging about the markers:

- They name the **test id**. A bare `# nosec` suppresses every check on that
  line, including ones nobody has assessed — the same "hides a future finding"
  problem one scope down.
- The explanatory comments deliberately do **not** start with `nosec`. bandit
  parses everything after `# nosec` as a test-id list, so a prose sentence there
  silently becomes a broad suppression and spams `Test in comment: the is not a
  test name or id`. Found the hard way, in this branch.

Verified with `--ignore-nosec` that exactly ten findings exist — every marker is
load-bearing, none is left over from a refactor.

## Reporting

The step ran bandit twice, once for the JSON artifact with `|| true` and once
for console output. Collapsed into one run, with the summary rendered from that
JSON — so the uploaded artifact and the text a reader sees can no longer
disagree. Rendered in Python because the report is JSON and `setup-python`
already ran.

- Findings → a table in `$GITHUB_STEP_SUMMARY` (file, line, test with a link to
  the plugin doc, severity/confidence, message) plus a `::warning file=,line=::`
  annotation each, so they land on the diff.
- **Scan errors annotate in their own right.** A file bandit cannot parse never
  shows up as a finding, so it is a hole in coverage that the old step reported
  as success — the same shape as the #257 bug.
- A non-zero exit that reports neither findings nor errors annotates too, rather
  than passing as clean.
- The **suppression count is reported on every run, including clean ones**, so
  `# nosec` markers cannot quietly accumulate.

`continue-on-error` stays, for the reason #259 gave: a finding in code a PR did
not touch should not block it. What makes that trade honest is the steady state
now being zero.

## On `docs/dependency-audit.md`

**No per-finding ledger for bandit** — `# nosec` with a reason is sufficient, and
a mirrored ledger would be worse than nothing. But the doc does get a section
saying so, because a reader who comes there for "what does this project do about
security scan findings" should not have to infer the answer from silence.

The advisory ledger exists because of three properties this case does not share:
the vulnerable code is third-party and has no line in this repo to annotate; the
suppression lives in the workflow, structurally far from what it suppresses, so
`--ignore-vuln PYSEC-2026-3552` is an unexplained magic string without it; and it
needs a review date because upstream changes without anyone here touching
anything. A bandit finding is our own code — the reason sits on the line it
excuses, where whoever edits that code is already looking, and it can only stop
being true through the same edit. A copy in a doc is the half that drifts.

The rule itself — fix it or annotate it with a test id and a reason, never bare,
never a project-wide skip — is in CONTRIBUTING.md (Code Conventions) and
CLAUDE.md (CI section).

> #260 merged into `development` about an hour into this branch, so
> `docs/dependency-audit.md` exists now and the section landed here rather than
> as the follow-up an earlier revision of this description promised.
> `development` is merged in; the pip-audit hunk and the bandit hunk sit in
> different parts of the workflow and merged cleanly.

## Verification

- `bandit` in the CI container: **0 medium findings, 10 suppressed** (was 12 / 0)
- Step script extracted from the workflow and run under `bash -e` against stub
  bandit output — findings / clean / scan-error / non-zero-but-empty all render
  and annotate correctly, and the exit code is preserved in each case
- Real step against the real tree: exit 0, clean summary, no annotation raised
- Both re-run after merging `development`
- Full unit suite in the CI container: **1136 passed, 20 skipped**
- First CI run on this PR: all four checks green, and the bandit step emitted no
  annotation — [run 32078014528](https://github.com/nuetzliches/powerbrain/actions/runs/32078014528)
- Two `test_audit_integrity` assertions updated from `"LIMIT 50" in sql` to
  checking the bound parameter — a stricter check, since it verifies the value
  actually reaches the driver

`bandit-report.json` is gitignored; the step writes it into the workspace and
running the scan locally drops it there too.

## One thing I did not change

bandit logs `nosec encountered (B608), but no failed test on file …` for some
markers. That is inherent to naming a test id: one source line spans several AST
nodes, the marker is checked against each, and the ones that did not fire warn.
It is stderr noise in the raw log, not in the summary, so it does not undermine
what this PR buys. It does mean a genuinely stale marker would warn in the same
shape as these eight benign ones. The reliable check for that is comparing the
`--ignore-nosec` finding count against the suppression count the summary already
prints — currently 10 and 10. Wiring that comparison into the step would catch
dead markers automatically, at the cost of a second scan. Happy to add it if you
want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
