### PR TITLE
Release 0.12.3

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -169,16 +169,112 @@ jobs:
           fi
           exit "$status"
 
+      # Same failure mode the audit above had (#257): bandit exits 1 on any
+      # finding, `continue-on-error` turns that back into a green check, and a
+      # finding becomes indistinguishable from a clean run unless somebody opens
+      # the log. The result goes to the job summary and raises annotations now.
+      #
+      # The step used to invoke bandit twice — once for the JSON artifact, once
+      # for console output. One run produces the JSON and the summary is
+      # rendered from it, so the uploaded artifact and what you read can no
+      # longer disagree.
+      #
+      # `continue-on-error` stays, for the same reason as the audit: a finding
+      # in code the PR did not touch should not block it. What makes that
+      # tolerable is that the expected steady state is zero — findings that were
+      # assessed and accepted carry a `# nosec Bxxx` marker with the reason at
+      # the point of use, and the summary reports how many were suppressed that
+      # way, so suppressions cannot quietly accumulate.
       - name: Static security scan (bandit)
         continue-on-error: true
         run: |
+          status=0
           bandit -r shared/ mcp-server/ ingestion/ reranker/ pb-proxy/ worker/ \
             -x '*/tests/*' \
             --severity-level medium \
-            -f json -o bandit-report.json || true
-          bandit -r shared/ mcp-server/ ingestion/ reranker/ pb-proxy/ worker/ \
-            -x '*/tests/*' \
-            --severity-level medium
+            -f json -o bandit-report.json || status=$?
+
+          # Rendered in Python rather than bash: the report is JSON, and the
+          # setup-python step above already put an interpreter on PATH.
+          python3 - "$status" <<'PY'
+          import json
+          import os
+          import sys
+
+          exit_status = int(sys.argv[1])
+
+          with open("bandit-report.json", encoding="utf-8") as fh:
+              report = json.load(fh)
+
+          results = report.get("results", [])
+          totals = report.get("metrics", {}).get("_totals", {})
+          suppressed = int(totals.get("skipped_tests", 0) or 0)
+          errors = report.get("errors", [])
+
+          def cell(text):
+              """Collapse whitespace and escape pipes so a message cannot break the table."""
+              return " ".join(str(text).split()).replace("|", "\\|")
+
+          out = ["## Static security scan (bandit)", ""]
+          if results:
+              out += [
+                  f"**{len(results)} finding(s)** at or above medium severity.",
+                  "",
+                  "| file | line | test | severity / confidence | issue |",
+                  "| --- | --- | --- | --- | --- |",
+              ]
+              out += [
+                  "| `{}` | {} | [{}]({}) | {} / {} | {} |".format(
+                      cell(r.get("filename")),
+                      r.get("line_number"),
+                      cell(r.get("test_id")),
+                      r.get("more_info"),
+                      cell(r.get("issue_severity")),
+                      cell(r.get("issue_confidence")),
+                      cell(r.get("issue_text")),
+                  )
+                  for r in results
+              ]
+          else:
+              out.append("No findings at or above medium severity.")
+
+          out += [
+              "",
+              f"{suppressed} finding(s) suppressed by reviewed `# nosec` markers "
+              "(see the reason next to each marker in the source).",
+          ]
+          if errors:
+              out += ["", "**Scan errors:**", "", "```", json.dumps(errors, indent=2), "```"]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write("\n".join(out) + "\n")
+
+          # File annotations attach each finding to its line in the PR view.
+          for r in results:
+              print("::warning file={},line={},title=bandit {}::{}".format(
+                  r.get("filename"), r.get("line_number"),
+                  r.get("test_id"), cell(r.get("issue_text")),
+              ))
+          if results:
+              print(
+                  "::warning title=Static security scan::bandit reported "
+                  f"{len(results)} finding(s) — see the job summary."
+              )
+          # A file bandit could not parse is a hole in the scan's coverage, and
+          # it does not show up as a finding — annotate it in its own right.
+          if errors:
+              print(
+                  "::warning title=Static security scan::bandit could not scan "
+                  f"{len(errors)} file(s) — see the job summary."
+              )
+          if exit_status != 0 and not results and not errors:
+              print(
+                  "::warning title=Static security scan::bandit exited "
+                  f"{exit_status} without reporting findings — the scan may not have run."
+              )
+          PY
+
+          exit "$status"
 
       - name: Upload bandit report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ composit-diff.html
 .coverage.*
 htmlcov/
 .pytest_cache/
+
+# bandit report — the security-scan job writes it into the workspace and uploads
+# it as an artifact; running the same scan locally drops it here too.
+bandit-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Graph writes were not idempotent, so every sync run duplicated the graph** —
+  `create_node` and `create_relationship` in `mcp-server/graph_service.py` built
+  plain Cypher `CREATE` statements. `CREATE` checks nothing for uniqueness, so a
+  repeated sync never errored and simply inserted another copy of every node and
+  edge it had already written. For edges it was worse than linear: the statement
+  is `MATCH (a), (b) CREATE (a)-[r]->(b)`, and `MATCH` returns the cross product
+  of both sides, so on run N it found N copies per side and created N² edges —
+  edge count grows with the sum of k². The same class of bug was fixed once
+  before in the `init-db/003` demo seed (0.11.3); this is the remaining occurrence,
+  in the primitives themselves, and it affected every caller of the `graph_mutate`
+  tool rather than one migration.
+
+  Both functions now `MERGE`. `create_node` merges on the identity property
+  (`id`, falling back to `name`) and applies the remaining properties with `SET`,
+  so a re-sync with changed data is an update rather than a second node. A node
+  with no properties at all keeps `CREATE`, because `MERGE` on a bare label would
+  match any existing node of that type. `create_relationship` merges the edge and
+  applies edge properties with `SET` rather than putting them inside the merge
+  pattern — a property in the pattern would make every changed value create an
+  additional edge, which is the duplication being fixed. Node deduplication is
+  what removes the cross product: with one node per identity, `MATCH (a), (b)`
+  binds exactly one on each side.
+
+  `create_node` now logs its sync action as `upsert` instead of `create`, which
+  also makes pre-fix and post-fix rows in `graph_sync_log` distinguishable.
+
+  Note for operators: `MERGE` makes re-syncs stable, but it does not invent an
+  identity. Where a caller passes a non-unique value as `id` — a project *name*
+  that repeats across customers, say — the merge collapses those onto one node by
+  design. That is a data-modelling question for the caller, not something this
+  fix can resolve.
+
 ## [0.12.2] - 2026-08-18
 
 This release changes CI and documentation only — the service images are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-08-18
+
+Unlike 0.12.2 this one does touch the images: the knowledge-graph write path
+and four MCP query builders changed.
+
 ### Fixed
 
 - **Graph writes were not idempotent, so every sync run duplicated the graph** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   design. That is a data-modelling question for the caller, not something this
   fix can resolve.
 
+- **The static security scan failed on every run and reported green** — `bandit`
+  found 12 medium-severity issues and exited 1 each time, but the step is
+  `continue-on-error: true`, so the check stayed green and the output only
+  existed inside a collapsed log nobody opens. Same failure mode as the
+  dependency audit below, on the step that was left out of scope there. All 12
+  are now resolved rather than tolerated, so the run is clean and the next
+  finding is the only thing in it: four queries that interpolated an
+  already-clamped `LIMIT` bind it as a parameter instead (`review_pending`,
+  `export_audit_log`, both `list_incidents` branches), which removes two
+  findings outright and leaves one rule behind — these queries interpolate
+  validated identifiers and literal fragments, never a caller value. The
+  remaining ten carry a `# nosec Bxxx` marker with the reason next to it: seven
+  `B608` where the dynamic part is a `$n`-placeholder fragment or a
+  module-level constant (and, for Apache AGE, a cypher string that cannot be
+  parameterised at all, built only by helpers that run every label through
+  `_require_identifier()` and every value through `_escape_cypher_value()`), and
+  three `B104` where a containerised service binds its own interfaces so it is
+  reachable on `pb-net` — what reaches the host is a compose port-publishing
+  decision. The step itself gets the same treatment the audit got: it invoked
+  bandit twice, once for the JSON artifact and once for console output, so the
+  uploaded report and the text people read could disagree; it now runs once and
+  renders the summary from that JSON. Findings land in the job summary as a
+  table, each one also raising a file annotation on its line, and a scan error
+  or an unexplained non-zero exit annotates too — a file bandit cannot parse is
+  a hole in coverage that never appears as a finding. The summary reports the
+  suppression count on every run, including clean ones, so `# nosec` markers
+  cannot quietly accumulate. (#262)
+
 ## [0.12.2] - 2026-08-18
 
 This release changes CI and documentation only — the service images are
@@ -71,34 +99,6 @@ functionally identical to 0.12.1.
   rather than the same three lines every run. (#258)
 
 ### Fixed
-
-- **The static security scan failed on every run and reported green** — `bandit`
-  found 12 medium-severity issues and exited 1 each time, but the step is
-  `continue-on-error: true`, so the check stayed green and the output only
-  existed inside a collapsed log nobody opens. Same failure mode as the
-  dependency audit below, on the step that was left out of scope there. All 12
-  are now resolved rather than tolerated, so the run is clean and the next
-  finding is the only thing in it: four queries that interpolated an
-  already-clamped `LIMIT` bind it as a parameter instead (`review_pending`,
-  `export_audit_log`, both `list_incidents` branches), which removes two
-  findings outright and leaves one rule behind — these queries interpolate
-  validated identifiers and literal fragments, never a caller value. The
-  remaining ten carry a `# nosec Bxxx` marker with the reason next to it: seven
-  `B608` where the dynamic part is a `$n`-placeholder fragment or a
-  module-level constant (and, for Apache AGE, a cypher string that cannot be
-  parameterised at all, built only by helpers that run every label through
-  `_require_identifier()` and every value through `_escape_cypher_value()`), and
-  three `B104` where a containerised service binds its own interfaces so it is
-  reachable on `pb-net` — what reaches the host is a compose port-publishing
-  decision. The step itself gets the same treatment the audit got: it invoked
-  bandit twice, once for the JSON artifact and once for console output, so the
-  uploaded report and the text people read could disagree; it now runs once and
-  renders the summary from that JSON. Findings land in the job summary as a
-  table, each one also raising a file annotation on its line, and a scan error
-  or an unexplained non-zero exit annotates too — a file bandit cannot parse is
-  a hole in coverage that never appears as a finding. The summary reports the
-  suppression count on every run, including clean ones, so `# nosec` markers
-  cannot quietly accumulate. (#257)
 
 - **The dependency audit skipped files and still reported success** — the
   `security-scan` job ran four `pip-audit` invocations as four plain lines in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The static security scan failed on every run and reported green** — `bandit`
+  found 12 medium-severity issues and exited 1 each time, but the step is
+  `continue-on-error: true`, so the check stayed green and the output only
+  existed inside a collapsed log nobody opens. Same failure mode as the
+  dependency audit below, on the step that was left out of scope there. All 12
+  are now resolved rather than tolerated, so the run is clean and the next
+  finding is the only thing in it: four queries that interpolated an
+  already-clamped `LIMIT` bind it as a parameter instead (`review_pending`,
+  `export_audit_log`, both `list_incidents` branches), which removes two
+  findings outright and leaves one rule behind — these queries interpolate
+  validated identifiers and literal fragments, never a caller value. The
+  remaining ten carry a `# nosec Bxxx` marker with the reason next to it: seven
+  `B608` where the dynamic part is a `$n`-placeholder fragment or a
+  module-level constant (and, for Apache AGE, a cypher string that cannot be
+  parameterised at all, built only by helpers that run every label through
+  `_require_identifier()` and every value through `_escape_cypher_value()`), and
+  three `B104` where a containerised service binds its own interfaces so it is
+  reachable on `pb-net` — what reaches the host is a compose port-publishing
+  decision. The step itself gets the same treatment the audit got: it invoked
+  bandit twice, once for the JSON artifact and once for console output, so the
+  uploaded report and the text people read could disagree; it now runs once and
+  renders the summary from that JSON. Findings land in the job summary as a
+  table, each one also raising a file annotation on its line, and a scan error
+  or an unexplained non-zero exit annotates too — a file bandit cannot parse is
+  a hole in coverage that never appears as a finding. The summary reports the
+  suppression count on every run, including clean ones, so `# nosec` markers
+  cannot quietly accumulate. (#257)
+
 - **The dependency audit skipped files and still reported success** — the
   `security-scan` job ran four `pip-audit` invocations as four plain lines in a
   `run:` block. GitHub runs those under `bash -e`, and `pip-audit` exits 1 when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,7 +489,7 @@ PR workflow (`.github/workflows/pr-validate.yml`) runs on every PR to `developme
 - **unit-tests** — All service tests in `python:3.12-slim` container (`-m "not integration"`), coverage threshold 80% (`--cov-fail-under=80`)
 - **opa-tests** — OPA policy tests (`opa test opa-policies/`)
 - **docker-build** — Build all 5 images (no push)
-- **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis), non-blocking
+- **security-scan** — `pip-audit` (dependency vulnerabilities) + `bandit` (static analysis). Both are `continue-on-error`, so neither blocks a PR on a finding in code it did not touch — but both write their result to the job summary and raise a `::warning::` annotation, so a finding is not indistinguishable from a clean run. bandit's expected steady state is zero findings: each one is either fixed or annotated `# nosec Bxxx` with the reason at the point of use, and the summary reports how many were suppressed that way so they cannot quietly accumulate
 
 Running the full suite on `master` PRs too means the exact `development → master` merge commit is re-validated before a release lands — green-on-`development` alone is not relied upon, since direct pushes to `development` are permitted.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,14 @@ All PRs require passing CI checks (unit tests, OPA policy tests, Docker build) b
 - **Environment variables** for all configuration (no hardcoded values)
 - **Graceful degradation** — every service must work when optional dependencies (reranker, Ollama) are unavailable
 - **`pb` prefix** for all project-specific identifiers (containers, metrics, OPA packages, collections)
+- **`# nosec` carries a test ID and a reason** — a bandit finding is either fixed
+  or annotated `# nosec Bxxx` with a comment above it saying why it is not a
+  problem at that spot. Not a bare `# nosec`, which hides every check on the
+  line rather than the one you assessed, and not a project-wide skip, which
+  hides it everywhere including code not written yet. The scan is
+  `continue-on-error`, so its value rests entirely on the steady state being
+  zero: the job summary reports the suppression count next to the findings, and
+  anything it does report is something nobody has looked at yet.
 
 ## License
 

--- a/docs/dependency-audit.md
+++ b/docs/dependency-audit.md
@@ -31,6 +31,38 @@ Suppression is what keeps the audit readable: with known-and-assessed advisories
 filtered out, anything the summary reports is new and unassessed. An audit that
 always shows the same three findings trains everyone to skip it.
 
+## Static analysis findings are not ledgered here
+
+The same job also runs `bandit` over the service code, under the same
+`continue-on-error` trade and with the same reporting: findings go to the job
+summary, each one raises an annotation on its line, and the summary states how
+many were suppressed even when the run is clean.
+
+What it does **not** have is a ledger. An accepted `bandit` finding is recorded
+as a `# nosec Bxxx` marker with its reason in the source, and that is the whole
+record. The asymmetry with the advisories above is deliberate, and rests on
+three differences:
+
+- **There is a line to annotate.** An advisory concerns third-party code that
+  does not exist in this repository, so the assessment has nowhere to live
+  except a document. A `bandit` finding is our own code.
+- **The suppression is not remote from what it suppresses.** `--ignore-vuln
+  PYSEC-2026-3552` sits in a workflow file, far from anything it refers to, and
+  is an unexplained magic string without an entry here. `# nosec B608` sits on
+  the line it excuses, with the reason directly above it, where whoever edits
+  that code is already reading.
+- **There is nothing to expire.** An advisory needs a review date because
+  upstream moves without anyone here touching anything — a new `presidio`
+  release could lift the cap tomorrow. A justification like "this identifier
+  came from a module-level literal list" can only stop being true through an
+  edit to that same line, which brings the reason back into view at exactly the
+  moment it stops holding.
+
+A copy of those reasons in this document would be the half that silently drifts
+when the code moves. The rule itself — fix it, or annotate it with the test id
+and a reason, never bare and never a project-wide skip — is in
+[CONTRIBUTING.md](../CONTRIBUTING.md) next to the other code conventions.
+
 ## Accepted risks
 
 ### A-01 — `cryptography` 48.0.1, three advisories, capped by `presidio-anonymizer`

--- a/ingestion/snapshot_service.py
+++ b/ingestion/snapshot_service.py
@@ -99,7 +99,9 @@ async def get_pg_row_counts(pool: asyncpg.Pool) -> dict:
     counts = {}
     for table in PG_SNAPSHOT_TABLES:
         try:
-            row = await pool.fetchrow(f"SELECT COUNT(*) AS cnt FROM {table}")
+            # B608 false positive: `table` iterates PG_SNAPSHOT_TABLES, a
+            # module-level literal list; no caller value reaches this statement.
+            row = await pool.fetchrow(f"SELECT COUNT(*) AS cnt FROM {table}")  # nosec B608
             counts[table] = row["cnt"] if row else 0
         except Exception:
             counts[table] = -1  # Table does not (yet) exist

--- a/mcp-server/graph_service.py
+++ b/mcp-server/graph_service.py
@@ -162,11 +162,13 @@ async def _execute_cypher(pool: asyncpg.Pool, cypher: str, params: dict | None =
     columns = _parse_return_columns(query)
     as_clause = ", ".join(f"{col} agtype" for col in columns)
 
-    sql = f"""
-    SELECT * FROM cypher('{GRAPH_NAME}', $$
-        {query}
-    $$) AS ({as_clause})
-    """
+    # B608 is unavoidable here: AGE has no parameter binding for cypher, so the
+    # query has to be interpolated. GRAPH_NAME is a module constant, `as_clause`
+    # is stripped to [A-Za-z0-9_] by _parse_return_columns(), and `query` only
+    # reaches here from the builders below, which run every label and property
+    # key through _require_identifier() and every value through
+    # _escape_cypher_value().
+    sql = f"SELECT * FROM cypher('{GRAPH_NAME}', $$\n{query}\n$$) AS ({as_clause})"  # nosec B608
 
     async with pool.acquire() as conn:
         await conn.execute(AGE_INIT)

--- a/mcp-server/graph_service.py
+++ b/mcp-server/graph_service.py
@@ -218,17 +218,41 @@ def _escape_cypher_value(value: Any) -> str:
 # ── Knoten-Operationen ──────────────────────────────────────
 
 async def create_node(pool: asyncpg.Pool, label: str, properties: dict) -> dict:
-    """Erstellt einen Knoten im Graph."""
+    """Legt einen Knoten an oder aktualisiert ihn (Upsert).
+
+    Verwendet `MERGE` statt `CREATE`: `CREATE` prueft nichts auf Eindeutigkeit,
+    laeuft also nie auf einen Fehler und legt bei jedem Sync-Lauf eine weitere
+    Kopie desselben Knotens an. Gemergt wird auf dem Identitaets-Property
+    (`id`, ersatzweise `name`), die uebrigen Properties werden per `SET`
+    aktualisiert -- so bleibt ein erneuter Lauf mit geaenderten Daten ein
+    Update statt einer zweiten Kopie.
+    """
     _require_identifier(label, "Label")
     for k in properties:
         _require_identifier(k, "Property-Key")
-    props_str = ", ".join(f"{k}: {_escape_cypher_value(v)}" for k, v in properties.items())
-    cypher = f"CREATE (n:{label} {{{props_str}}}) RETURN n"
+
+    merge_key = next((k for k in ("id", "name") if k in properties), None)
+    if not properties:
+        # Ohne Properties gibt es keinen Schluessel zum Deduplizieren -- ein
+        # MERGE nur auf dem Label wuerde jeden beliebigen Knoten dieses Typs
+        # treffen, was schlimmer waere als eine Kopie.
+        cypher = f"CREATE (n:{label}) RETURN n"
+    elif merge_key is None:
+        props_str = ", ".join(f"{k}: {_escape_cypher_value(v)}" for k, v in properties.items())
+        cypher = f"MERGE (n:{label} {{{props_str}}}) RETURN n"
+    else:
+        cypher = f"MERGE (n:{label} {{{merge_key}: {_escape_cypher_value(properties[merge_key])}}})"
+        rest = {k: v for k, v in properties.items() if k != merge_key}
+        if rest:
+            set_str = ", ".join(f"n.{k} = {_escape_cypher_value(v)}" for k, v in rest.items())
+            cypher += f" SET {set_str}"
+        cypher += " RETURN n"
+
     results = await _execute_cypher(pool, cypher)
 
     # Sync-Log
     node_id = properties.get("id", properties.get("name", "unknown"))
-    await _log_sync(pool, label.lower(), str(node_id), "create")
+    await _log_sync(pool, label.lower(), str(node_id), "upsert")
 
     return results[0] if results else {}
 
@@ -264,21 +288,32 @@ async def create_relationship(
     rel_type: str,
     properties: dict | None = None,
 ) -> dict:
-    """Erstellt eine Beziehung zwischen zwei Knoten."""
+    """Legt eine Beziehung zwischen zwei Knoten an oder aktualisiert sie (Upsert).
+
+    Verwendet `MERGE` statt `CREATE`, damit ein erneuter Sync-Lauf keine
+    zweite Kante zwischen denselben Knoten anlegt. Kanten-Properties kommen
+    per `SET` dazu und nicht in das MERGE-Pattern -- sonst gaebe ein
+    geaenderter Property-Wert wieder eine zusaetzliche Kante.
+
+    Achtung: `MATCH (a), (b)` bildet das Kreuzprodukt beider Seiten. Solange
+    Knoten dedupliziert sind (siehe `create_node`), ist das je Seite genau
+    einer; auf einem Graphen mit Knoten-Duplikaten bleibt eine Kante je
+    Kopien-Kombination bestehen.
+    """
     _require_identifier(from_label, "from_label")
     _require_identifier(to_label, "to_label")
     _require_identifier(rel_type, "rel_type")
-    props_str = ""
+    set_str = ""
     if properties:
         for k in properties:
             _require_identifier(k, "Property-Key")
-        props_items = ", ".join(f"{k}: {_escape_cypher_value(v)}" for k, v in properties.items())
-        props_str = f" {{{props_items}}}"
+        set_items = ", ".join(f"r.{k} = {_escape_cypher_value(v)}" for k, v in properties.items())
+        set_str = f" SET {set_items}"
 
     cypher = (
         f"MATCH (a:{from_label} {{id: {_escape_cypher_value(from_id)}}}), "
         f"(b:{to_label} {{id: {_escape_cypher_value(to_id)}}}) "
-        f"CREATE (a)-[r:{rel_type}{props_str}]->(b) RETURN r"
+        f"MERGE (a)-[r:{rel_type}]->(b){set_str} RETURN r"
     )
     results = await _execute_cypher(pool, cypher)
     return results[0] if results else {}

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -154,7 +154,10 @@ _rerank_provider   = create_rerank_provider(
 from shared.embedding_cache import EmbeddingCache
 embedding_cache = EmbeddingCache()
 
-MCP_HOST       = os.getenv("MCP_HOST", "0.0.0.0")
+# B104 accepted: the service runs in a container and has to bind the container's
+# own interfaces to be reachable on pb-net; what is exposed to the host is
+# decided by docker compose port publishing, not here. Override with MCP_HOST.
+MCP_HOST       = os.getenv("MCP_HOST", "0.0.0.0")  # nosec B104
 MCP_PORT       = int(os.getenv("MCP_PORT", "8080"))
 MCP_PATH       = os.getenv("MCP_PATH", "/mcp")
 MCP_PUBLIC_URL = os.getenv("MCP_PUBLIC_URL", f"http://localhost:{MCP_PORT}")
@@ -2317,7 +2320,10 @@ async def _dispatch(name: str, arguments: dict[str, Any],
             params.append(str(value))
             idx += 1
 
-        q = f"SELECT data FROM dataset_rows WHERE {' AND '.join(where_clauses)} LIMIT ${idx}"
+        # B608 false positive: the only interpolated fragment is `where_clauses`,
+        # whose condition keys were rejected above unless validate_identifier()
+        # passed; every condition value and the limit are bound as $n.
+        q = f"SELECT data FROM dataset_rows WHERE {' AND '.join(where_clauses)} LIMIT ${idx}"  # nosec B608
         params.append(int(limit))
         rows = await pool.fetch(q, *params)
 
@@ -3002,8 +3008,11 @@ async def _dispatch(name: str, arguments: dict[str, Any],
         }, "errors": []}
 
         # 1. Fetch doc_ids from PostgreSQL (needed for graph cleanup + vault count)
+        # B608 false positive: pg_where comes from _build_delete_filter(), which
+        # emits literal column comparisons against $n placeholders only; the
+        # source_type/project values travel in pg_params.
         doc_rows = await pool.fetch(
-            f"SELECT id FROM documents_meta WHERE {pg_where}", *pg_params)
+            f"SELECT id FROM documents_meta WHERE {pg_where}", *pg_params)  # nosec B608
         doc_ids = [str(r["id"]) for r in doc_rows]
         result["deleted"]["documents_meta"] = len(doc_ids)
 
@@ -3041,8 +3050,10 @@ async def _dispatch(name: str, arguments: dict[str, Any],
 
         # 4. Delete from PostgreSQL (CASCADE handles vault)
         if doc_ids:
+            # B608 false positive: same _build_delete_filter() output as the
+            # SELECT above.
             await pool.execute(
-                f"DELETE FROM documents_meta WHERE {pg_where}", *pg_params)
+                f"DELETE FROM documents_meta WHERE {pg_where}", *pg_params)  # nosec B608
 
         # 5. Delete Document nodes from Knowledge Graph
         graph_deleted = 0
@@ -3096,7 +3107,8 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 "FROM pending_reviews "
                 "WHERE status = 'pending' "
                 "ORDER BY created_at ASC "
-                f"LIMIT {limit}"
+                "LIMIT $1",
+                limit,
             )
             out = [{
                 "review_id":      r["id"],
@@ -3334,18 +3346,22 @@ async def _dispatch(name: str, arguments: dict[str, Any],
             idx += 1
         where_sql = " AND ".join(where_parts) if where_parts else "TRUE"
 
+        params.append(limit)
+
         pool = await get_pg_pool()
         rows = await pool.fetch(
-            f"SELECT id, agent_id, agent_role, resource_type, resource_id, "
-            f"       action, policy_result, policy_reason, "
-            f"       contains_pii, purpose, legal_basis, data_category, "
-            f"       fields_redacted, created_at, "
-            f"       encode(prev_hash, 'hex')  AS prev_hash, "
-            f"       encode(entry_hash, 'hex') AS entry_hash "
-            f"FROM agent_access_log "
-            f"WHERE {where_sql} "
-            f"ORDER BY id ASC "
-            f"LIMIT {limit}",
+            "SELECT id, agent_id, agent_role, resource_type, resource_id, "
+            "       action, policy_result, policy_reason, "
+            "       contains_pii, purpose, legal_basis, data_category, "
+            "       fields_redacted, created_at, "
+            "       encode(prev_hash, 'hex')  AS prev_hash, "
+            "       encode(entry_hash, 'hex') AS entry_hash "
+            "FROM agent_access_log "
+            # B608 false positive: where_sql is joined from the literal fragments
+            # built above; every caller value is bound as $n, never interpolated.
+            f"WHERE {where_sql} "  # nosec B608
+            "ORDER BY id ASC "
+            f"LIMIT ${idx}",
             *params,
         )
 
@@ -3485,7 +3501,8 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 "       source::text, description, pii_types_found, notifiable_risk, "
                 "       frist_warnung "
                 "FROM v_incidents_requiring_attention "
-                f"LIMIT {limit}"
+                "LIMIT $1",
+                limit,
             )
             out = [{
                 "incident_id":            r["id"],
@@ -3511,14 +3528,17 @@ async def _dispatch(name: str, arguments: dict[str, Any],
                 params.append(source_filter)
                 idx += 1
             where_sql = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+            params.append(limit)
             rows = await pool.fetch(
                 "SELECT id::text, detected_at, detected_by, source::text, status::text, "
                 "       description, pii_types_found, data_category, notifiable_risk, "
                 "       authority_notified_at, subject_notified_at, resolved_at "
                 "FROM privacy_incidents"
-                + where_sql +
+                # B608 false positive: where_sql is joined from the literal
+                # fragments built above; the filter values are bound as $1/$2.
+                + where_sql +  # nosec B608
                 " ORDER BY detected_at DESC "
-                f"LIMIT {limit}",
+                f"LIMIT ${idx}",
                 *params,
             )
             out = [{

--- a/mcp-server/tests/test_audit_integrity.py
+++ b/mcp-server/tests/test_audit_integrity.py
@@ -206,9 +206,11 @@ class TestExportAuditLog:
         )
         payload = json.loads(result[0].text)
         assert payload["limit"] == 50
-        # Generated SQL contains the capped limit
+        # The capped limit is bound as the last parameter, not interpolated
+        # into the SQL text.
         sql = mock_pool.fetch.call_args[0][0]
-        assert "LIMIT 50" in sql
+        assert "LIMIT $1" in sql
+        assert mock_pool.fetch.call_args[0][-1] == 50
 
     async def test_default_limit_when_missing(self, _patch_globals):
         mock_http, mock_pool = _patch_globals
@@ -221,7 +223,8 @@ class TestExportAuditLog:
 
         await _dispatch("export_audit_log", {}, "admin-1", "admin")
         sql = mock_pool.fetch.call_args[0][0]
-        assert "LIMIT 250" in sql
+        assert "LIMIT $1" in sql
+        assert mock_pool.fetch.call_args[0][-1] == 250
 
     async def test_filters_applied(self, _patch_globals):
         mock_http, mock_pool = _patch_globals

--- a/mcp-server/tests/test_graph_crud.py
+++ b/mcp-server/tests/test_graph_crud.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from graph_service import (
-    create_node, find_node, delete_node,
+    create_node, create_relationship, find_node, delete_node,
     _execute_cypher, validate_identifier,
 )
 
@@ -61,6 +61,95 @@ class TestCreateNode:
         pool, conn = mock_pool
         with pytest.raises(ValueError, match="Property-Key"):
             await create_node(pool, "Project", {"invalid key": "x"})
+
+
+class TestCreateNodeIsIdempotent:
+    """A repeated sync run must not add a second copy of the same node.
+
+    Plain CREATE never checks uniqueness, so it never errors and every run
+    silently inserts another copy of the same entity.
+    """
+
+    @staticmethod
+    def _cypher(conn):
+        """The cypher statement, unwrapped from the SELECT ... cypher(...) shell."""
+        return conn.fetch.call_args[0][0]
+
+    async def test_merges_on_id_and_sets_remaining_properties(self, mock_pool):
+        pool, conn = mock_pool
+        await create_node(pool, "Project", {"id": "proj-1", "name": "Project One", "status": "active"})
+
+        cypher = self._cypher(conn)
+        assert "MERGE (n:Project {id: 'proj-1'})" in cypher
+        assert "CREATE" not in cypher
+        # name/status must be SET, not part of the MERGE pattern -- otherwise a
+        # renamed project would merge into a second node instead of updating.
+        assert "SET n.name = 'Project One', n.status = 'active'" in cypher
+
+    async def test_falls_back_to_name_when_no_id(self, mock_pool):
+        pool, conn = mock_pool
+        await create_node(pool, "Customer", {"name": "Acme"})
+
+        assert "MERGE (n:Customer {name: 'Acme'})" in self._cypher(conn)
+
+    async def test_merges_on_all_properties_without_identity_key(self, mock_pool):
+        pool, conn = mock_pool
+        await create_node(pool, "Concept", {"topic": "GDPR"})
+
+        cypher = self._cypher(conn)
+        assert "MERGE (n:Concept {topic: 'GDPR'})" in cypher
+        assert "SET" not in cypher
+
+    async def test_keeps_create_for_property_less_node(self, mock_pool):
+        pool, conn = mock_pool
+        await create_node(pool, "Project", {})
+
+        # MERGE on a bare label would match any existing Project.
+        assert "CREATE (n:Project) RETURN n" in self._cypher(conn)
+        assert "MERGE" not in self._cypher(conn)
+
+    async def test_logs_upsert_not_create(self, mock_pool):
+        pool, conn = mock_pool
+        await create_node(pool, "Project", {"id": "proj-1"})
+
+        assert pool.execute.call_args[0][3] == "upsert"
+
+
+class TestCreateRelationshipIsIdempotent:
+    """MATCH ... CREATE grows worse than linear: on run N it matches N copies
+    per side and creates N^2 edges, so edge count grows with the sum of k^2.
+    """
+
+    @staticmethod
+    def _cypher(conn):
+        return conn.fetch.call_args[0][0]
+
+    async def test_merges_the_edge(self, mock_pool):
+        pool, conn = mock_pool
+        await create_relationship(
+            pool, "Project", "proj-1", "Customer", "cust-1", "BELONGS_TO",
+        )
+
+        cypher = self._cypher(conn)
+        assert "MERGE (a)-[r:BELONGS_TO]->(b)" in cypher
+        assert "CREATE" not in cypher
+
+    async def test_properties_are_set_not_merged(self, mock_pool):
+        pool, conn = mock_pool
+        await create_relationship(
+            pool, "Project", "proj-1", "Customer", "cust-1", "BELONGS_TO",
+            properties={"since": "2026-04-21"},
+        )
+
+        cypher = self._cypher(conn)
+        # A property inside the MERGE pattern would make every changed value
+        # create an additional edge -- exactly the duplication we are fixing.
+        assert "MERGE (a)-[r:BELONGS_TO]->(b) SET r.since = '2026-04-21'" in cypher
+
+    async def test_rejects_invalid_rel_type(self, mock_pool):
+        pool, conn = mock_pool
+        with pytest.raises(ValueError, match="rel_type"):
+            await create_relationship(pool, "Project", "a", "Customer", "b", "BAD-TYPE")
 
 
 class TestFindNode:

--- a/pb-proxy/config.py
+++ b/pb-proxy/config.py
@@ -15,7 +15,10 @@ log = logging.getLogger("pb-proxy")
 
 
 # ── Service ──────────────────────────────────────────────────
-PROXY_HOST = os.getenv("PROXY_HOST", "0.0.0.0")
+# B104 accepted: containerised service, binds the container's interfaces so it
+# is reachable on pb-net. Host exposure is a docker compose port-publishing
+# decision, not this default. Override with PROXY_HOST.
+PROXY_HOST = os.getenv("PROXY_HOST", "0.0.0.0")  # nosec B104
 PROXY_PORT = int(os.getenv("PROXY_PORT", "8090"))
 
 # ── MCP Server ───────────────────────────────────────────────

--- a/reranker/service.py
+++ b/reranker/service.py
@@ -244,4 +244,7 @@ async def list_models():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8082)
+    # B104 accepted: dev entrypoint mirroring the container CMD, which binds the
+    # same address so the service is reachable on pb-net. Host exposure is a
+    # docker compose port-publishing decision.
+    uvicorn.run(app, host="0.0.0.0", port=8082)  # nosec B104


### PR DESCRIPTION
Release 0.12.3. Unlike 0.12.2 this one does touch the images — the
knowledge-graph write path and four MCP query builders changed.

## What's in it

**Graph writes were not idempotent (`58adc4c`).** `create_node` and
`create_relationship` built plain Cypher `CREATE`, which checks nothing for
uniqueness, so every repeated sync silently inserted another copy of every node
and edge it had already written. For edges it was worse than linear:
`MATCH (a), (b) CREATE (a)-[r]->(b)` returns the cross product of both sides, so
run N matched N copies per endpoint. Both use `MERGE` now. This is the change
most likely to be noticed in practice — anyone running repo sync on a schedule
has been accumulating duplicates.

**bandit's 12 medium findings resolved, and its result made visible (#262).**
The step exited 1 on every run while `continue-on-error: true` reported the check
green — the failure mode #257 described for `pip-audit`, on the step deliberately
left out of scope in #259. Four queries that interpolated an already-clamped
`LIMIT` now bind it as a parameter (`review_pending`, `export_audit_log`, both
`list_incidents` branches); the remaining ten carry a `# nosec Bxxx` marker with
its reason. The step now runs bandit once instead of twice, renders the summary
from the JSON it uploads, and reports the suppression count on every run so
`# nosec` markers cannot quietly accumulate.

## Note on the changelog

The bandit entry had landed inside the already-tagged `## [0.12.2]` section — its
branch was cut before that header existed, so the merge placed it there. Moved
verbatim into 0.12.3 where it actually ships (`952df34`); 0.12.2's "CI and
documentation only" claim is true again.

## Verification

#262 was green on `development`, including the newly meaningful bandit step,
which now exits 0 and raises no annotation. The four `LIMIT` conversions are
covered by updated assertions in `test_audit_integrity.py` that check the bound
parameter rather than the interpolated literal, and the graph fix ships with 91
lines of new tests in `test_graph_crud.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
